### PR TITLE
Disable update engine service for AlicloudCoreOS

### DIFF
--- a/controllers/os-coreos-alicloud/pkg/coreos-alicloud/internal/templates/cloud-init.sh.template
+++ b/controllers/os-coreos-alicloud/pkg/coreos-alicloud/internal/templates/cloud-init.sh.template
@@ -7,9 +7,11 @@ EOF
 {{- end -}}
 
 {{- if .Bootstrap }}
-#Disable locksmithd
+#Disable upgrade related services
 systemctl disable locksmithd
 systemctl stop locksmithd
+systemctl disable update-engine
+systemctl stop update-engine
 
 #Fix mis-configuration of dockerd
 mkdir -p /etc/docker

--- a/controllers/os-coreos-alicloud/pkg/coreos-alicloud/internal/testfiles/cloud-init.sh
+++ b/controllers/os-coreos-alicloud/pkg/coreos-alicloud/internal/testfiles/cloud-init.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
-#Disable locksmithd
+#Disable upgrade related services
 systemctl disable locksmithd
 systemctl stop locksmithd
+systemctl disable update-engine
+systemctl stop update-engine
 
 #Fix mis-configuration of dockerd
 mkdir -p /etc/docker


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable update engine service for AlicloudCoreOS