### PR TITLE
Black list SCTP protocol (CVE-2019-3874)

### DIFF
--- a/controllers/os-coreos/pkg/coreos/actuator_reconcile.go
+++ b/controllers/os-coreos/pkg/coreos/actuator_reconcile.go
@@ -63,6 +63,19 @@ func (c *actuator) cloudConfigFromOperatingSystemConfig(ctx context.Context, con
 		},
 	}
 
+	// blacklist sctp kernel module
+	if config.Spec.Purpose == extensionsv1alpha1.OperatingSystemConfigPurposeReconcile {
+		cloudConfig.WriteFiles = []File{
+			{
+				Encoding:           "b64",
+				Content:            base64.StdEncoding.EncodeToString([]byte("install sctp /bin/true")),
+				Owner:              "root",
+				Path:               "/etc/modprobe.d/sctp.conf",
+				RawFilePermissions: "0644",
+			},
+		}
+	}
+
 	unitNames := make([]string, 0, len(config.Spec.Units))
 	for _, unit := range config.Spec.Units {
 		unitNames = append(unitNames, unit.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is a workaround for CVE-2019-3874. It disables the PCTP protocol on all nodes.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Currently the fix is only for the core-os controller. The core-os-alicloud controller is currently not covered with this PR and will require more time (probably 2+ weeks or unless somebody else is able to validate the fix). In the interest of security those will be submitted separately.

This is the fix for 
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
The CoreOS Container Linux controller does now disable the PCTP protocol on all nodes (as a workaround for CVE-2019-3874).
```
