### PR TITLE
Make CI-pipeline generate controller registrations for next dev cycle

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -28,6 +28,7 @@ gardener-extensions:
           preprocess: 'finalize'
         release:
           nextversion: 'bump_minor'
+          next_version_callback: '.ci/prepare_release'
           release_callback: '.ci/prepare_release'
         slack:
           default_channel: 'internal_scp_workspace'

--- a/hack/generate-controller-registration.sh
+++ b/hack/generate-controller-registration.sh
@@ -24,7 +24,6 @@ Usage:
 generate-controller-registration <name> <chart-dir> <dest> <kind-and-type> [kinds-and-types ...]
 
     <name>            Name of the controller registration to generate.
-    <type>            Type of the controller registration.
     <chart-dir>       Location of the chart directory.
     <dest>            The destination file to write the registration YAML to.
     <kind-and-type>   A tuple of kind and type of the controller registration to generate.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the CI pipeline execute the `prepare_release` script during its `Prepare next dev cycle` step. 

As a result all controller registration manifests will contain the next dev version which in turn will prevent future verification failures.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
