### PR TITLE
Prepare release script

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -28,7 +28,9 @@ gardener-extensions:
       traits:
         version:
           preprocess: 'finalize'
-        release: ~
+        release:
+          nextversion: 'bump_minor'
+          release_callback: '.ci/prepare_release'
         slack:
           default_channel: 'internal_scp_workspace'
           channel_cfgs:

--- a/.ci/prepare_release
+++ b/.ci/prepare_release
@@ -1,0 +1,55 @@
+#!/usr/bin/env sh
+#
+# Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+apk update
+apk add --no-cache \
+    ca-certificates \
+    make \
+    bash \
+    go \
+    git \
+    musl-dev \
+    curl \
+    openssl \
+    tar \
+    gcc \
+    sed
+
+if [ -z "$REPO_DIR" ]; then
+    export REPO_DIR="$(readlink -f "$(dirname "$0")"/..)"
+else
+    export REPO_DIR="$(readlink -f "$REPO_DIR")"
+fi
+
+GOLANG_VERSION="$(sed -rn 's/FROM golang:([^ ]+).*/\1/p' < "$REPO_DIR/Dockerfile")"
+
+export \
+    GOROOT="$(go env GOROOT)" \
+    GOOS="$(go env GOOS)" \
+    GOARCH="$(go env GOARCH)" \
+    GOHOSTOS="$(go env GOHOSTOS)" \
+    GOHOSTARCH="$(go env GOHOSTARCH)" \
+    GOPATH=/go \
+    GOBIN="$GOPATH/bin" \
+    PATH="$GOBIN:$PATH"
+
+wget -O - "https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz" | tar zx -C /usr/local
+
+"$REPO_DIR"/hack/install-requirements.sh
+
+make -C "$REPO_DIR" generate

--- a/hack/install-requirements.sh
+++ b/hack/install-requirements.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 set -e
 
+echo "Installing requirements"
 go get -u "gopkg.in/gobuffalo/packr.v1/v2/packr2"
 go get -u "gopkg.in/onsi/ginkgo.v1/ginkgo"
 go get -u "golang.org/x/lint/golint"


### PR DESCRIPTION
Fixes #1 
Current problem is that the `prepare_release` script is always being run in the default concourse image - This is not feasible for us as this would require us to do the whole bootstrap process ourselves in the script again, leading to us having to maintain yet another 'setup'.