### PR TITLE
Add network policies

### DIFF
--- a/controllers/extension-certificate-service/charts/internal/cert-broker/templates/deployment.yaml
+++ b/controllers/extension-certificate-service/charts/internal/cert-broker/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         app: {{ template "cert-broker.name" . }}
         release: {{ .Release.Name }}
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-shoot-apiserver: allowed
+        networking.gardener.cloud/to-seed-apiserver: allowed
+        networking.gardener.cloud/from-prometheus: allowed
     spec:
       serviceAccountName: {{ template "cert-broker.name" . }}
       containers:

--- a/controllers/extension-certificate-service/charts/internal/cert-manager/values.yaml
+++ b/controllers/extension-certificate-service/charts/internal/cert-manager/values.yaml
@@ -48,7 +48,12 @@ resources:
 
 podAnnotations: {}
 
-podLabels: {}
+podLabels:
+  networking.gardener.cloud/to-dns: allowed
+  networking.gardener.cloud/to-seed-apiserver: allowed
+  networking.gardener.cloud/to-public-networks: allowed
+  networking.gardener.cloud/from-prometheus: allowed
+
 # Optional DNS settings, useful if you have a public and private DNS zone for
 # the same domain on Route 53. What follows is an example of ensuring
 # cert-manager can access an ingress or DNS TXT records at all times.

--- a/controllers/provider-alicloud/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/controllers/provider-alicloud/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -19,13 +19,19 @@ spec:
     metadata:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-      {{- if .Values.podAnnotations }}
+{{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
-      {{- end }}
+{{- end }}
       labels:
         garden.sapcloud.io/role: controlplane
         app: kubernetes
         role: machine-controller-manager
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-private-networks: allowed
+        networking.gardener.cloud/to-seed-apiserver: allowed
+        networking.gardener.cloud/to-shoot-apiserver: allowed
+        networking.gardener.cloud/from-prometheus: allowed
     spec:
       serviceAccountName: machine-controller-manager
       terminationGracePeriodSeconds: 5
@@ -59,6 +65,10 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 5
+        ports:
+        - name: metrics
+          containerPort: {{ .Values.metricsPort }}
+          protocol: TCP
         resources:
           requests:
             cpu: 50m

--- a/controllers/provider-aws/charts/internal/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/controllers/provider-aws/charts/internal/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -43,6 +43,10 @@ spec:
         garden.sapcloud.io/role: controlplane
         app: kubernetes
         role: cloud-controller-manager
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-shoot-apiserver: allowed
+        networking.gardener.cloud/from-prometheus: allowed
     spec:
       tolerations:
       - effect: NoExecute
@@ -105,6 +109,10 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 10
           timeoutSeconds: 15
+        ports:
+        - containerPort: {{ include "cloud-controller-manager.port" . }}
+          name: metrics
+          protocol: TCP
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         {{- if .Values.resources }}

--- a/controllers/provider-aws/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/controllers/provider-aws/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -19,13 +19,19 @@ spec:
     metadata:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-      {{- if .Values.podAnnotations }}
+{{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
-      {{- end }}
+{{- end }}
       labels:
         garden.sapcloud.io/role: controlplane
         app: kubernetes
         role: machine-controller-manager
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-private-networks: allowed
+        networking.gardener.cloud/to-seed-apiserver: allowed
+        networking.gardener.cloud/to-shoot-apiserver: allowed
+        networking.gardener.cloud/from-prometheus: allowed
     spec:
       serviceAccountName: machine-controller-manager
       terminationGracePeriodSeconds: 5
@@ -59,6 +65,10 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 5
+        ports:
+        - name: metrics
+          containerPort: {{ .Values.metricsPort }}
+          protocol: TCP
         resources:
           requests:
             cpu: 50m

--- a/controllers/provider-azure/charts/internal/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/controllers/provider-azure/charts/internal/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -43,6 +43,10 @@ spec:
         garden.sapcloud.io/role: controlplane
         app: kubernetes
         role: cloud-controller-manager
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-shoot-apiserver: allowed
+        networking.gardener.cloud/from-prometheus: allowed
     spec:
       tolerations:
       - effect: NoExecute
@@ -94,6 +98,10 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 10
           timeoutSeconds: 15
+        ports:
+        - containerPort: {{ include "cloud-controller-manager.port" . }}
+          name: metrics
+          protocol: TCP
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         {{- if .Values.resources }}

--- a/controllers/provider-azure/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/controllers/provider-azure/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -19,13 +19,19 @@ spec:
     metadata:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-      {{- if .Values.podAnnotations }}
+{{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
-      {{- end }}
+{{- end }}
       labels:
         garden.sapcloud.io/role: controlplane
         app: kubernetes
         role: machine-controller-manager
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-private-networks: allowed
+        networking.gardener.cloud/to-seed-apiserver: allowed
+        networking.gardener.cloud/to-shoot-apiserver: allowed
+        networking.gardener.cloud/from-prometheus: allowed
     spec:
       serviceAccountName: machine-controller-manager
       terminationGracePeriodSeconds: 5
@@ -59,6 +65,10 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 5
+        ports:
+        - name: metrics
+          containerPort: {{ .Values.metricsPort }}
+          protocol: TCP
         resources:
           requests:
             cpu: 50m

--- a/controllers/provider-gcp/charts/internal/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/controllers/provider-gcp/charts/internal/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -43,6 +43,10 @@ spec:
         garden.sapcloud.io/role: controlplane
         app: kubernetes
         role: cloud-controller-manager
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-shoot-apiserver: allowed
+        networking.gardener.cloud/from-prometheus: allowed
     spec:
       tolerations:
       - effect: NoExecute
@@ -97,6 +101,10 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 10
           timeoutSeconds: 15
+        ports:
+        - containerPort: {{ include "cloud-controller-manager.port" . }}
+          name: metrics
+          protocol: TCP
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         {{- if .Values.resources }}

--- a/controllers/provider-gcp/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/controllers/provider-gcp/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -19,13 +19,19 @@ spec:
     metadata:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-      {{- if .Values.podAnnotations }}
+{{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
-      {{- end }}
+{{- end }}
       labels:
         garden.sapcloud.io/role: controlplane
         app: kubernetes
         role: machine-controller-manager
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-private-networks: allowed
+        networking.gardener.cloud/to-seed-apiserver: allowed
+        networking.gardener.cloud/to-shoot-apiserver: allowed
+        networking.gardener.cloud/from-prometheus: allowed
     spec:
       serviceAccountName: machine-controller-manager
       terminationGracePeriodSeconds: 5
@@ -59,6 +65,10 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 5
+        ports:
+        - name: metrics
+          containerPort: {{ .Values.metricsPort }}
+          protocol: TCP
         resources:
           requests:
             cpu: 50m

--- a/controllers/provider-openstack/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/controllers/provider-openstack/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -19,13 +19,19 @@ spec:
     metadata:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-      {{- if .Values.podAnnotations }}
+{{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
-      {{- end }}
+{{- end }}
       labels:
         garden.sapcloud.io/role: controlplane
         app: kubernetes
         role: machine-controller-manager
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-private-networks: allowed
+        networking.gardener.cloud/to-seed-apiserver: allowed
+        networking.gardener.cloud/to-shoot-apiserver: allowed
+        networking.gardener.cloud/from-prometheus: allowed
     spec:
       serviceAccountName: machine-controller-manager
       terminationGracePeriodSeconds: 5
@@ -59,6 +65,10 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 5
+        ports:
+        - name: metrics
+          containerPort: {{ .Values.metricsPort }}
+          protocol: TCP
         resources:
           requests:
             cpu: 50m

--- a/controllers/provider-packet/charts/internal/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/controllers/provider-packet/charts/internal/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -18,6 +18,10 @@ spec:
       labels:
         app: packet-cloud-controller-manager
         garden.sapcloud.io/role: controlplane
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-shoot-apiserver: allowed
+        networking.gardener.cloud/from-prometheus: allowed
 {{- if .Values.podAnnotations }}
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
@@ -47,6 +51,11 @@ spec:
             secretKeyRef:
               name: cloudprovider
               key: projectID
+        ports:
+        # Packet's CCM is based on K8S 1.11 and uses 10253 port by default.
+        - containerPort: 10253
+          name: metrics
+          protocol: TCP
         {{- if .Values.resources }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/controllers/provider-packet/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/controllers/provider-packet/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -19,13 +19,19 @@ spec:
     metadata:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-      {{- if .Values.podAnnotations }}
+{{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
-      {{- end }}
+{{- end }}
       labels:
         garden.sapcloud.io/role: controlplane
         app: kubernetes
         role: machine-controller-manager
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-private-networks: allowed
+        networking.gardener.cloud/to-seed-apiserver: allowed
+        networking.gardener.cloud/to-shoot-apiserver: allowed
+        networking.gardener.cloud/from-prometheus: allowed
     spec:
       serviceAccountName: machine-controller-manager
       terminationGracePeriodSeconds: 5
@@ -59,6 +65,10 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 5
+        ports:
+        - name: metrics
+          containerPort: {{ .Values.metricsPort }}
+          protocol: TCP
         resources:
           requests:
             cpu: 50m

--- a/vendor/github.com/gardener/gardener/pkg/operation/terraformer/terraformer.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/terraformer/terraformer.go
@@ -295,6 +295,7 @@ func (t *Terraformer) deployTerraformerPod(ctx context.Context, scriptName strin
 			pod.Labels = make(map[string]string)
 		}
 		pod.Labels[jobNameLabel] = t.jobName
+		t.addNetworkPolicyLabels(pod.Labels)
 		pod.Spec = *t.podSpec(scriptName)
 		return nil
 	})
@@ -321,6 +322,7 @@ func (t *Terraformer) deployTerraformerJob(ctx context.Context, scriptName strin
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: t.namespace,
 				Name:      t.jobName,
+				Labels:    t.addNetworkPolicyLabels(nil),
 			},
 			Spec: *podSpec,
 		}
@@ -339,6 +341,18 @@ func (t *Terraformer) env() []corev1.EnvVar {
 		envVars = append(envVars, corev1.EnvVar{Name: k, Value: v})
 	}
 	return envVars
+}
+
+func (t *Terraformer) addNetworkPolicyLabels(labels map[string]string) map[string]string {
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels["networking.gardener.cloud/to-dns"] = "allowed"
+	labels["networking.gardener.cloud/to-private-networks"] = "allowed"
+	labels["networking.gardener.cloud/to-public-networks"] = "allowed"
+	labels["networking.gardener.cloud/to-seed-apiserver"] = "allowed"
+
+	return labels
 }
 
 func (t *Terraformer) podSpec(scriptName string) *corev1.PodSpec {


### PR DESCRIPTION
**What this PR does / why we need it**:

Network policies are going to be added in https://github.com/gardener/gardener/pull/904 blocking all egress and ingress traffic. This PR is a prerequisite for that.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

There is a little chicken and egg problem - the https://github.com/gardener/gardener/pull/904 PR must be merged in order to update the terraformer with correct labels, but it cannot be merged, because extension controllers don't use the annotations and it'll break the cluster creation.

## !!! Please make that 27c74de is not overwritten when doing `dep ensure`. If it's overwritten, then it's required to cherry-pick it until https://github.com/gardener/gardener/pull/904 is merged in upstream gardener. !!!

/cc @timuthy @deitch @stoyanr @jia-jerry

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NetworkPolicy labels are added to all components deployed in a Shoot namespace.
```
