### PR TITLE
Enhance output of `clean` and `generate` in check

### DIFF
--- a/hack/check-generate.sh
+++ b/hack/check-generate.sh
@@ -87,11 +87,17 @@ if which git &>/dev/null; then
     git commit -q --allow-empty -m 'check-generate checkpoint'
 
     old_status="$(git status -s)"
-    "$DIRNAME/clean.sh" &>/dev/null
+    if ! out=$("$DIRNAME/clean.sh" 2>&1); then
+        echo "Error during calling $DIRNAME/clean.sh: $out"
+        exit 1
+    fi
     generated=true
     # We are using VERSIONFILE_VERSION since we want to check with respect to
     # the content of the source state.
-    VERSION="$VERSIONFILE_VERSION" "$DIRNAME/generate.sh" &>/dev/null
+    if ! out=$(VERSION="$VERSIONFILE_VERSION" "$DIRNAME/generate.sh" 2>&1); then
+        echo "Error during calling $DIRNAME/generate.sh: $out"
+        exit 1
+    fi
     new_status="$(git status -s)"
 
     if [[ "$old_status" != "$new_status" ]]; then

--- a/hack/clean.sh
+++ b/hack/clean.sh
@@ -24,7 +24,5 @@ header_text "Clean"
 for source_tree in ${SOURCE_TREES[@]}; do
   find "$(dirname "$source_tree")" -type f -name "controller-registration.yaml" -exec rm '{}' \;
   find "$(dirname "$source_tree")" -type f -name "zz_*.go" -exec rm '{}' \;
+  grep -lr --include="*.go" "//go:generate packr2" | xargs -i packr2 clean "{}/.."
 done
-
-packr2 clean "$ROOT/controllers/os-coreos-alicloud/pkg/coreos-alicloud/internal"
-packr2 clean "$ROOT/controllers/provider-gcp/pkg/internal/imagevector"


### PR DESCRIPTION
**What this PR does / why we need it**:
This simplifies spotting issues discovered during `check-generate`: The generated error messages are being printed in case one of the commands fail instead of silently discarding them.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
