### PR TITLE
Use `etc/hostname` for hostname override.

### DIFF
--- a/controllers/provider-gcp/pkg/webhook/controlplane/ensurer.go
+++ b/controllers/provider-gcp/pkg/webhook/controlplane/ensurer.go
@@ -145,7 +145,7 @@ func (e *ensurer) EnsureKubeletServiceUnitOptions(ctx context.Context, opts []*u
 	opts = controlplane.EnsureUnitOption(opts, &unit.UnitOption{
 		Section: "Service",
 		Name:    "ExecStartPre",
-		Value:   `/bin/sh -c 'hostnamectl set-hostname $(echo $HOSTNAME | cut -d '.' -f 1)'`,
+		Value:   `/bin/sh -c 'hostnamectl set-hostname $(cat /etc/hostname | cut -d '.' -f 1)'`,
 	})
 	return opts, nil
 }

--- a/controllers/provider-gcp/pkg/webhook/controlplane/ensurer_test.go
+++ b/controllers/provider-gcp/pkg/webhook/controlplane/ensurer_test.go
@@ -220,7 +220,7 @@ var _ = Describe("Ensurer", func() {
 					{
 						Section: "Service",
 						Name:    "ExecStartPre",
-						Value:   `/bin/sh -c 'hostnamectl set-hostname $(echo $HOSTNAME | cut -d '.' -f 1)'`,
+						Value:   `/bin/sh -c 'hostnamectl set-hostname $(cat /etc/hostname | cut -d '.' -f 1)'`,
 					},
 				}
 			)


### PR DESCRIPTION
**What this PR does / why we need it**:

Reading `/etc/hostname` is the canonical way of getting the static hostname of a machine.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

See https://github.com/gardener/gardener/pull/1077

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
GCP: `kubelet.service` now reads from `/etc/hostname` for hostname override.
```
