### PR TITLE
Temporarily disable writing to shoot in controlplane controllers

### DIFF
--- a/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/pkg/controller/controlplane/genericactuator/actuator.go
@@ -31,7 +31,6 @@ import (
 	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
@@ -188,22 +187,22 @@ func (a *actuator) Reconcile(
 	}
 
 	// Create shoot clients
-	sc, err := a.shootClientsFactory.NewClientsForShoot(ctx, a.client, cp.Namespace, client.Options{})
-	if err != nil {
-		return errors.Wrapf(err, "could not create shoot clients for shoot '%s'", cp.Namespace)
-	}
+	// sc, err := a.shootClientsFactory.NewClientsForShoot(ctx, a.client, cp.Namespace, client.Options{})
+	// if err != nil {
+	// 	return errors.Wrapf(err, "could not create shoot clients for shoot '%s'", cp.Namespace)
+	// }
 
 	// Get control plane shoot chart values
-	values, err = a.vp.GetControlPlaneShootChartValues(ctx, cp, cluster)
-	if err != nil {
-		return err
-	}
+	// values, err = a.vp.GetControlPlaneShootChartValues(ctx, cp, cluster)
+	// if err != nil {
+	// 	return err
+	// }
 
 	// Apply control plane shoot chart
-	a.logger.Info("Applying control plane shoot chart", "controlplane", util.ObjectName(cp), "values", values)
-	if err := a.controlPlaneShootChart.Apply(ctx, sc.GardenerClientset(), sc.ChartApplier(), metav1.NamespaceSystem, cluster.Shoot, a.imageVector, nil, values); err != nil {
-		return errors.Wrapf(err, "could not apply control plane shoot chart for controlplane '%s'", util.ObjectName(cp))
-	}
+	// a.logger.Info("Applying control plane shoot chart", "controlplane", util.ObjectName(cp), "values", values)
+	// if err := a.controlPlaneShootChart.Apply(ctx, sc.GardenerClientset(), sc.ChartApplier(), metav1.NamespaceSystem, cluster.Shoot, a.imageVector, nil, values); err != nil {
+	// 	return errors.Wrapf(err, "could not apply control plane shoot chart for controlplane '%s'", util.ObjectName(cp))
+	// }
 
 	return nil
 }
@@ -216,16 +215,16 @@ func (a *actuator) Delete(
 	cluster *extensionscontroller.Cluster,
 ) error {
 	// Create shoot clients
-	sc, err := a.shootClientsFactory.NewClientsForShoot(ctx, a.client, cp.Namespace, client.Options{})
-	if err != nil {
-		return errors.Wrapf(err, "could not create shoot clients for shoot '%s'", cp.Namespace)
-	}
+	// sc, err := a.shootClientsFactory.NewClientsForShoot(ctx, a.client, cp.Namespace, client.Options{})
+	// if err != nil {
+	// 	return errors.Wrapf(err, "could not create shoot clients for shoot '%s'", cp.Namespace)
+	// }
 
 	// Delete control plane shoot objects
-	a.logger.Info("Deleting control plane shoot objects", "controlplane", util.ObjectName(cp))
-	if err := a.controlPlaneShootChart.Delete(ctx, sc.Client(), metav1.NamespaceSystem); err != nil {
-		return errors.Wrapf(err, "could not delete control plane shoot objects for controlplane '%s'", util.ObjectName(cp))
-	}
+	// a.logger.Info("Deleting control plane shoot objects", "controlplane", util.ObjectName(cp))
+	// if err := a.controlPlaneShootChart.Delete(ctx, sc.Client(), metav1.NamespaceSystem); err != nil {
+	// 	return errors.Wrapf(err, "could not delete control plane shoot objects for controlplane '%s'", util.ObjectName(cp))
+	// }
 
 	// Delete control plane objects
 	a.logger.Info("Deleting control plane objects", "controlplane", util.ObjectName(cp))

--- a/pkg/controller/controlplane/genericactuator/actuator_test.go
+++ b/pkg/controller/controlplane/genericactuator/actuator_test.go
@@ -111,9 +111,9 @@ var _ = Describe("Actuator", func() {
 			"clusterName": namespace,
 		}
 
-		controlPlaneShootChartValues = map[string]interface{}{
-			"foo": "bar",
-		}
+		// controlPlaneShootChartValues = map[string]interface{}{
+		// 	"foo": "bar",
+		// }
 
 		logger = log.Log.WithName("test")
 	)
@@ -141,20 +141,20 @@ var _ = Describe("Actuator", func() {
 			ccmChart := mockutil.NewMockChart(ctrl)
 			ccmChart.EXPECT().Apply(context.TODO(), gomock.Any(), gomock.Any(), namespace, cluster.Shoot, imageVector, checksums, controlPlaneChartValues).Return(nil)
 			ccmShootChart := mockutil.NewMockChart(ctrl)
-			ccmShootChart.EXPECT().Apply(context.TODO(), gomock.Any(), gomock.Any(), metav1.NamespaceSystem, cluster.Shoot, imageVector, nil, controlPlaneShootChartValues).Return(nil)
+			// ccmShootChart.EXPECT().Apply(context.TODO(), gomock.Any(), gomock.Any(), metav1.NamespaceSystem, cluster.Shoot, imageVector, nil, controlPlaneShootChartValues).Return(nil)
 
 			// Create mock values provider
 			vp := mockgenericactuator.NewMockValuesProvider(ctrl)
 			vp.EXPECT().GetConfigChartValues(context.TODO(), cp, cluster).Return(configChartValues, nil)
 			vp.EXPECT().GetControlPlaneChartValues(context.TODO(), cp, cluster, checksums).Return(controlPlaneChartValues, nil)
-			vp.EXPECT().GetControlPlaneShootChartValues(context.TODO(), cp, cluster).Return(controlPlaneShootChartValues, nil)
+			// vp.EXPECT().GetControlPlaneShootChartValues(context.TODO(), cp, cluster).Return(controlPlaneShootChartValues, nil)
 
 			// Create mock shoot clients factory
-			sc := mockutil.NewMockShootClients(ctrl)
-			sc.EXPECT().GardenerClientset().Return(nil)
-			sc.EXPECT().ChartApplier().Return(nil)
+			// sc := mockutil.NewMockShootClients(ctrl)
+			// sc.EXPECT().GardenerClientset().Return(nil)
+			// sc.EXPECT().ChartApplier().Return(nil)
 			scf := mockgenericactuator.NewMockShootClientsFactory(ctrl)
-			scf.EXPECT().NewClientsForShoot(context.TODO(), client, namespace, gomock.Any()).Return(sc, nil)
+			// scf.EXPECT().NewClientsForShoot(context.TODO(), client, namespace, gomock.Any()).Return(sc, nil)
 
 			// Create actuator
 			a := NewActuator(secrets, configChart, ccmChart, ccmShootChart, vp, scf, imageVector, cloudProviderConfigName, logger)
@@ -177,19 +177,19 @@ var _ = Describe("Actuator", func() {
 			ccmChart := mockutil.NewMockChart(ctrl)
 			ccmChart.EXPECT().Apply(context.TODO(), gomock.Any(), gomock.Any(), namespace, cluster.Shoot, imageVector, checksumsWithoutConfig, controlPlaneChartValues).Return(nil)
 			ccmShootChart := mockutil.NewMockChart(ctrl)
-			ccmShootChart.EXPECT().Apply(context.TODO(), gomock.Any(), gomock.Any(), metav1.NamespaceSystem, cluster.Shoot, imageVector, nil, controlPlaneShootChartValues).Return(nil)
+			// ccmShootChart.EXPECT().Apply(context.TODO(), gomock.Any(), gomock.Any(), metav1.NamespaceSystem, cluster.Shoot, imageVector, nil, controlPlaneShootChartValues).Return(nil)
 
 			// Create mock values provider
 			vp := mockgenericactuator.NewMockValuesProvider(ctrl)
 			vp.EXPECT().GetControlPlaneChartValues(context.TODO(), cp, cluster, checksumsWithoutConfig).Return(controlPlaneChartValues, nil)
-			vp.EXPECT().GetControlPlaneShootChartValues(context.TODO(), cp, cluster).Return(controlPlaneShootChartValues, nil)
+			// vp.EXPECT().GetControlPlaneShootChartValues(context.TODO(), cp, cluster).Return(controlPlaneShootChartValues, nil)
 
 			// Create mock shoot clients factory
-			sc := mockutil.NewMockShootClients(ctrl)
-			sc.EXPECT().GardenerClientset().Return(nil)
-			sc.EXPECT().ChartApplier().Return(nil)
+			// sc := mockutil.NewMockShootClients(ctrl)
+			// sc.EXPECT().GardenerClientset().Return(nil)
+			// sc.EXPECT().ChartApplier().Return(nil)
 			scf := mockgenericactuator.NewMockShootClientsFactory(ctrl)
-			scf.EXPECT().NewClientsForShoot(context.TODO(), client, namespace, gomock.Any()).Return(sc, nil)
+			// scf.EXPECT().NewClientsForShoot(context.TODO(), client, namespace, gomock.Any()).Return(sc, nil)
 
 			// Create actuator
 			a := NewActuator(secrets, nil, ccmChart, ccmShootChart, vp, scf, imageVector, "", logger)
@@ -206,7 +206,7 @@ var _ = Describe("Actuator", func() {
 		It("should delete secrets and charts", func() {
 			// Create mock clients
 			client := mockclient.NewMockClient(ctrl)
-			shootClient := mockclient.NewMockClient(ctrl)
+			// shootClient := mockclient.NewMockClient(ctrl)
 
 			// Create mock secrets and charts
 			secrets := mockutil.NewMockSecrets(ctrl)
@@ -216,13 +216,13 @@ var _ = Describe("Actuator", func() {
 			ccmChart := mockutil.NewMockChart(ctrl)
 			ccmChart.EXPECT().Delete(context.TODO(), client, namespace).Return(nil)
 			ccmShootChart := mockutil.NewMockChart(ctrl)
-			ccmShootChart.EXPECT().Delete(context.TODO(), shootClient, metav1.NamespaceSystem).Return(nil)
+			// ccmShootChart.EXPECT().Delete(context.TODO(), shootClient, metav1.NamespaceSystem).Return(nil)
 
 			// Create mock shoot clients factory
-			sc := mockutil.NewMockShootClients(ctrl)
-			sc.EXPECT().Client().Return(shootClient)
+			// sc := mockutil.NewMockShootClients(ctrl)
+			// sc.EXPECT().Client().Return(shootClient)
 			scf := mockgenericactuator.NewMockShootClientsFactory(ctrl)
-			scf.EXPECT().NewClientsForShoot(context.TODO(), client, namespace, gomock.Any()).Return(sc, nil)
+			// scf.EXPECT().NewClientsForShoot(context.TODO(), client, namespace, gomock.Any()).Return(sc, nil)
 
 			// Create actuator
 			a := NewActuator(secrets, configChart, ccmChart, ccmShootChart, nil, scf, nil, cloudProviderConfigName, logger)
@@ -237,7 +237,7 @@ var _ = Describe("Actuator", func() {
 		It("should delete secrets and charts (only controlplane chart)", func() {
 			// Create mock client
 			client := mockclient.NewMockClient(ctrl)
-			shootClient := mockclient.NewMockClient(ctrl)
+			// shootClient := mockclient.NewMockClient(ctrl)
 
 			// Create mock secrets and charts
 			secrets := mockutil.NewMockSecrets(ctrl)
@@ -245,13 +245,13 @@ var _ = Describe("Actuator", func() {
 			ccmChart := mockutil.NewMockChart(ctrl)
 			ccmChart.EXPECT().Delete(context.TODO(), client, namespace).Return(nil)
 			ccmShootChart := mockutil.NewMockChart(ctrl)
-			ccmShootChart.EXPECT().Delete(context.TODO(), shootClient, metav1.NamespaceSystem).Return(nil)
+			// ccmShootChart.EXPECT().Delete(context.TODO(), shootClient, metav1.NamespaceSystem).Return(nil)
 
 			// Create mock shoot clients factory
-			sc := mockutil.NewMockShootClients(ctrl)
-			sc.EXPECT().Client().Return(shootClient)
+			// sc := mockutil.NewMockShootClients(ctrl)
+			// sc.EXPECT().Client().Return(shootClient)
 			scf := mockgenericactuator.NewMockShootClientsFactory(ctrl)
-			scf.EXPECT().NewClientsForShoot(context.TODO(), client, namespace, gomock.Any()).Return(sc, nil)
+			// scf.EXPECT().NewClientsForShoot(context.TODO(), client, namespace, gomock.Any()).Return(sc, nil)
 
 			// Create actuator
 			a := NewActuator(secrets, nil, ccmChart, ccmShootChart, nil, scf, nil, "", logger)


### PR DESCRIPTION
**What this PR does / why we need it**:
Temporarily disables writing to shoot in controlplane controllers to resolve ordering issue in Gardener flow.

**Special notes for your reviewer**:
* The issue and a proposed approach for solving it is described in #111.
* Code is intentionally commented out, not deleted, as it will be needed soon to implement a more permanent solutions to the issue.
* Depends on #107 which should be merged first.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Temporarily disable writing to shoot in controlplane controllers
```
