### PR TITLE
Black list SCTP protocol for alicloud (CVE-2019-3874)

### DIFF
--- a/controllers/os-coreos-alicloud/pkg/coreos-alicloud/actuator_reconcile.go
+++ b/controllers/os-coreos-alicloud/pkg/coreos-alicloud/actuator_reconcile.go
@@ -54,6 +54,15 @@ func (a *actuator) cloudConfigFromOperatingSystemConfig(ctx context.Context, con
 		files = append(files, &internal.File{Path: file.Path, Content: data, Permissions: file.Permissions})
 	}
 
+	// blacklist sctp kernel module
+	if config.Spec.Purpose == extensionsv1alpha1.OperatingSystemConfigPurposeReconcile {
+		files = append(files,
+			&internal.File{
+				Path:    "/etc/modprobe.d/sctp.conf",
+				Content: []byte("install sctp /bin/true"),
+			})
+	}
+
 	units := make([]*internal.Unit, 0, len(config.Spec.Units))
 	for _, unit := range config.Spec.Units {
 		var content []byte


### PR DESCRIPTION
**What this PR does / why we need it**:

DO NOT SUBMIT, NOT TESTED

This PR is a workaround for CVE-2019-3874. It disables the PCTP protocol on all nodes.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
This is not yet tested due to the lack of testing environment for Alicloud (or failure to set up a working environment). It was migrated from https://github.com/gardener/gardener-extensions/pull/33 which tested ok.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
The CoreOS Container Linux (Alicloud-modified) controller does now disable the PCTP protocol on all nodes (as a workaround for CVE-2019-3874).
```
