### PR TITLE
Fix comparison of networks during route deletion

### DIFF
--- a/controllers/provider-gcp/pkg/internal/infrastructure/infrastructure.go
+++ b/controllers/provider-gcp/pkg/internal/infrastructure/infrastructure.go
@@ -53,7 +53,7 @@ func ListKubernetesRoutes(ctx context.Context, client gcpclient.Interface, proje
 	var routes []string
 	if err := client.Routes().List(projectID).Pages(ctx, func(page *compute.RouteList) error {
 		for _, route := range page.Items {
-			if strings.HasPrefix(route.Name, routePrefix) && route.Network == network {
+			if strings.HasPrefix(route.Name, routePrefix) && strings.HasSuffix(route.Network, network) {
 				routes = append(routes, route.Name)
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix comparison of networks during route deletion

```improvement operator
NONE
```
