### PR TITLE
Fix OpenStack ControlPlane controller's values

### DIFF
--- a/controllers/provider-openstack/pkg/apis/openstack/types_controlplane.go
+++ b/controllers/provider-openstack/pkg/apis/openstack/types_controlplane.go
@@ -28,12 +28,6 @@ type ControlPlaneConfig struct {
 	// LoadBalancerProvider is the name of the load balancer provider in the OpenStack environment.
 	LoadBalancerProvider string
 
-	// DHCPDomain is the dhcp domain of the OpenStack system configured in nova.conf. Only meaningful for
-	// Kubernetes 1.10.1+. See https://github.com/kubernetes/kubernetes/pull/61890 for details.
-	DHCPDomain *string
-	// RequestTimeout specifies the HTTP timeout against the OpenStack API.
-	RequestTimeout *metav1.Duration
-
 	// CloudControllerManager contains configuration settings for the cloud-controller-manager.
 	// +optional
 	CloudControllerManager *CloudControllerManagerConfig

--- a/controllers/provider-openstack/pkg/apis/openstack/v1alpha1/types_controlplane.go
+++ b/controllers/provider-openstack/pkg/apis/openstack/v1alpha1/types_controlplane.go
@@ -28,14 +28,6 @@ type ControlPlaneConfig struct {
 	// LoadBalancerProvider is the name of the load balancer provider in the OpenStack environment.
 	LoadBalancerProvider string `json:"loadBalancerProvider"`
 
-	// DHCPDomain is the dhcp domain of the OpenStack system configured in nova.conf. Only meaningful for
-	// Kubernetes 1.10.1+. See https://github.com/kubernetes/kubernetes/pull/61890 for details.
-	// +optional
-	DHCPDomain *string `json:"dhcpDomain,omitempty"`
-	// RequestTimeout specifies the HTTP timeout against the OpenStack API.
-	// +optional
-	RequestTimeout *metav1.Duration `json:"requestTimeout,omitempty"`
-
 	// CloudControllerManager contains configuration settings for the cloud-controller-manager.
 	// +optional
 	CloudControllerManager *CloudControllerManagerConfig `json:"cloudControllerManager,omitempty"`

--- a/controllers/provider-openstack/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
+++ b/controllers/provider-openstack/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
@@ -25,7 +25,6 @@ import (
 
 	openstack "github.com/gardener/gardener-extensions/controllers/provider-openstack/pkg/apis/openstack"
 	corev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -182,8 +181,6 @@ func Convert_openstack_CloudControllerManagerConfig_To_v1alpha1_CloudControllerM
 
 func autoConvert_v1alpha1_ControlPlaneConfig_To_openstack_ControlPlaneConfig(in *ControlPlaneConfig, out *openstack.ControlPlaneConfig, s conversion.Scope) error {
 	out.LoadBalancerProvider = in.LoadBalancerProvider
-	out.DHCPDomain = (*string)(unsafe.Pointer(in.DHCPDomain))
-	out.RequestTimeout = (*v1.Duration)(unsafe.Pointer(in.RequestTimeout))
 	out.CloudControllerManager = (*openstack.CloudControllerManagerConfig)(unsafe.Pointer(in.CloudControllerManager))
 	return nil
 }
@@ -195,8 +192,6 @@ func Convert_v1alpha1_ControlPlaneConfig_To_openstack_ControlPlaneConfig(in *Con
 
 func autoConvert_openstack_ControlPlaneConfig_To_v1alpha1_ControlPlaneConfig(in *openstack.ControlPlaneConfig, out *ControlPlaneConfig, s conversion.Scope) error {
 	out.LoadBalancerProvider = in.LoadBalancerProvider
-	out.DHCPDomain = (*string)(unsafe.Pointer(in.DHCPDomain))
-	out.RequestTimeout = (*v1.Duration)(unsafe.Pointer(in.RequestTimeout))
 	out.CloudControllerManager = (*CloudControllerManagerConfig)(unsafe.Pointer(in.CloudControllerManager))
 	return nil
 }

--- a/controllers/provider-openstack/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
+++ b/controllers/provider-openstack/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -46,16 +45,6 @@ func (in *CloudControllerManagerConfig) DeepCopy() *CloudControllerManagerConfig
 func (in *ControlPlaneConfig) DeepCopyInto(out *ControlPlaneConfig) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	if in.DHCPDomain != nil {
-		in, out := &in.DHCPDomain, &out.DHCPDomain
-		*out = new(string)
-		**out = **in
-	}
-	if in.RequestTimeout != nil {
-		in, out := &in.RequestTimeout, &out.RequestTimeout
-		*out = new(v1.Duration)
-		**out = **in
-	}
 	if in.CloudControllerManager != nil {
 		in, out := &in.CloudControllerManager, &out.CloudControllerManager
 		*out = new(CloudControllerManagerConfig)

--- a/controllers/provider-openstack/pkg/apis/openstack/zz_generated.deepcopy.go
+++ b/controllers/provider-openstack/pkg/apis/openstack/zz_generated.deepcopy.go
@@ -21,7 +21,6 @@ limitations under the License.
 package openstack
 
 import (
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -46,16 +45,6 @@ func (in *CloudControllerManagerConfig) DeepCopy() *CloudControllerManagerConfig
 func (in *ControlPlaneConfig) DeepCopyInto(out *ControlPlaneConfig) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	if in.DHCPDomain != nil {
-		in, out := &in.DHCPDomain, &out.DHCPDomain
-		*out = new(string)
-		**out = **in
-	}
-	if in.RequestTimeout != nil {
-		in, out := &in.RequestTimeout, &out.RequestTimeout
-		*out = new(v1.Duration)
-		**out = **in
-	}
 	if in.CloudControllerManager != nil {
 		in, out := &in.CloudControllerManager, &out.CloudControllerManager
 		*out = new(CloudControllerManagerConfig)

--- a/controllers/provider-openstack/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-openstack/pkg/controller/controlplane/valuesprovider.go
@@ -17,7 +17,6 @@ package controlplane
 import (
 	"context"
 	"path/filepath"
-	"time"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -210,11 +209,6 @@ func getConfigChartValues(
 		return nil, errors.Wrapf(err, "could not determine subnet ID from infrastructureProviderStatus of controlplane '%s'", util.ObjectName(cp))
 	}
 
-	var requestedTimeout time.Duration
-	if cpConfig.RequestTimeout != nil {
-		requestedTimeout = cpConfig.RequestTimeout.Duration
-	}
-
 	// Collect config chart values
 	return map[string]interface{}{
 		"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
@@ -226,8 +220,8 @@ func getConfigChartValues(
 		"floatingNetworkID": infraStatus.Networks.FloatingPool.ID,
 		"subnetID":          subnetID.ID,
 		"authUrl":           cluster.CloudProfile.Spec.OpenStack.KeyStoneURL,
-		"dhcpDomain":        cpConfig.DHCPDomain,
-		"requestTimeout":    requestedTimeout,
+		"dhcpDomain":        cluster.CloudProfile.Spec.OpenStack.DHCPDomain,
+		"requestTimeout":    cluster.CloudProfile.Spec.OpenStack.RequestTimeout,
 	}, nil
 }
 

--- a/controllers/provider-openstack/pkg/controller/controlplane/valuesprovider_test.go
+++ b/controllers/provider-openstack/pkg/controller/controlplane/valuesprovider_test.go
@@ -23,8 +23,6 @@ import (
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener-extensions/pkg/util"
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
-	"time"
-
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/operation/common"
@@ -44,12 +42,12 @@ import (
 )
 
 const (
-	namespace      = "test"
-	authURL        = "someurl"
-	requestTimeout = 2 * time.Second
+	namespace = "test"
+	authURL   = "someurl"
 )
 
 var dhcpDomain = util.StringPtr("dhcp-domain")
+var requestTimeout = util.StringPtr("2s")
 
 var _ = Describe("ValuesProvider", func() {
 	var (
@@ -72,8 +70,6 @@ var _ = Describe("ValuesProvider", func() {
 				ProviderConfig: &runtime.RawExtension{
 					Raw: encode(&openstack.ControlPlaneConfig{
 						LoadBalancerProvider: "load-balancer-provider",
-						DHCPDomain:           dhcpDomain,
-						RequestTimeout:       &metav1.Duration{Duration: requestTimeout},
 						CloudControllerManager: &openstack.CloudControllerManagerConfig{
 							KubernetesConfig: gardenv1beta1.KubernetesConfig{
 								FeatureGates: map[string]bool{
@@ -106,7 +102,9 @@ var _ = Describe("ValuesProvider", func() {
 			CloudProfile: &gardenv1beta1.CloudProfile{
 				Spec: gardenv1beta1.CloudProfileSpec{
 					OpenStack: &gardenv1beta1.OpenStackProfile{
-						KeyStoneURL: authURL,
+						KeyStoneURL:    authURL,
+						DHCPDomain:     dhcpDomain,
+						RequestTimeout: requestTimeout,
 					},
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
Read `DHCPDomain` and `RequestTimeout` from the CloudProfile instead of ControlPlaneConfig in OpenStack ControlPlane controller

**Which issue(s) this PR fixes**:
Fixes #117 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Read `DHCPDomain` and `RequestTimeout` from the CloudProfile in OpenStack ControlPlane controller
```
