### PR TITLE
[WIP]Enhance controlplane webhooks to modify kube-apiserver NetworkPolicy

### DIFF
--- a/controllers/provider-alicloud/pkg/webhook/controlplaneexposure/add.go
+++ b/controllers/provider-alicloud/pkg/webhook/controlplaneexposure/add.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane/genericmutator"
 
 	appsv1 "k8s.io/api/apps/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -47,7 +48,7 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) (webhook.Webh
 	return controlplane.Add(mgr, controlplane.AddArgs{
 		Kind:     extensionswebhook.SeedKind,
 		Provider: alicloud.Type,
-		Types:    []runtime.Object{&appsv1.Deployment{}, &appsv1.StatefulSet{}},
+		Types:    []runtime.Object{&appsv1.Deployment{}, &appsv1.StatefulSet{}, &networkingv1.NetworkPolicy{}},
 		Mutator:  genericmutator.NewMutator(NewEnsurer(&opts.ETCDStorage, logger), nil, nil, logger),
 	})
 }

--- a/pkg/mock/gardener-extensions/webhook/controlplane/genericmutator/mocks.go
+++ b/pkg/mock/gardener-extensions/webhook/controlplane/genericmutator/mocks.go
@@ -11,6 +11,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/apps/v1"
 	v10 "k8s.io/api/core/v1"
+	v11 "k8s.io/api/networking/v1"
 	v1beta1 "k8s.io/kubelet/config/v1beta1"
 	reflect "reflect"
 )
@@ -64,6 +65,20 @@ func (m *MockEnsurer) EnsureKubeAPIServerDeployment(arg0 context.Context, arg1 *
 func (mr *MockEnsurerMockRecorder) EnsureKubeAPIServerDeployment(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeAPIServerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeAPIServerDeployment), arg0, arg1)
+}
+
+// EnsureKubeAPIServerNetworkPolicy mocks base method
+func (m *MockEnsurer) EnsureKubeAPIServerNetworkPolicy(arg0 context.Context, arg1 *v11.NetworkPolicy) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureKubeAPIServerNetworkPolicy", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureKubeAPIServerNetworkPolicy indicates an expected call of EnsureKubeAPIServerNetworkPolicy
+func (mr *MockEnsurerMockRecorder) EnsureKubeAPIServerNetworkPolicy(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeAPIServerNetworkPolicy", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeAPIServerNetworkPolicy), arg0, arg1)
 }
 
 // EnsureKubeAPIServerService mocks base method

--- a/pkg/webhook/controlplane/genericmutator/noopensurer.go
+++ b/pkg/webhook/controlplane/genericmutator/noopensurer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/coreos/go-systemd/unit"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 )
 
@@ -35,6 +36,11 @@ func (e *NoopEnsurer) EnsureKubeAPIServerService(context.Context, *corev1.Servic
 
 // EnsureKubeAPIServerDeployment ensures that the kube-apiserver deployment conforms to the provider requirements.
 func (e *NoopEnsurer) EnsureKubeAPIServerDeployment(context.Context, *appsv1.Deployment) error {
+	return nil
+}
+
+// EnsureKubeAPIServerNetworkPolicy ensures that the kube-apiserver network policy conforms to the provider requirements.
+func (e *NoopEnsurer) EnsureKubeAPIServerNetworkPolicy(context.Context, *networkingv1.NetworkPolicy) error {
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Enhance controlplane webhooks to do provider-specific modifications of kube-apiserver NetworkPolicy

**Which issue(s) this PR fixes**:
Fixes #114 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Enhance controlplane webhooks to modify kube-apiserver NetworkPolicy
```
