### PR TITLE
Fix relative repo path

### DIFF
--- a/.ci/prepare_release
+++ b/.ci/prepare_release
@@ -57,5 +57,7 @@ cp -R "$REPO_DIR" "$REPO_PATH"
 "$REPO_PATH"/hack/install-requirements.sh
 
 echo "$EFFECTIVE_VERSION" > "$REPO_PATH/VERSION"
-make -C "$REPO_PATH" generate
+pushd "$REPO_PATH"
+make generate || { popd; exit 1 }
+popd
 cp -RT "$REPO_PATH/" "$REPO_DIR/"


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix repo path with `pushd` / `popd` for `make generate`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
