### PR TITLE
Improve generate script and local dev experience

### DIFF
--- a/hack/generate-controller-registration.sh
+++ b/hack/generate-controller-registration.sh
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 set -e
+set -o pipefail
 
 DIRNAME="$(echo "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )")"
 source "$DIRNAME/common.sh"

--- a/hack/install-requirements.sh
+++ b/hack/install-requirements.sh
@@ -21,3 +21,24 @@ go get -u "gopkg.in/onsi/ginkgo.v1/ginkgo"
 go get -u "gopkg.in/golang/mock.v1/mockgen"
 go get -u "golang.org/x/lint/golint"
 curl -s "https://raw.githubusercontent.com/helm/helm/master/scripts/get" | bash
+
+function mac_os_hint {
+    cat <<EOM
+You are running in a MAC OS environment!
+
+Please make sure you have installed the following requirements:
+
+- GNU Core Utils
+- GNU Tar
+
+Brew command:
+$ brew install coreutils gnu-tar
+
+Please allow them to be used without their "g" prefix:
+$ export PATH=/usr/local/opt/coreutils/libexec/gnubin:\$PATH
+
+EOM
+    exit 0
+}
+
+[[ `uname -s | grep -i darwin` ]] && mac_os_hint


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the `generate-controller-registration.sh` to fail whenever there is an error (also considers pipe failures).

```improvement operator
NONE
```
