### PR TITLE
Skip Cert-Broker when DNS provider is unmanaged

### DIFF
--- a/controllers/extension-certificate-service/pkg/controller/certservice/actuator.go
+++ b/controllers/extension-certificate-service/pkg/controller/certservice/actuator.go
@@ -84,6 +84,11 @@ func (a *actuator) Reconcile(ctx context.Context, ex *extensionsv1alpha1.Extensi
 		return err
 	}
 
+	dns := cluster.Shoot.Spec.DNS
+	if dns.Domain == nil && dns.Provider == gardenv1beta1.DNSUnmanaged {
+		return nil
+	}
+
 	if !controller.IsHibernated(cluster.Shoot) {
 		if err := a.createRBAC(ctx, kubecfg); err != nil {
 			return err


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue for the `Certificate-Service` extension controller when the `domain` of a shoot is nil. This is a valid scenario if the shoot's dns provider is `unmanaged`. Hence, the extension controller can omit the deployment of `Cert-Broker`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Fixes an issue for the `Certificate-Service` controller which couldn't handle shoots whose dns provider was `unmanaged`.
```
