### PR TITLE
Add AWS controlplane webhooks tests

### DIFF
--- a/controllers/provider-aws/pkg/webhook/controlplane/mutator_test.go
+++ b/controllers/provider-aws/pkg/webhook/controlplane/mutator_test.go
@@ -1,0 +1,211 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gardener/gardener-extensions/controllers/provider-aws/pkg/aws"
+	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
+	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane/test"
+
+	"github.com/gardener/gardener/pkg/operation/common"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AWS Controlplane Webhook Suite")
+}
+
+var _ = Describe("Mutator", func() {
+
+	Describe("#Mutate", func() {
+		It("should add missing elements to kube-apiserver deployment", func() {
+			var (
+				dep = &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: common.KubeAPIServerDeploymentName},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "kube-apiserver",
+									},
+								},
+							},
+						},
+					},
+				}
+			)
+
+			mutator := newMutator(logger)
+			err := mutator.Mutate(context.TODO(), dep)
+			Expect(err).To(Not(HaveOccurred()))
+			checkKubeAPIServerDeployment(dep)
+		})
+
+		It("should modify existing elements of kube-apiserver deployment", func() {
+			var (
+				dep = &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: common.KubeAPIServerDeploymentName},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "kube-apiserver",
+										Command: []string{
+											"--cloud-provider=?",
+											"--cloud-config=?",
+											"--enable-admission-plugins=Priority,NamespaceLifecycle",
+											"--disable-admission-plugins=PersistentVolumeLabel",
+										},
+										Env: []corev1.EnvVar{
+											{Name: "AWS_ACCESS_KEY_ID", Value: "?"},
+											{Name: "AWS_SECRET_ACCESS_KEY", Value: "?"},
+										},
+										VolumeMounts: []corev1.VolumeMount{
+											{Name: aws.CloudProviderConfigName, MountPath: "?"},
+											// TODO Use constant from github.com/gardener/gardener/pkg/apis/core/v1alpha1 when available
+											// See https://github.com/gardener/gardener/pull/930
+											{Name: common.CloudProviderSecretName, MountPath: "?"},
+										},
+									},
+								},
+								Volumes: []corev1.Volume{
+									{Name: aws.CloudProviderConfigName},
+									{Name: common.CloudProviderSecretName},
+								},
+							},
+						},
+					},
+				}
+			)
+
+			mutator := newMutator(logger)
+			err := mutator.Mutate(context.TODO(), dep)
+			Expect(err).To(Not(HaveOccurred()))
+			checkKubeAPIServerDeployment(dep)
+		})
+
+		It("should add missing elements to kube-controller-manager deployment", func() {
+			var (
+				dep = &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: common.KubeControllerManagerDeploymentName},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "kube-controller-manager",
+									},
+								},
+							},
+						},
+					},
+				}
+			)
+
+			mutator := newMutator(logger)
+			err := mutator.Mutate(context.TODO(), dep)
+			Expect(err).To(Not(HaveOccurred()))
+			checkKubeControllerManagerDeployment(dep)
+		})
+
+		It("should modify existing elements of kube-controller-manager deployment", func() {
+			var (
+				dep = &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: common.KubeControllerManagerDeploymentName},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "kube-controller-manager",
+										Command: []string{
+											"--cloud-provider=?",
+											"--cloud-config=?",
+											"--external-cloud-volume-plugin=?",
+										},
+										Env: []corev1.EnvVar{
+											{Name: "AWS_ACCESS_KEY_ID", Value: "?"},
+											{Name: "AWS_SECRET_ACCESS_KEY", Value: "?"},
+										},
+										VolumeMounts: []corev1.VolumeMount{
+											{Name: aws.CloudProviderConfigName, MountPath: "?"},
+											{Name: common.CloudProviderSecretName, MountPath: "?"},
+										},
+									},
+								},
+								Volumes: []corev1.Volume{
+									{Name: aws.CloudProviderConfigName},
+									{Name: common.CloudProviderSecretName},
+								},
+							},
+						},
+					},
+				}
+			)
+
+			mutator := newMutator(logger)
+			err := mutator.Mutate(context.TODO(), dep)
+			Expect(err).To(Not(HaveOccurred()))
+			checkKubeControllerManagerDeployment(dep)
+		})
+	})
+})
+
+func checkKubeAPIServerDeployment(dep *appsv1.Deployment) {
+	// Check that the kube-apiserver container still exists and contains all needed command line args,
+	// env vars, and volume mounts
+	c := controlplane.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-apiserver")
+	Expect(c).To(Not(BeNil()))
+	Expect(c.Command).To(ContainElement("--cloud-provider=aws"))
+	Expect(c.Command).To(ContainElement("--cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf"))
+	Expect(c.Command).To(test.ContainElementWithPrefixContaining("--enable-admission-plugins=", "PersistentVolumeLabel", ","))
+	Expect(c.Command).To(Not(test.ContainElementWithPrefixContaining("--disable-admission-plugins=", "PersistentVolumeLabel", ",")))
+	Expect(c.Env).To(ContainElement(accessKeyIDEnvVar))
+	Expect(c.Env).To(ContainElement(secretAccessKeyEnvVar))
+	Expect(c.VolumeMounts).To(ContainElement(cloudProviderConfigVolumeMount))
+	Expect(c.VolumeMounts).To(ContainElement(cloudProviderSecretVolumeMount))
+
+	// Check that the Pod spec contains all needed volumes
+	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderConfigVolume))
+	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderSecretVolume))
+}
+
+func checkKubeControllerManagerDeployment(dep *appsv1.Deployment) {
+	// Check that the kube-controller-manager container still exists and contains all needed command line args,
+	// env vars, and volume mounts
+	c := controlplane.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-controller-manager")
+	Expect(c).To(Not(BeNil()))
+	Expect(c.Command).To(ContainElement("--cloud-provider=external"))
+	Expect(c.Command).To(ContainElement("--cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf"))
+	Expect(c.Command).To(ContainElement("--external-cloud-volume-plugin=aws"))
+	Expect(c.Env).To(ContainElement(accessKeyIDEnvVar))
+	Expect(c.Env).To(ContainElement(secretAccessKeyEnvVar))
+	Expect(c.VolumeMounts).To(ContainElement(cloudProviderConfigVolumeMount))
+	Expect(c.VolumeMounts).To(ContainElement(cloudProviderSecretVolumeMount))
+
+	// Check that the Pod spec contains all needed volumes
+	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderConfigVolume))
+	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderSecretVolume))
+}

--- a/controllers/provider-aws/pkg/webhook/controlplaneexposure/mutator.go
+++ b/controllers/provider-aws/pkg/webhook/controlplaneexposure/mutator.go
@@ -42,7 +42,7 @@ func (v *mutator) Mutate(ctx context.Context, obj runtime.Object) error {
 	switch x := obj.(type) {
 	case *corev1.Service:
 		switch x.Name {
-		case common.KubeAPIServerDeploymentName:
+		case "kube-apiserver":
 			return mutateKubeAPIServerService(x)
 		}
 	case *appsv1.Deployment:

--- a/controllers/provider-aws/pkg/webhook/controlplaneexposure/mutator_test.go
+++ b/controllers/provider-aws/pkg/webhook/controlplaneexposure/mutator_test.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplaneexposure
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
+
+	"github.com/gardener/gardener/pkg/operation/common"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AWS Controlplane Exposure Webhook Suite")
+}
+
+var _ = Describe("Mutator", func() {
+
+	Describe("#Mutate", func() {
+		It("should add annotations to kube-apiserver service", func() {
+			var (
+				svc = &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver"},
+				}
+			)
+
+			mutator := newMutator(logger)
+			err := mutator.Mutate(context.TODO(), svc)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(svc.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout", "3600"))
+			Expect(svc.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-backend-protocol", "ssl"))
+			Expect(svc.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-ssl-ports", "443"))
+			Expect(svc.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout", "5"))
+			Expect(svc.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval", "30"))
+			Expect(svc.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold", "2"))
+			Expect(svc.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold", "2"))
+			Expect(svc.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy", "ELBSecurityPolicy-TLS-1-2-2017-01"))
+		})
+
+		It("should ignore other services than kube-apiserver", func() {
+			var (
+				svc = &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				}
+			)
+
+			mutator := newMutator(logger)
+			err := mutator.Mutate(context.TODO(), svc)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(svc.Annotations).To(BeEmpty())
+		})
+
+		It("should add missing elements to kube-apiserver deployment", func() {
+			var (
+				dep = &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: common.KubeAPIServerDeploymentName},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "kube-apiserver",
+									},
+								},
+							},
+						},
+					},
+				}
+			)
+
+			mutator := newMutator(logger)
+			err := mutator.Mutate(context.TODO(), dep)
+			Expect(err).To(Not(HaveOccurred()))
+			checkKubeAPIServerDeployment(dep)
+		})
+
+		It("should modify existing elements of kube-apiserver deployment", func() {
+			var (
+				dep = &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: common.KubeAPIServerDeploymentName},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:    "kube-apiserver",
+										Command: []string{"--endpoint-reconciler-type=?"},
+									},
+								},
+							},
+						},
+					},
+				}
+			)
+
+			mutator := newMutator(logger)
+			err := mutator.Mutate(context.TODO(), dep)
+			Expect(err).To(Not(HaveOccurred()))
+			checkKubeAPIServerDeployment(dep)
+		})
+	})
+})
+
+func checkKubeAPIServerDeployment(dep *appsv1.Deployment) {
+	// Check that the kube-apiserver container still exists and contains all needed command line args
+	c := controlplane.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-apiserver")
+	Expect(c).To(Not(BeNil()))
+	Expect(c.Command).To(ContainElement("--endpoint-reconciler-type=none"))
+}

--- a/pkg/webhook/controlplane/test/matchers.go
+++ b/pkg/webhook/controlplane/test/matchers.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
+	"github.com/onsi/gomega/types"
+)
+
+// ContainElementWithPrefixContaining succeeds if actual contains a string having the given prefix
+// and containing the given value in a list separated by sep.
+// Actual must be a slice of strings.
+func ContainElementWithPrefixContaining(prefix, value, sep string) types.GomegaMatcher {
+	return &containElementWithPrefixContainingMatcher{
+		prefix: prefix,
+		value:  value,
+		sep:    sep,
+	}
+}
+
+type containElementWithPrefixContainingMatcher struct {
+	prefix, value, sep string
+}
+
+func (m *containElementWithPrefixContainingMatcher) Match(actual interface{}) (success bool, err error) {
+	items, ok := actual.([]string)
+	if !ok {
+		return false, fmt.Errorf("ContainElementWithPrefixContaining matcher expects []string")
+	}
+	i := controlplane.StringWithPrefixIndex(items, m.prefix)
+	if i < 0 {
+		return false, nil
+	}
+	values := strings.Split(strings.TrimPrefix(items[i], m.prefix), m.sep)
+	j := controlplane.StringIndex(values, m.value)
+	return j >= 0, nil
+}
+
+func (m *containElementWithPrefixContainingMatcher) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected\n\t%#v\nto contain an element with prefix '%s' containing '%s'", actual, m.prefix, m.value)
+}
+
+func (m *containElementWithPrefixContainingMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected\n\t%#v\nnot to contain an element with prefix '%s' containing '%s'", actual, m.prefix, m.value)
+}

--- a/pkg/webhook/controlplane/utils.go
+++ b/pkg/webhook/controlplane/utils.go
@@ -33,7 +33,7 @@ func ContainerWithName(containers []corev1.Container, name string) *corev1.Conta
 // with a value equal to prefix + value.
 func EnsureStringWithPrefix(items []string, prefix, value string) []string {
 	item := prefix + value
-	if i := stringWithPrefixIndex(items, prefix); i < 0 {
+	if i := StringWithPrefixIndex(items, prefix); i < 0 {
 		items = append(items, item)
 	} else if items[i] != item {
 		items = append(append(items[:i], item), items[i+1:]...)
@@ -43,7 +43,7 @@ func EnsureStringWithPrefix(items []string, prefix, value string) []string {
 
 // EnsureNoStringWithPrefix ensures that a string having the given prefix does not exist in the given slice.
 func EnsureNoStringWithPrefix(items []string, prefix string) []string {
-	if i := stringWithPrefixIndex(items, prefix); i >= 0 {
+	if i := StringWithPrefixIndex(items, prefix); i >= 0 {
 		items = append(items[:i], items[i+1:]...)
 	}
 	return items
@@ -52,11 +52,11 @@ func EnsureNoStringWithPrefix(items []string, prefix string) []string {
 // EnsureStringWithPrefixContains ensures that a string having the given prefix exists in the given slice
 // and contains the given value in a list separated by sep.
 func EnsureStringWithPrefixContains(items []string, prefix, value, sep string) []string {
-	if i := stringWithPrefixIndex(items, prefix); i < 0 {
+	if i := StringWithPrefixIndex(items, prefix); i < 0 {
 		items = append(items, prefix+value)
 	} else {
 		values := strings.Split(strings.TrimPrefix(items[i], prefix), sep)
-		if j := stringIndex(values, value); j < 0 {
+		if j := StringIndex(values, value); j < 0 {
 			values = append(values, value)
 			items = append(append(items[:i], prefix+strings.Join(values, sep)), items[i+1:]...)
 		}
@@ -67,9 +67,9 @@ func EnsureStringWithPrefixContains(items []string, prefix, value, sep string) [
 // EnsureNoStringWithPrefixContains ensures that either a string having the given prefix does not exist in the given slice,
 // or it doesn't contain the given value in a list separated by sep.
 func EnsureNoStringWithPrefixContains(items []string, prefix, value, sep string) []string {
-	if i := stringWithPrefixIndex(items, prefix); i >= 0 {
+	if i := StringWithPrefixIndex(items, prefix); i >= 0 {
 		values := strings.Split(strings.TrimPrefix(items[i], prefix), sep)
-		if j := stringIndex(values, value); j >= 0 {
+		if j := StringIndex(values, value); j >= 0 {
 			values = append(values[:j], values[j+1:]...)
 			items = append(append(items[:i], prefix+strings.Join(values, sep)), items[i+1:]...)
 		}
@@ -134,7 +134,8 @@ func EnsureNoVolumeWithName(items []corev1.Volume, name string) []corev1.Volume 
 	return items
 }
 
-func stringIndex(items []string, value string) int {
+// StringIndex returns the index of the first occurrence of the given string in the given slice, or -1 if not found.
+func StringIndex(items []string, value string) int {
 	for i, item := range items {
 		if item == value {
 			return i
@@ -143,7 +144,8 @@ func stringIndex(items []string, value string) int {
 	return -1
 }
 
-func stringWithPrefixIndex(items []string, prefix string) int {
+// StringWithPrefixIndex returns the index of the first occurrence of a string having the given prefix in the given slice, or -1 if not found.
+func StringWithPrefixIndex(items []string, prefix string) int {
 	for i, item := range items {
 		if strings.HasPrefix(item, prefix) {
 			return i


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds tests for the actual implementation of AWS controlplane webhooks.

**Special notes for your reviewer**:
Based on #52, which should be merged first. Tests for the generic part of the controlplane webhooks introduced with #48 will follow in another PR.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add AWS controlplane webhooks tests
```
