### PR TITLE
[ci:component:github.com/gardener/machine-controller-manager:0.16.0->0.18.0]

### DIFF
--- a/controllers/provider-aws/charts/images.yaml
+++ b/controllers/provider-aws/charts/images.yaml
@@ -9,4 +9,4 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.16.0"
+  tag: "0.18.0"

--- a/controllers/provider-azure/charts/images.yaml
+++ b/controllers/provider-azure/charts/images.yaml
@@ -6,4 +6,4 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.16.0"
+  tag: "0.18.0"

--- a/controllers/provider-gcp/charts/images.yaml
+++ b/controllers/provider-gcp/charts/images.yaml
@@ -9,4 +9,4 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.16.0"
+  tag: "0.18.0"

--- a/controllers/provider-openstack/charts/images.yaml
+++ b/controllers/provider-openstack/charts/images.yaml
@@ -6,4 +6,4 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.16.0"
+  tag: "0.18.0"

--- a/controllers/provider-packet/charts/images.yaml
+++ b/controllers/provider-packet/charts/images.yaml
@@ -10,4 +10,4 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.16.0"
+  tag: "0.18.0"


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/machine-controller-manager #271 @rfranzke
The machine-controller-manager does now correctly add its finalizer to Alicloud machine class secrets.
```

``` noteworthy user github.com/gardener/machine-controller-manager #268 @prashanth26
Deletion of annotations, labels and taints are now supported
```

``` improvement operator github.com/gardener/machine-controller-manager #268 @prashanth26
Multiple taints with the same key but different values are now supported
```

``` improvement operator github.com/gardener/machine-controller-manager #265 @hardikdr
Bugfix: Existing machine-objects now adopts the node-label.
```

``` improvement operator github.com/gardener/machine-controller-manager #264 @prashanth26
Bugfix: MachineDeployment with partial freeze status has been syncronized to display the correct status
```

``` improvement operator github.com/gardener/machine-controller-manager #257 @prashanth26
Added safety controller cases in integration tests
```

``` noteworthy user github.com/gardener/machine-controller-manager #256 @hardikdr
Enables support for propagating and maintaining the taints, annotations and labels from machine-api objects to node-objects.
```