### PR TITLE
Fix etcd-main PVC template name based on latest Gardener changes

### DIFF
--- a/controllers/provider-alicloud/pkg/webhook/controlplaneexposure/ensurer.go
+++ b/controllers/provider-alicloud/pkg/webhook/controlplaneexposure/ensurer.go
@@ -78,9 +78,15 @@ func (e *ensurer) ensureVolumeClaimTemplates(spec *appsv1.StatefulSetSpec, name 
 }
 
 func (e *ensurer) getVolumeClaimTemplate(name string) *corev1.PersistentVolumeClaim {
-	var etcdStorage config.ETCDStorage
+	var (
+		etcdStorage             config.ETCDStorage
+		volumeClaimTemplateName = name
+	)
+
 	if name == common.EtcdMainStatefulSetName {
 		etcdStorage = *e.etcdStorage
+		volumeClaimTemplateName = controlplane.EtcdMainVolumeClaimTemplateName
 	}
-	return controlplane.GetETCDVolumeClaimTemplate(name, etcdStorage.ClassName, etcdStorage.Capacity)
+
+	return controlplane.GetETCDVolumeClaimTemplate(volumeClaimTemplateName, etcdStorage.ClassName, etcdStorage.Capacity)
 }

--- a/controllers/provider-alicloud/pkg/webhook/controlplaneexposure/ensurer_test.go
+++ b/controllers/provider-alicloud/pkg/webhook/controlplaneexposure/ensurer_test.go
@@ -250,13 +250,13 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment) {
 }
 
 func checkETCDMainStatefulSet(ss *appsv1.StatefulSet) {
-	pvc := controlplane.PVCWithName(ss.Spec.VolumeClaimTemplates, "etcd-main")
-	Expect(pvc).To(Equal(controlplane.GetETCDVolumeClaimTemplate(common.EtcdMainStatefulSetName, util.StringPtr("gardener.cloud-fast"),
+	pvc := controlplane.PVCWithName(ss.Spec.VolumeClaimTemplates, controlplane.EtcdMainVolumeClaimTemplateName)
+	Expect(pvc).To(Equal(controlplane.GetETCDVolumeClaimTemplate(controlplane.EtcdMainVolumeClaimTemplateName, util.StringPtr("gardener.cloud-fast"),
 		util.QuantityPtr(resource.MustParse("25Gi")))))
 }
 
 func checkETCDEventsStatefulSet(ss *appsv1.StatefulSet) {
-	pvc := controlplane.PVCWithName(ss.Spec.VolumeClaimTemplates, "etcd-events")
+	pvc := controlplane.PVCWithName(ss.Spec.VolumeClaimTemplates, common.EtcdEventsStatefulSetName)
 	Expect(pvc).To(Equal(controlplane.GetETCDVolumeClaimTemplate(common.EtcdEventsStatefulSetName, nil, nil)))
 }
 

--- a/controllers/provider-aws/pkg/webhook/controlplaneexposure/ensurer.go
+++ b/controllers/provider-aws/pkg/webhook/controlplaneexposure/ensurer.go
@@ -78,9 +78,15 @@ func (e *ensurer) ensureVolumeClaimTemplates(spec *appsv1.StatefulSetSpec, name 
 }
 
 func (e *ensurer) getVolumeClaimTemplate(name string) *corev1.PersistentVolumeClaim {
-	var etcdStorage config.ETCDStorage
+	var (
+		etcdStorage             config.ETCDStorage
+		volumeClaimTemplateName = name
+	)
+
 	if name == common.EtcdMainStatefulSetName {
 		etcdStorage = *e.etcdStorage
+		volumeClaimTemplateName = controlplane.EtcdMainVolumeClaimTemplateName
 	}
-	return controlplane.GetETCDVolumeClaimTemplate(name, etcdStorage.ClassName, etcdStorage.Capacity)
+
+	return controlplane.GetETCDVolumeClaimTemplate(volumeClaimTemplateName, etcdStorage.ClassName, etcdStorage.Capacity)
 }

--- a/controllers/provider-aws/pkg/webhook/controlplaneexposure/ensurer_test.go
+++ b/controllers/provider-aws/pkg/webhook/controlplaneexposure/ensurer_test.go
@@ -231,12 +231,12 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment) {
 }
 
 func checkETCDMainStatefulSet(ss *appsv1.StatefulSet) {
-	pvc := controlplane.PVCWithName(ss.Spec.VolumeClaimTemplates, "etcd-main")
-	Expect(pvc).To(Equal(controlplane.GetETCDVolumeClaimTemplate(common.EtcdMainStatefulSetName, util.StringPtr("gardener.cloud-fast"),
+	pvc := controlplane.PVCWithName(ss.Spec.VolumeClaimTemplates, controlplane.EtcdMainVolumeClaimTemplateName)
+	Expect(pvc).To(Equal(controlplane.GetETCDVolumeClaimTemplate(controlplane.EtcdMainVolumeClaimTemplateName, util.StringPtr("gardener.cloud-fast"),
 		util.QuantityPtr(resource.MustParse("80Gi")))))
 }
 
 func checkETCDEventsStatefulSet(ss *appsv1.StatefulSet) {
-	pvc := controlplane.PVCWithName(ss.Spec.VolumeClaimTemplates, "etcd-events")
+	pvc := controlplane.PVCWithName(ss.Spec.VolumeClaimTemplates, common.EtcdEventsStatefulSetName)
 	Expect(pvc).To(Equal(controlplane.GetETCDVolumeClaimTemplate(common.EtcdEventsStatefulSetName, nil, nil)))
 }

--- a/controllers/provider-azure/pkg/webhook/controlplaneexposure/ensurer.go
+++ b/controllers/provider-azure/pkg/webhook/controlplaneexposure/ensurer.go
@@ -98,9 +98,15 @@ func (e *ensurer) ensureVolumeClaimTemplates(spec *appsv1.StatefulSetSpec, name 
 }
 
 func (e *ensurer) getVolumeClaimTemplate(name string) *corev1.PersistentVolumeClaim {
-	var etcdStorage config.ETCDStorage
+	var (
+		etcdStorage             config.ETCDStorage
+		volumeClaimTemplateName = name
+	)
+
 	if name == common.EtcdMainStatefulSetName {
 		etcdStorage = *e.etcdStorage
+		volumeClaimTemplateName = controlplane.EtcdMainVolumeClaimTemplateName
 	}
-	return controlplane.GetETCDVolumeClaimTemplate(name, etcdStorage.ClassName, etcdStorage.Capacity)
+
+	return controlplane.GetETCDVolumeClaimTemplate(volumeClaimTemplateName, etcdStorage.ClassName, etcdStorage.Capacity)
 }

--- a/controllers/provider-azure/pkg/webhook/controlplaneexposure/ensurer_test.go
+++ b/controllers/provider-azure/pkg/webhook/controlplaneexposure/ensurer_test.go
@@ -250,13 +250,13 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment) {
 }
 
 func checkETCDMainStatefulSet(ss *appsv1.StatefulSet) {
-	pvc := controlplane.PVCWithName(ss.Spec.VolumeClaimTemplates, "etcd-main")
-	Expect(pvc).To(Equal(controlplane.GetETCDVolumeClaimTemplate(common.EtcdMainStatefulSetName, util.StringPtr("gardener.cloud-fast"),
+	pvc := controlplane.PVCWithName(ss.Spec.VolumeClaimTemplates, controlplane.EtcdMainVolumeClaimTemplateName)
+	Expect(pvc).To(Equal(controlplane.GetETCDVolumeClaimTemplate(controlplane.EtcdMainVolumeClaimTemplateName, util.StringPtr("gardener.cloud-fast"),
 		util.QuantityPtr(resource.MustParse("25Gi")))))
 }
 
 func checkETCDEventsStatefulSet(ss *appsv1.StatefulSet) {
-	pvc := controlplane.PVCWithName(ss.Spec.VolumeClaimTemplates, "etcd-events")
+	pvc := controlplane.PVCWithName(ss.Spec.VolumeClaimTemplates, common.EtcdEventsStatefulSetName)
 	Expect(pvc).To(Equal(controlplane.GetETCDVolumeClaimTemplate(common.EtcdEventsStatefulSetName, nil, nil)))
 }
 

--- a/controllers/provider-gcp/pkg/webhook/controlplaneexposure/ensurer.go
+++ b/controllers/provider-gcp/pkg/webhook/controlplaneexposure/ensurer.go
@@ -77,9 +77,15 @@ func (e *ensurer) ensureVolumeClaimTemplates(spec *appsv1.StatefulSetSpec, name 
 }
 
 func (e *ensurer) getVolumeClaimTemplate(name string) *corev1.PersistentVolumeClaim {
-	var etcdStorage config.ETCDStorage
+	var (
+		etcdStorage             config.ETCDStorage
+		volumeClaimTemplateName = name
+	)
+
 	if name == common.EtcdMainStatefulSetName {
 		etcdStorage = *e.etcdStorage
+		volumeClaimTemplateName = controlplane.EtcdMainVolumeClaimTemplateName
 	}
-	return controlplane.GetETCDVolumeClaimTemplate(name, etcdStorage.ClassName, etcdStorage.Capacity)
+
+	return controlplane.GetETCDVolumeClaimTemplate(volumeClaimTemplateName, etcdStorage.ClassName, etcdStorage.Capacity)
 }

--- a/controllers/provider-gcp/pkg/webhook/controlplaneexposure/ensurer_test.go
+++ b/controllers/provider-gcp/pkg/webhook/controlplaneexposure/ensurer_test.go
@@ -249,13 +249,13 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment) {
 }
 
 func checkETCDMainStatefulSet(ss *appsv1.StatefulSet) {
-	pvc := controlplane.PVCWithName(ss.Spec.VolumeClaimTemplates, "etcd-main")
-	Expect(pvc).To(Equal(controlplane.GetETCDVolumeClaimTemplate(common.EtcdMainStatefulSetName, util.StringPtr("gardener.cloud-fast"),
+	pvc := controlplane.PVCWithName(ss.Spec.VolumeClaimTemplates, controlplane.EtcdMainVolumeClaimTemplateName)
+	Expect(pvc).To(Equal(controlplane.GetETCDVolumeClaimTemplate(controlplane.EtcdMainVolumeClaimTemplateName, util.StringPtr("gardener.cloud-fast"),
 		util.QuantityPtr(resource.MustParse("25Gi")))))
 }
 
 func checkETCDEventsStatefulSet(ss *appsv1.StatefulSet) {
-	pvc := controlplane.PVCWithName(ss.Spec.VolumeClaimTemplates, "etcd-events")
+	pvc := controlplane.PVCWithName(ss.Spec.VolumeClaimTemplates, common.EtcdEventsStatefulSetName)
 	Expect(pvc).To(Equal(controlplane.GetETCDVolumeClaimTemplate(common.EtcdEventsStatefulSetName, nil, nil)))
 }
 

--- a/controllers/provider-openstack/pkg/webhook/controlplaneexposure/ensurer.go
+++ b/controllers/provider-openstack/pkg/webhook/controlplaneexposure/ensurer.go
@@ -77,9 +77,15 @@ func (e *ensurer) ensureVolumeClaimTemplates(spec *appsv1.StatefulSetSpec, name 
 }
 
 func (e *ensurer) getVolumeClaimTemplate(name string) *corev1.PersistentVolumeClaim {
-	var etcdStorage config.ETCDStorage
+	var (
+		etcdStorage             config.ETCDStorage
+		volumeClaimTemplateName = name
+	)
+
 	if name == common.EtcdMainStatefulSetName {
 		etcdStorage = *e.etcdStorage
+		volumeClaimTemplateName = controlplane.EtcdMainVolumeClaimTemplateName
 	}
-	return controlplane.GetETCDVolumeClaimTemplate(name, etcdStorage.ClassName, etcdStorage.Capacity)
+
+	return controlplane.GetETCDVolumeClaimTemplate(volumeClaimTemplateName, etcdStorage.ClassName, etcdStorage.Capacity)
 }

--- a/controllers/provider-openstack/pkg/webhook/controlplaneexposure/ensurer_test.go
+++ b/controllers/provider-openstack/pkg/webhook/controlplaneexposure/ensurer_test.go
@@ -250,13 +250,13 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment) {
 }
 
 func checkETCDMainStatefulSet(ss *appsv1.StatefulSet) {
-	pvc := controlplane.PVCWithName(ss.Spec.VolumeClaimTemplates, "etcd-main")
-	Expect(pvc).To(Equal(controlplane.GetETCDVolumeClaimTemplate(common.EtcdMainStatefulSetName, util.StringPtr("gardener.cloud-fast"),
+	pvc := controlplane.PVCWithName(ss.Spec.VolumeClaimTemplates, controlplane.EtcdMainVolumeClaimTemplateName)
+	Expect(pvc).To(Equal(controlplane.GetETCDVolumeClaimTemplate(controlplane.EtcdMainVolumeClaimTemplateName, util.StringPtr("gardener.cloud-fast"),
 		util.QuantityPtr(resource.MustParse("25Gi")))))
 }
 
 func checkETCDEventsStatefulSet(ss *appsv1.StatefulSet) {
-	pvc := controlplane.PVCWithName(ss.Spec.VolumeClaimTemplates, "etcd-events")
+	pvc := controlplane.PVCWithName(ss.Spec.VolumeClaimTemplates, common.EtcdEventsStatefulSetName)
 	Expect(pvc).To(Equal(controlplane.GetETCDVolumeClaimTemplate(common.EtcdEventsStatefulSetName, nil, nil)))
 }
 

--- a/pkg/webhook/controlplane/etcd.go
+++ b/pkg/webhook/controlplane/etcd.go
@@ -22,6 +22,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// EtcdMainVolumeClaimTemplateName is the name of the volume claim template in the etcd-main StatefulSet. It uses a
+// different naming scheme because Gardener was using HDD-based volumes for etcd in the past and did migrate to fast
+// SSD volumes recently. Due to the migration of the data of the old volume to the new one the PVC name is now different.
+const EtcdMainVolumeClaimTemplateName = "main-etcd"
+
 // GetBackupRestoreContainer returns an etcd backup-restore container with the given name, schedule, provider, image,
 // and additional provider-specific command line args and env variables.
 func GetBackupRestoreContainer(


### PR DESCRIPTION
**What this PR does / why we need it**:
The name has recently changed in Gardener due to etcd migration and needs to be reflected here in the extension controllers as well.

Fixes #116

**Special notes for your reviewer**:
FYI @mkoynov 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
