### PR TITLE
Fix alicloud's status units and command

### DIFF
--- a/controllers/os-coreos-alicloud/cmd/gardener-extension-os-coreos-alicloud/app/app.go
+++ b/controllers/os-coreos-alicloud/cmd/gardener-extension-os-coreos-alicloud/app/app.go
@@ -33,6 +33,7 @@ func NewControllerCommand(ctx context.Context) *cobra.Command {
 		restOpts = &controllercmd.RESTOptions{}
 		mgrOpts  = &controllercmd.ManagerOptions{
 			LeaderElection:          true,
+			LeaderElectionID:        controllercmd.LeaderElectionNameID(Name),
 			LeaderElectionNamespace: os.Getenv("LEADER_ELECTION_NAMESPACE"),
 		}
 		ctrlOpts = &controllercmd.ControllerOptions{

--- a/controllers/os-coreos-alicloud/pkg/coreos-alicloud/internal/templates/cloud-init.sh.template
+++ b/controllers/os-coreos-alicloud/pkg/coreos-alicloud/internal/templates/cloud-init.sh.template
@@ -44,6 +44,7 @@ echo PROVIDER_ID=$PROVIDER_ID > $DOWNLOAD_MAIN_PATH/provider-id
 echo PROVIDER_ID=$PROVIDER_ID >> /etc/environment
 
 systemctl daemon-reload
+systemctl restart docker
 {{ range $_, $unit := .Units -}}
 systemctl enable '{{ $unit.Name }}' && systemctl restart '{{ $unit.Name }}'
 {{- end -}}

--- a/controllers/os-coreos/cmd/gardener-extension-os-coreos/app/app.go
+++ b/controllers/os-coreos/cmd/gardener-extension-os-coreos/app/app.go
@@ -33,6 +33,7 @@ func NewControllerCommand(ctx context.Context) *cobra.Command {
 		restOpts = &controllercmd.RESTOptions{}
 		mgrOpts  = &controllercmd.ManagerOptions{
 			LeaderElection:          true,
+			LeaderElectionID:        controllercmd.LeaderElectionNameID(Name),
 			LeaderElectionNamespace: os.Getenv("LEADER_ELECTION_NAMESPACE"),
 		}
 		ctrlOpts = &controllercmd.ControllerOptions{

--- a/pkg/controller/cmd/options.go
+++ b/pkg/controller/cmd/options.go
@@ -44,6 +44,11 @@ const (
 	MasterURLFlag = "master"
 )
 
+// LeaderElectionNameID returns a leader election ID for the given name.
+func LeaderElectionNameID(name string) string {
+	return fmt.Sprintf("%s-leader-election", name)
+}
+
 // Flagger adds flags to a given FlagSet.
 type Flagger interface {
 	// AddFlags adds the flags of this Flagger to the given FlagSet.

--- a/pkg/controller/cmd/options_test.go
+++ b/pkg/controller/cmd/options_test.go
@@ -110,6 +110,12 @@ var _ = Describe("Options", func() {
 		ctrl.Finish()
 	})
 
+	Describe("#LeaderElectionNameID", func() {
+		It("should return a leader election with the name", func() {
+			Expect(LeaderElectionNameID("foo")).To(Equal("foo-leader-election"))
+		})
+	})
+
 	Describe("#PrefixFlagger", func() {
 		const (
 			cmdName  = "test"


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable `.status.units` and `status.command` for aliclouds operating system config resource.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The `os-coreos-alicloud` controller does now correctly set the `.status.units` and `.status.command` fields in the `OperatingSystemConfig` resource.
```
