### PR TITLE
Add checksum annotations in controlplane webhooks

### DIFF
--- a/controllers/provider-alicloud/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-alicloud/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -21,17 +21,26 @@ import (
 	"github.com/gardener/gardener-extensions/controllers/provider-alicloud/pkg/alicloud"
 	"github.com/gardener/gardener-extensions/controllers/provider-alicloud/pkg/apis/config"
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
+	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener-extensions/pkg/util"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
 
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+const (
+	namespace = "test"
 )
 
 func TestController(t *testing.T) {
@@ -42,6 +51,8 @@ func TestController(t *testing.T) {
 var _ = Describe("Ensurer", func() {
 	Describe("#EnsureETCDStatefulSet", func() {
 		var (
+			ctrl *gomock.Controller
+
 			etcdBackup = &config.ETCDBackup{
 				Schedule: util.StringPtr("0 */24 * * *"),
 			}
@@ -63,28 +74,52 @@ var _ = Describe("Ensurer", func() {
 					},
 				},
 			}
+
+			secretKey = client.ObjectKey{Namespace: namespace, Name: alicloud.BackupSecretName}
+			secret    = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: alicloud.BackupSecretName, Namespace: namespace},
+				Data:       map[string][]byte{"foo": []byte("bar")},
+			}
+
+			annotations = map[string]string{
+				"checksum/secret-" + alicloud.BackupSecretName: "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
+			}
 		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
 
 		It("should add or modify elements to etcd-main statefulset", func() {
 			var (
 				ss = &appsv1.StatefulSet{
-					ObjectMeta: metav1.ObjectMeta{Name: common.EtcdMainStatefulSetName},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: common.EtcdMainStatefulSetName},
 				}
 			)
 
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
+
 			// Create ensurer
 			ensurer := NewEnsurer(etcdBackup, imageVector, logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureETCDStatefulSet method and check the result
-			err := ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
 			Expect(err).To(Not(HaveOccurred()))
-			checkETCDMainStatefulSet(ss)
+			checkETCDMainStatefulSet(ss, annotations)
 		})
 
 		It("should modify existing elements of etcd-main statefulset", func() {
 			var (
 				ss = &appsv1.StatefulSet{
-					ObjectMeta: metav1.ObjectMeta{Name: common.EtcdMainStatefulSetName},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: common.EtcdMainStatefulSetName},
 					Spec: appsv1.StatefulSetSpec{
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
@@ -99,13 +134,19 @@ var _ = Describe("Ensurer", func() {
 				}
 			)
 
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
+
 			// Create ensurer
 			ensurer := NewEnsurer(etcdBackup, imageVector, logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureETCDStatefulSet method and check the result
-			err := ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
 			Expect(err).To(Not(HaveOccurred()))
-			checkETCDMainStatefulSet(ss)
+			checkETCDMainStatefulSet(ss, annotations)
 		})
 
 		It("should add or modify elements to etcd-events statefulset", func() {
@@ -153,7 +194,7 @@ var _ = Describe("Ensurer", func() {
 	})
 })
 
-func checkETCDMainStatefulSet(ss *appsv1.StatefulSet) {
+func checkETCDMainStatefulSet(ss *appsv1.StatefulSet, annotations map[string]string) {
 	var (
 		env = []corev1.EnvVar{
 			{
@@ -198,10 +239,21 @@ func checkETCDMainStatefulSet(ss *appsv1.StatefulSet) {
 	c := controlplane.ContainerWithName(ss.Spec.Template.Spec.Containers, "backup-restore")
 	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdMainStatefulSetName, "0 */24 * * *", alicloud.StorageProviderName,
 		"test-repository:test-tag", nil, env, nil)))
+	Expect(ss.Spec.Template.Annotations).To(Equal(annotations))
 }
 
 func checkETCDEventsStatefulSet(ss *appsv1.StatefulSet) {
 	c := controlplane.ContainerWithName(ss.Spec.Template.Spec.Containers, "backup-restore")
 	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdEventsStatefulSetName, "0 */24 * * *", "",
 		"test-repository:test-tag", nil, nil, nil)))
+}
+
+func clientGet(result runtime.Object) interface{} {
+	return func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+		switch obj.(type) {
+		case *corev1.Secret:
+			*obj.(*corev1.Secret) = *result.(*corev1.Secret)
+		}
+		return nil
+	}
 }

--- a/controllers/provider-aws/pkg/webhook/controlplane/ensurer_test.go
+++ b/controllers/provider-aws/pkg/webhook/controlplane/ensurer_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/coreos/go-systemd/unit"
 	"github.com/gardener/gardener-extensions/controllers/provider-aws/pkg/aws"
+	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane/test"
 	"github.com/gardener/gardener/pkg/operation/common"
@@ -30,7 +31,14 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+const (
+	namespace = "test"
 )
 
 func TestController(t *testing.T) {
@@ -41,6 +49,23 @@ func TestController(t *testing.T) {
 var _ = Describe("Ensurer", func() {
 	var (
 		ctrl *gomock.Controller
+
+		secretKey = client.ObjectKey{Namespace: namespace, Name: common.CloudProviderSecretName}
+		secret    = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: common.CloudProviderSecretName},
+			Data:       map[string][]byte{"foo": []byte("bar")},
+		}
+
+		cmKey = client.ObjectKey{Namespace: namespace, Name: aws.CloudProviderConfigName}
+		cm    = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: aws.CloudProviderConfigName},
+			Data:       map[string]string{"abc": "xyz"},
+		}
+
+		annotations = map[string]string{
+			"checksum/secret-" + common.CloudProviderSecretName: "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
+			"checksum/configmap-" + aws.CloudProviderConfigName: "08a7bc7fe8f59b055f173145e211760a83f02cf89635cef26ebb351378635606",
+		}
 	)
 
 	BeforeEach(func() {
@@ -55,7 +80,7 @@ var _ = Describe("Ensurer", func() {
 		It("should add missing elements to kube-apiserver deployment", func() {
 			var (
 				dep = &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: common.KubeAPIServerDeploymentName},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: common.KubeAPIServerDeploymentName},
 					Spec: appsv1.DeploymentSpec{
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
@@ -70,19 +95,26 @@ var _ = Describe("Ensurer", func() {
 				}
 			)
 
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
+			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
+
 			// Create ensurer
 			ensurer := NewEnsurer(logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
-			err := ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dep)
+			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeAPIServerDeployment(dep)
+			checkKubeAPIServerDeployment(dep, annotations)
 		})
 
 		It("should modify existing elements of kube-apiserver deployment", func() {
 			var (
 				dep = &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: common.KubeAPIServerDeploymentName},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: common.KubeAPIServerDeploymentName},
 					Spec: appsv1.DeploymentSpec{
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
@@ -101,15 +133,11 @@ var _ = Describe("Ensurer", func() {
 										},
 										VolumeMounts: []corev1.VolumeMount{
 											{Name: aws.CloudProviderConfigName, MountPath: "?"},
-											// TODO Use constant from github.com/gardener/gardener/pkg/apis/core/v1alpha1 when available
-											// See https://github.com/gardener/gardener/pull/930
-											{Name: common.CloudProviderSecretName, MountPath: "?"},
 										},
 									},
 								},
 								Volumes: []corev1.Volume{
 									{Name: aws.CloudProviderConfigName},
-									{Name: common.CloudProviderSecretName},
 								},
 							},
 						},
@@ -117,13 +145,20 @@ var _ = Describe("Ensurer", func() {
 				}
 			)
 
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
+			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
+
 			// Create ensurer
 			ensurer := NewEnsurer(logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
-			err := ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dep)
+			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeAPIServerDeployment(dep)
+			checkKubeAPIServerDeployment(dep, annotations)
 		})
 	})
 
@@ -131,7 +166,7 @@ var _ = Describe("Ensurer", func() {
 		It("should add missing elements to kube-controller-manager deployment", func() {
 			var (
 				dep = &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: common.KubeControllerManagerDeploymentName},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: common.KubeControllerManagerDeploymentName},
 					Spec: appsv1.DeploymentSpec{
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
@@ -146,19 +181,26 @@ var _ = Describe("Ensurer", func() {
 				}
 			)
 
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
+			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
+
 			// Create ensurer
 			ensurer := NewEnsurer(logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeControllerManagerDeployment method and check the result
-			err := ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), dep)
+			err = ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeControllerManagerDeployment(dep)
+			checkKubeControllerManagerDeployment(dep, annotations)
 		})
 
 		It("should modify existing elements of kube-controller-manager deployment", func() {
 			var (
 				dep = &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: common.KubeControllerManagerDeploymentName},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: common.KubeControllerManagerDeploymentName},
 					Spec: appsv1.DeploymentSpec{
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
@@ -176,13 +218,11 @@ var _ = Describe("Ensurer", func() {
 										},
 										VolumeMounts: []corev1.VolumeMount{
 											{Name: aws.CloudProviderConfigName, MountPath: "?"},
-											{Name: common.CloudProviderSecretName, MountPath: "?"},
 										},
 									},
 								},
 								Volumes: []corev1.Volume{
 									{Name: aws.CloudProviderConfigName},
-									{Name: common.CloudProviderSecretName},
 								},
 							},
 						},
@@ -190,13 +230,20 @@ var _ = Describe("Ensurer", func() {
 				}
 			)
 
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
+			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
+
 			// Create ensurer
 			ensurer := NewEnsurer(logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeControllerManagerDeployment method and check the result
-			err := ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), dep)
+			err = ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeControllerManagerDeployment(dep)
+			checkKubeControllerManagerDeployment(dep, annotations)
 		})
 	})
 
@@ -282,7 +329,7 @@ var _ = Describe("Ensurer", func() {
 	})
 })
 
-func checkKubeAPIServerDeployment(dep *appsv1.Deployment) {
+func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string]string) {
 	// Check that the kube-apiserver container still exists and contains all needed command line args,
 	// env vars, and volume mounts
 	c := controlplane.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-apiserver")
@@ -294,14 +341,15 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment) {
 	Expect(c.Env).To(ContainElement(accessKeyIDEnvVar))
 	Expect(c.Env).To(ContainElement(secretAccessKeyEnvVar))
 	Expect(c.VolumeMounts).To(ContainElement(cloudProviderConfigVolumeMount))
-	Expect(c.VolumeMounts).To(ContainElement(cloudProviderSecretVolumeMount))
 
 	// Check that the Pod spec contains all needed volumes
 	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderConfigVolume))
-	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderSecretVolume))
+
+	// Check that the Pod template contains all needed checksum annotations
+	Expect(dep.Spec.Template.Annotations).To(Equal(annotations))
 }
 
-func checkKubeControllerManagerDeployment(dep *appsv1.Deployment) {
+func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations map[string]string) {
 	// Check that the kube-controller-manager container still exists and contains all needed command line args,
 	// env vars, and volume mounts
 	c := controlplane.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-controller-manager")
@@ -312,9 +360,22 @@ func checkKubeControllerManagerDeployment(dep *appsv1.Deployment) {
 	Expect(c.Env).To(ContainElement(accessKeyIDEnvVar))
 	Expect(c.Env).To(ContainElement(secretAccessKeyEnvVar))
 	Expect(c.VolumeMounts).To(ContainElement(cloudProviderConfigVolumeMount))
-	Expect(c.VolumeMounts).To(ContainElement(cloudProviderSecretVolumeMount))
 
 	// Check that the Pod spec contains all needed volumes
 	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderConfigVolume))
-	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderSecretVolume))
+
+	// Check that the Pod template contains all needed checksum annotations
+	Expect(dep.Spec.Template.Annotations).To(Equal(annotations))
+}
+
+func clientGet(result runtime.Object) interface{} {
+	return func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+		switch obj.(type) {
+		case *corev1.Secret:
+			*obj.(*corev1.Secret) = *result.(*corev1.Secret)
+		case *corev1.ConfigMap:
+			*obj.(*corev1.ConfigMap) = *result.(*corev1.ConfigMap)
+		}
+		return nil
+	}
 }

--- a/controllers/provider-aws/pkg/webhook/controlplanebackup/ensurer.go
+++ b/controllers/provider-aws/pkg/webhook/controlplanebackup/ensurer.go
@@ -16,7 +16,6 @@ package controlplanebackup
 
 import (
 	"context"
-	"github.com/gardener/gardener/pkg/operation/common"
 
 	"github.com/gardener/gardener-extensions/controllers/provider-aws/pkg/apis/config"
 	"github.com/gardener/gardener-extensions/controllers/provider-aws/pkg/aws"
@@ -24,11 +23,13 @@ import (
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane/genericmutator"
 
+	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewEnsurer creates a new controlplaneexposure ensurer.
@@ -44,7 +45,14 @@ type ensurer struct {
 	genericmutator.NoopEnsurer
 	etcdBackup  *config.ETCDBackup
 	imageVector imagevector.ImageVector
+	client      client.Client
 	logger      logr.Logger
+}
+
+// InjectClient injects the given client into the ensurer.
+func (e *ensurer) InjectClient(client client.Client) error {
+	e.client = client
+	return nil
 }
 
 // EnsureETCDStatefulSet ensures that the etcd stateful sets conform to the provider requirements.
@@ -52,7 +60,7 @@ func (e *ensurer) EnsureETCDStatefulSet(ctx context.Context, ss *appsv1.Stateful
 	if err := e.ensureContainers(&ss.Spec.Template.Spec, ss.Name, cluster); err != nil {
 		return err
 	}
-	return nil
+	return e.ensureChecksumAnnotations(ctx, &ss.Spec.Template, ss.Namespace, ss.Name)
 }
 
 func (e *ensurer) ensureContainers(ps *corev1.PodSpec, name string, cluster *extensionscontroller.Cluster) error {
@@ -61,6 +69,13 @@ func (e *ensurer) ensureContainers(ps *corev1.PodSpec, name string, cluster *ext
 		return err
 	}
 	ps.Containers = controlplane.EnsureContainerWithName(ps.Containers, *c)
+	return nil
+}
+
+func (e *ensurer) ensureChecksumAnnotations(ctx context.Context, template *corev1.PodTemplateSpec, namespace, name string) error {
+	if name == common.EtcdMainStatefulSetName {
+		return controlplane.EnsureSecretChecksumAnnotation(ctx, template, e.client, namespace, aws.BackupSecretName)
+	}
 	return nil
 }
 

--- a/controllers/provider-aws/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-aws/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -21,17 +21,26 @@ import (
 	"github.com/gardener/gardener-extensions/controllers/provider-aws/pkg/apis/config"
 	"github.com/gardener/gardener-extensions/controllers/provider-aws/pkg/aws"
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
+	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener-extensions/pkg/util"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
 
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+const (
+	namespace = "test"
 )
 
 func TestController(t *testing.T) {
@@ -42,6 +51,8 @@ func TestController(t *testing.T) {
 var _ = Describe("Ensurer", func() {
 	Describe("#EnsureETCDStatefulSet", func() {
 		var (
+			ctrl *gomock.Controller
+
 			etcdBackup = &config.ETCDBackup{
 				Schedule: util.StringPtr("0 */24 * * *"),
 			}
@@ -63,28 +74,52 @@ var _ = Describe("Ensurer", func() {
 					},
 				},
 			}
+
+			secretKey = client.ObjectKey{Namespace: namespace, Name: aws.BackupSecretName}
+			secret    = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: aws.BackupSecretName, Namespace: namespace},
+				Data:       map[string][]byte{"foo": []byte("bar")},
+			}
+
+			annotations = map[string]string{
+				"checksum/secret-" + aws.BackupSecretName: "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
+			}
 		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
 
 		It("should add or modify elements to etcd-main statefulset", func() {
 			var (
 				ss = &appsv1.StatefulSet{
-					ObjectMeta: metav1.ObjectMeta{Name: common.EtcdMainStatefulSetName},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: common.EtcdMainStatefulSetName},
 				}
 			)
 
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
+
 			// Create ensurer
 			ensurer := NewEnsurer(etcdBackup, imageVector, logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureETCDStatefulSet method and check the result
-			err := ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
 			Expect(err).To(Not(HaveOccurred()))
-			checkETCDMainStatefulSet(ss)
+			checkETCDMainStatefulSet(ss, annotations)
 		})
 
 		It("should modify existing elements of etcd-main statefulset", func() {
 			var (
 				ss = &appsv1.StatefulSet{
-					ObjectMeta: metav1.ObjectMeta{Name: common.EtcdMainStatefulSetName},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: common.EtcdMainStatefulSetName},
 					Spec: appsv1.StatefulSetSpec{
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
@@ -99,13 +134,19 @@ var _ = Describe("Ensurer", func() {
 				}
 			)
 
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
+
 			// Create ensurer
 			ensurer := NewEnsurer(etcdBackup, imageVector, logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureETCDStatefulSet method and check the result
-			err := ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
 			Expect(err).To(Not(HaveOccurred()))
-			checkETCDMainStatefulSet(ss)
+			checkETCDMainStatefulSet(ss, annotations)
 		})
 
 		It("should add or modify elements to etcd-events statefulset", func() {
@@ -153,7 +194,7 @@ var _ = Describe("Ensurer", func() {
 	})
 })
 
-func checkETCDMainStatefulSet(ss *appsv1.StatefulSet) {
+func checkETCDMainStatefulSet(ss *appsv1.StatefulSet, annotations map[string]string) {
 	var (
 		env = []corev1.EnvVar{
 			{
@@ -198,10 +239,21 @@ func checkETCDMainStatefulSet(ss *appsv1.StatefulSet) {
 	c := controlplane.ContainerWithName(ss.Spec.Template.Spec.Containers, "backup-restore")
 	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdMainStatefulSetName, "0 */24 * * *", aws.StorageProviderName,
 		"test-repository:test-tag", nil, env, nil)))
+	Expect(ss.Spec.Template.Annotations).To(Equal(annotations))
 }
 
 func checkETCDEventsStatefulSet(ss *appsv1.StatefulSet) {
 	c := controlplane.ContainerWithName(ss.Spec.Template.Spec.Containers, "backup-restore")
 	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdEventsStatefulSetName, "0 */24 * * *", "",
 		"test-repository:test-tag", nil, nil, nil)))
+}
+
+func clientGet(result runtime.Object) interface{} {
+	return func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+		switch obj.(type) {
+		case *corev1.Secret:
+			*obj.(*corev1.Secret) = *result.(*corev1.Secret)
+		}
+		return nil
+	}
 }

--- a/controllers/provider-azure/pkg/webhook/controlplane/ensurer.go
+++ b/controllers/provider-azure/pkg/webhook/controlplane/ensurer.go
@@ -16,16 +16,17 @@ package controlplane
 
 import (
 	"context"
+
 	"github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/azure"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane/genericmutator"
 
 	"github.com/coreos/go-systemd/unit"
-	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewEnsurer creates a new controlplane ensurer.
@@ -37,29 +38,38 @@ func NewEnsurer(logger logr.Logger) genericmutator.Ensurer {
 
 type ensurer struct {
 	genericmutator.NoopEnsurer
+	client client.Client
 	logger logr.Logger
+}
+
+// InjectClient injects the given client into the ensurer.
+func (e *ensurer) InjectClient(client client.Client) error {
+	e.client = client
+	return nil
 }
 
 // EnsureKubeAPIServerDeployment ensures that the kube-apiserver deployment conforms to the provider requirements.
 func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, dep *appsv1.Deployment) error {
-	ps := &dep.Spec.Template.Spec
+	template := &dep.Spec.Template
+	ps := &template.Spec
 	if c := controlplane.ContainerWithName(ps.Containers, "kube-apiserver"); c != nil {
 		ensureKubeAPIServerCommandLineArgs(c)
 		ensureVolumeMounts(c)
 	}
 	ensureVolumes(ps)
-	return nil
+	return e.ensureChecksumAnnotations(ctx, &dep.Spec.Template, dep.Namespace)
 }
 
 // EnsureKubeControllerManagerDeployment ensures that the kube-controller-manager deployment conforms to the provider requirements.
 func (e *ensurer) EnsureKubeControllerManagerDeployment(ctx context.Context, dep *appsv1.Deployment) error {
-	ps := &dep.Spec.Template.Spec
+	template := &dep.Spec.Template
+	ps := &template.Spec
 	if c := controlplane.ContainerWithName(ps.Containers, "kube-controller-manager"); c != nil {
 		ensureKubeControllerManagerCommandLineArgs(c)
 		ensureVolumeMounts(c)
 	}
 	ensureVolumes(ps)
-	return nil
+	return e.ensureChecksumAnnotations(ctx, &dep.Spec.Template, dep.Namespace)
 }
 
 func ensureKubeAPIServerCommandLineArgs(c *corev1.Container) {
@@ -84,11 +94,6 @@ var (
 		Name:      azure.CloudProviderConfigName,
 		MountPath: "/etc/kubernetes/cloudprovider",
 	}
-	cloudProviderSecretVolumeMount = corev1.VolumeMount{
-		Name:      common.CloudProviderSecretName,
-		MountPath: "/srv/cloudprovider",
-	}
-
 	cloudProviderConfigVolume = corev1.Volume{
 		Name: azure.CloudProviderConfigName,
 		VolumeSource: corev1.VolumeSource{
@@ -97,26 +102,21 @@ var (
 			},
 		},
 	}
-	cloudProviderSecretVolume = corev1.Volume{
-		Name: common.CloudProviderSecretName,
-		VolumeSource: corev1.VolumeSource{
-			Secret: &corev1.SecretVolumeSource{
-				// TODO Use constant from github.com/gardener/gardener/pkg/apis/core/v1alpha1 when available
-				// See https://github.com/gardener/gardener/pull/930
-				SecretName: common.CloudProviderSecretName,
-			},
-		},
-	}
 )
 
 func ensureVolumeMounts(c *corev1.Container) {
 	c.VolumeMounts = controlplane.EnsureVolumeMountWithName(c.VolumeMounts, cloudProviderConfigVolumeMount)
-	c.VolumeMounts = controlplane.EnsureVolumeMountWithName(c.VolumeMounts, cloudProviderSecretVolumeMount)
 }
 
 func ensureVolumes(ps *corev1.PodSpec) {
 	ps.Volumes = controlplane.EnsureVolumeWithName(ps.Volumes, cloudProviderConfigVolume)
-	ps.Volumes = controlplane.EnsureVolumeWithName(ps.Volumes, cloudProviderSecretVolume)
+}
+
+func (e *ensurer) ensureChecksumAnnotations(ctx context.Context, template *corev1.PodTemplateSpec, namespace string) error {
+	if err := controlplane.EnsureConfigMapChecksumAnnotation(ctx, template, e.client, namespace, azure.CloudProviderConfigName); err != nil {
+		return err
+	}
+	return nil
 }
 
 // EnsureKubeletServiceUnitOptions ensures that the kubelet.service unit options conform to the provider requirements.

--- a/controllers/provider-azure/pkg/webhook/controlplanebackup/ensurer.go
+++ b/controllers/provider-azure/pkg/webhook/controlplanebackup/ensurer.go
@@ -16,6 +16,7 @@ package controlplanebackup
 
 import (
 	"context"
+
 	"github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/apis/config"
 	"github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/azure"
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
@@ -28,6 +29,7 @@ import (
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewEnsurer creates a new controlplaneexposure ensurer.
@@ -43,7 +45,14 @@ type ensurer struct {
 	genericmutator.NoopEnsurer
 	etcdBackup  *config.ETCDBackup
 	imageVector imagevector.ImageVector
+	client      client.Client
 	logger      logr.Logger
+}
+
+// InjectClient injects the given client into the ensurer.
+func (e *ensurer) InjectClient(client client.Client) error {
+	e.client = client
+	return nil
 }
 
 // EnsureETCDStatefulSet ensures that the etcd stateful sets conform to the provider requirements.
@@ -51,7 +60,7 @@ func (e *ensurer) EnsureETCDStatefulSet(ctx context.Context, ss *appsv1.Stateful
 	if err := e.ensureContainers(&ss.Spec.Template.Spec, ss.Name, cluster); err != nil {
 		return err
 	}
-	return nil
+	return e.ensureChecksumAnnotations(ctx, &ss.Spec.Template, ss.Namespace, ss.Name)
 }
 
 func (e *ensurer) ensureContainers(ps *corev1.PodSpec, name string, cluster *extensionscontroller.Cluster) error {
@@ -60,6 +69,13 @@ func (e *ensurer) ensureContainers(ps *corev1.PodSpec, name string, cluster *ext
 		return err
 	}
 	ps.Containers = controlplane.EnsureContainerWithName(ps.Containers, *c)
+	return nil
+}
+
+func (e *ensurer) ensureChecksumAnnotations(ctx context.Context, template *corev1.PodTemplateSpec, namespace, name string) error {
+	if name == common.EtcdMainStatefulSetName {
+		return controlplane.EnsureSecretChecksumAnnotation(ctx, template, e.client, namespace, azure.BackupSecretName)
+	}
 	return nil
 }
 

--- a/controllers/provider-azure/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-azure/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -16,22 +16,31 @@ package controlplanebackup
 
 import (
 	"context"
-	"github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/azure"
 	"testing"
 
 	"github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/apis/config"
+	"github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/azure"
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
+	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener-extensions/pkg/util"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
 
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+const (
+	namespace = "test"
 )
 
 func TestController(t *testing.T) {
@@ -42,6 +51,8 @@ func TestController(t *testing.T) {
 var _ = Describe("Ensurer", func() {
 	Describe("#EnsureETCDStatefulSet", func() {
 		var (
+			ctrl *gomock.Controller
+
 			etcdBackup = &config.ETCDBackup{
 				Schedule: util.StringPtr("0 */24 * * *"),
 			}
@@ -63,28 +74,52 @@ var _ = Describe("Ensurer", func() {
 					},
 				},
 			}
+
+			secretKey = client.ObjectKey{Namespace: namespace, Name: azure.BackupSecretName}
+			secret    = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: azure.BackupSecretName, Namespace: namespace},
+				Data:       map[string][]byte{"foo": []byte("bar")},
+			}
+
+			annotations = map[string]string{
+				"checksum/secret-" + azure.BackupSecretName: "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
+			}
 		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
 
 		It("should add or modify elements to etcd-main statefulset", func() {
 			var (
 				ss = &appsv1.StatefulSet{
-					ObjectMeta: metav1.ObjectMeta{Name: common.EtcdMainStatefulSetName},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: common.EtcdMainStatefulSetName},
 				}
 			)
 
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
+
 			// Create ensurer
 			ensurer := NewEnsurer(etcdBackup, imageVector, logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureETCDStatefulSet method and check the result
-			err := ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
 			Expect(err).To(Not(HaveOccurred()))
-			checkETCDMainStatefulSet(ss)
+			checkETCDMainStatefulSet(ss, annotations)
 		})
 
 		It("should modify existing elements of etcd-main statefulset", func() {
 			var (
 				ss = &appsv1.StatefulSet{
-					ObjectMeta: metav1.ObjectMeta{Name: common.EtcdMainStatefulSetName},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: common.EtcdMainStatefulSetName},
 					Spec: appsv1.StatefulSetSpec{
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
@@ -99,13 +134,19 @@ var _ = Describe("Ensurer", func() {
 				}
 			)
 
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
+
 			// Create ensurer
 			ensurer := NewEnsurer(etcdBackup, imageVector, logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureETCDStatefulSet method and check the result
-			err := ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
 			Expect(err).To(Not(HaveOccurred()))
-			checkETCDMainStatefulSet(ss)
+			checkETCDMainStatefulSet(ss, annotations)
 		})
 
 		It("should add or modify elements to etcd-events statefulset", func() {
@@ -153,7 +194,7 @@ var _ = Describe("Ensurer", func() {
 	})
 })
 
-func checkETCDMainStatefulSet(ss *appsv1.StatefulSet) {
+func checkETCDMainStatefulSet(ss *appsv1.StatefulSet, annotations map[string]string) {
 	var (
 		env = []corev1.EnvVar{
 			{
@@ -189,10 +230,21 @@ func checkETCDMainStatefulSet(ss *appsv1.StatefulSet) {
 	c := controlplane.ContainerWithName(ss.Spec.Template.Spec.Containers, "backup-restore")
 	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdMainStatefulSetName, "0 */24 * * *", azure.StorageProviderName,
 		"test-repository:test-tag", nil, env, nil)))
+	Expect(ss.Spec.Template.Annotations).To(Equal(annotations))
 }
 
 func checkETCDEventsStatefulSet(ss *appsv1.StatefulSet) {
 	c := controlplane.ContainerWithName(ss.Spec.Template.Spec.Containers, "backup-restore")
 	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdEventsStatefulSetName, "0 */24 * * *", "",
 		"test-repository:test-tag", nil, nil, nil)))
+}
+
+func clientGet(result runtime.Object) interface{} {
+	return func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+		switch obj.(type) {
+		case *corev1.Secret:
+			*obj.(*corev1.Secret) = *result.(*corev1.Secret)
+		}
+		return nil
+	}
 }

--- a/controllers/provider-gcp/pkg/webhook/controlplane/ensurer_test.go
+++ b/controllers/provider-gcp/pkg/webhook/controlplane/ensurer_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/gardener/gardener-extensions/controllers/provider-gcp/pkg/internal"
+	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane/test"
 
@@ -31,7 +32,14 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+const (
+	namespace = "test"
 )
 
 func TestController(t *testing.T) {
@@ -42,6 +50,23 @@ func TestController(t *testing.T) {
 var _ = Describe("Ensurer", func() {
 	var (
 		ctrl *gomock.Controller
+
+		secretKey = client.ObjectKey{Namespace: namespace, Name: common.CloudProviderSecretName}
+		secret    = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: common.CloudProviderSecretName},
+			Data:       map[string][]byte{"foo": []byte("bar")},
+		}
+
+		cmKey = client.ObjectKey{Namespace: namespace, Name: internal.CloudProviderConfigName}
+		cm    = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: internal.CloudProviderConfigName},
+			Data:       map[string]string{"abc": "xyz"},
+		}
+
+		annotations = map[string]string{
+			"checksum/secret-" + common.CloudProviderSecretName:      "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
+			"checksum/configmap-" + internal.CloudProviderConfigName: "08a7bc7fe8f59b055f173145e211760a83f02cf89635cef26ebb351378635606",
+		}
 	)
 
 	BeforeEach(func() {
@@ -56,7 +81,7 @@ var _ = Describe("Ensurer", func() {
 		It("should add missing elements to kube-apiserver deployment", func() {
 			var (
 				dep = &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: common.KubeAPIServerDeploymentName},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: common.KubeAPIServerDeploymentName},
 					Spec: appsv1.DeploymentSpec{
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
@@ -71,19 +96,26 @@ var _ = Describe("Ensurer", func() {
 				}
 			)
 
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
+			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
+
 			// Create ensurer
 			ensurer := NewEnsurer(logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
-			err := ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dep)
+			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeAPIServerDeployment(dep)
+			checkKubeAPIServerDeployment(dep, annotations)
 		})
 
 		It("should modify existing elements of kube-apiserver deployment", func() {
 			var (
 				dep = &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: common.KubeAPIServerDeploymentName},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: common.KubeAPIServerDeploymentName},
 					Spec: appsv1.DeploymentSpec{
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
@@ -117,13 +149,20 @@ var _ = Describe("Ensurer", func() {
 				}
 			)
 
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
+			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
+
 			// Create ensurer
 			ensurer := NewEnsurer(logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
-			err := ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dep)
+			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeAPIServerDeployment(dep)
+			checkKubeAPIServerDeployment(dep, annotations)
 		})
 	})
 
@@ -131,7 +170,7 @@ var _ = Describe("Ensurer", func() {
 		It("should add missing elements to kube-controller-manager deployment", func() {
 			var (
 				dep = &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: common.KubeControllerManagerDeploymentName},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: common.KubeControllerManagerDeploymentName},
 					Spec: appsv1.DeploymentSpec{
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
@@ -146,19 +185,26 @@ var _ = Describe("Ensurer", func() {
 				}
 			)
 
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
+			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
+
 			// Create ensurer
 			ensurer := NewEnsurer(logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeControllerManagerDeployment method and check the result
-			err := ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), dep)
+			err = ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeControllerManagerDeployment(dep)
+			checkKubeControllerManagerDeployment(dep, annotations)
 		})
 
 		It("should modify existing elements of kube-controller-manager deployment", func() {
 			var (
 				dep = &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: common.KubeControllerManagerDeploymentName},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: common.KubeControllerManagerDeploymentName},
 					Spec: appsv1.DeploymentSpec{
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
@@ -189,13 +235,20 @@ var _ = Describe("Ensurer", func() {
 				}
 			)
 
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
+			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
+
 			// Create ensurer
 			ensurer := NewEnsurer(logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeControllerManagerDeployment method and check the result
-			err := ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), dep)
+			err = ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeControllerManagerDeployment(dep)
+			checkKubeControllerManagerDeployment(dep, annotations)
 		})
 	})
 
@@ -285,7 +338,7 @@ var _ = Describe("Ensurer", func() {
 	})
 })
 
-func checkKubeAPIServerDeployment(dep *appsv1.Deployment) {
+func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string]string) {
 	// Check that the kube-apiserver container still exists and contains all needed command line args,
 	// env vars, and volume mounts
 	c := controlplane.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-apiserver")
@@ -301,9 +354,12 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment) {
 	// Check that the Pod spec contains all needed volumes
 	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderConfigVolume))
 	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderSecretVolume))
+
+	// Check that the Pod template contains all needed checksum annotations
+	Expect(dep.Spec.Template.Annotations).To(Equal(annotations))
 }
 
-func checkKubeControllerManagerDeployment(dep *appsv1.Deployment) {
+func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations map[string]string) {
 	// Check that the kube-controller-manager container still exists and contains all needed command line args,
 	// env vars, and volume mounts
 	c := controlplane.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-controller-manager")
@@ -318,4 +374,19 @@ func checkKubeControllerManagerDeployment(dep *appsv1.Deployment) {
 	// Check that the Pod spec contains all needed volumes
 	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderConfigVolume))
 	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderSecretVolume))
+
+	// Check that the Pod template contains all needed checksum annotations
+	Expect(dep.Spec.Template.Annotations).To(Equal(annotations))
+}
+
+func clientGet(result runtime.Object) interface{} {
+	return func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+		switch obj.(type) {
+		case *corev1.Secret:
+			*obj.(*corev1.Secret) = *result.(*corev1.Secret)
+		case *corev1.ConfigMap:
+			*obj.(*corev1.ConfigMap) = *result.(*corev1.ConfigMap)
+		}
+		return nil
+	}
 }

--- a/controllers/provider-gcp/pkg/webhook/controlplanebackup/ensurer.go
+++ b/controllers/provider-gcp/pkg/webhook/controlplanebackup/ensurer.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewEnsurer creates a new controlplaneexposure ensurer.
@@ -45,7 +46,14 @@ type ensurer struct {
 	genericmutator.NoopEnsurer
 	etcdBackup  *config.ETCDBackup
 	imageVector imagevector.ImageVector
+	client      client.Client
 	logger      logr.Logger
+}
+
+// InjectClient injects the given client into the ensurer.
+func (e *ensurer) InjectClient(client client.Client) error {
+	e.client = client
+	return nil
 }
 
 // EnsureETCDStatefulSet ensures that the etcd stateful sets conform to the provider requirements.
@@ -54,7 +62,7 @@ func (e *ensurer) EnsureETCDStatefulSet(ctx context.Context, ss *appsv1.Stateful
 		return err
 	}
 	e.ensureVolumes(&ss.Spec.Template.Spec, ss.Name)
-	return nil
+	return e.ensureChecksumAnnotations(ctx, &ss.Spec.Template, ss.Namespace, ss.Name)
 }
 
 func (e *ensurer) ensureContainers(ps *corev1.PodSpec, name string, cluster *extensionscontroller.Cluster) error {
@@ -63,6 +71,13 @@ func (e *ensurer) ensureContainers(ps *corev1.PodSpec, name string, cluster *ext
 		return err
 	}
 	ps.Containers = controlplane.EnsureContainerWithName(ps.Containers, *c)
+	return nil
+}
+
+func (e *ensurer) ensureChecksumAnnotations(ctx context.Context, template *corev1.PodTemplateSpec, namespace, name string) error {
+	if name == common.EtcdMainStatefulSetName {
+		return controlplane.EnsureSecretChecksumAnnotation(ctx, template, e.client, namespace, gcp.BackupSecretName)
+	}
 	return nil
 }
 

--- a/controllers/provider-openstack/pkg/webhook/controlplane/ensurer_test.go
+++ b/controllers/provider-openstack/pkg/webhook/controlplane/ensurer_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/gardener/gardener-extensions/controllers/provider-openstack/pkg/openstack"
+	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane/test"
 
@@ -30,7 +31,14 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+const (
+	namespace = "test"
 )
 
 func TestController(t *testing.T) {
@@ -41,11 +49,22 @@ func TestController(t *testing.T) {
 var _ = Describe("Ensurer", func() {
 	var (
 		ctrl *gomock.Controller
+
+		cmKey = client.ObjectKey{Namespace: namespace, Name: openstack.CloudProviderConfigName}
+		cm    = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: openstack.CloudProviderConfigName},
+			Data:       map[string]string{"abc": "xyz"},
+		}
+
+		annotations = map[string]string{
+			"checksum/configmap-" + openstack.CloudProviderConfigName: "08a7bc7fe8f59b055f173145e211760a83f02cf89635cef26ebb351378635606",
+		}
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 	})
+
 	AfterEach(func() {
 		ctrl.Finish()
 	})
@@ -54,7 +73,7 @@ var _ = Describe("Ensurer", func() {
 		It("should add missing elements to kube-apiserver deployment", func() {
 			var (
 				dep = &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: common.KubeAPIServerDeploymentName},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: common.KubeAPIServerDeploymentName},
 					Spec: appsv1.DeploymentSpec{
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
@@ -69,19 +88,25 @@ var _ = Describe("Ensurer", func() {
 				}
 			)
 
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
+
 			// Create ensurer
 			ensurer := NewEnsurer(logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
-			err := ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dep)
+			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeAPIServerDeployment(dep)
+			checkKubeAPIServerDeployment(dep, annotations)
 		})
 
 		It("should modify existing elements of kube-apiserver deployment", func() {
 			var (
 				dep = &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: common.KubeAPIServerDeploymentName},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: common.KubeAPIServerDeploymentName},
 					Spec: appsv1.DeploymentSpec{
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
@@ -96,15 +121,11 @@ var _ = Describe("Ensurer", func() {
 										},
 										VolumeMounts: []corev1.VolumeMount{
 											{Name: openstack.CloudProviderConfigName, MountPath: "?"},
-											// TODO Use constant from github.com/gardener/gardener/pkg/apis/core/v1alpha1 when available
-											// See https://github.com/gardener/gardener/pull/930
-											{Name: common.CloudProviderSecretName, MountPath: "?"},
 										},
 									},
 								},
 								Volumes: []corev1.Volume{
 									{Name: openstack.CloudProviderConfigName},
-									{Name: common.CloudProviderSecretName},
 								},
 							},
 						},
@@ -112,13 +133,19 @@ var _ = Describe("Ensurer", func() {
 				}
 			)
 
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
+
 			// Create ensurer
 			ensurer := NewEnsurer(logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
-			err := ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dep)
+			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeAPIServerDeployment(dep)
+			checkKubeAPIServerDeployment(dep, annotations)
 		})
 	})
 
@@ -126,7 +153,7 @@ var _ = Describe("Ensurer", func() {
 		It("should add missing elements to kube-controller-manager deployment", func() {
 			var (
 				dep = &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: common.KubeControllerManagerDeploymentName},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: common.KubeControllerManagerDeploymentName},
 					Spec: appsv1.DeploymentSpec{
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
@@ -141,19 +168,25 @@ var _ = Describe("Ensurer", func() {
 				}
 			)
 
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
+
 			// Create ensurer
 			ensurer := NewEnsurer(logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeControllerManagerDeployment method and check the result
-			err := ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), dep)
+			err = ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeControllerManagerDeployment(dep)
+			checkKubeControllerManagerDeployment(dep, annotations)
 		})
 
 		It("should modify existing elements of kube-controller-manager deployment", func() {
 			var (
 				dep = &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: common.KubeControllerManagerDeploymentName},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: common.KubeControllerManagerDeploymentName},
 					Spec: appsv1.DeploymentSpec{
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
@@ -167,13 +200,11 @@ var _ = Describe("Ensurer", func() {
 										},
 										VolumeMounts: []corev1.VolumeMount{
 											{Name: openstack.CloudProviderConfigName, MountPath: "?"},
-											{Name: common.CloudProviderSecretName, MountPath: "?"},
 										},
 									},
 								},
 								Volumes: []corev1.Volume{
 									{Name: openstack.CloudProviderConfigName},
-									{Name: common.CloudProviderSecretName},
 								},
 							},
 						},
@@ -181,13 +212,19 @@ var _ = Describe("Ensurer", func() {
 				}
 			)
 
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
+
 			// Create ensurer
 			ensurer := NewEnsurer(logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeControllerManagerDeployment method and check the result
-			err := ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), dep)
+			err = ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeControllerManagerDeployment(dep)
+			checkKubeControllerManagerDeployment(dep, annotations)
 		})
 	})
 
@@ -252,7 +289,7 @@ var _ = Describe("Ensurer", func() {
 	})
 })
 
-func checkKubeAPIServerDeployment(dep *appsv1.Deployment) {
+func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string]string) {
 	// Check that the kube-apiserver container still exists and contains all needed command line args,
 	// env vars, and volume mounts
 	c := controlplane.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-apiserver")
@@ -262,14 +299,15 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment) {
 	Expect(c.Command).To(test.ContainElementWithPrefixContaining("--enable-admission-plugins=", "PersistentVolumeLabel", ","))
 	Expect(c.Command).To(Not(test.ContainElementWithPrefixContaining("--disable-admission-plugins=", "PersistentVolumeLabel", ",")))
 	Expect(c.VolumeMounts).To(ContainElement(cloudProviderConfigVolumeMount))
-	Expect(c.VolumeMounts).To(ContainElement(cloudProviderSecretVolumeMount))
 
 	// Check that the Pod spec contains all needed volumes
 	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderConfigVolume))
-	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderSecretVolume))
+
+	// Check that the Pod template contains all needed checksum annotations
+	Expect(dep.Spec.Template.Annotations).To(Equal(annotations))
 }
 
-func checkKubeControllerManagerDeployment(dep *appsv1.Deployment) {
+func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations map[string]string) {
 	// Check that the kube-controller-manager container still exists and contains all needed command line args,
 	// env vars, and volume mounts
 	c := controlplane.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-controller-manager")
@@ -278,9 +316,22 @@ func checkKubeControllerManagerDeployment(dep *appsv1.Deployment) {
 	Expect(c.Command).To(ContainElement("--cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf"))
 	Expect(c.Command).To(ContainElement("--external-cloud-volume-plugin=openstack"))
 	Expect(c.VolumeMounts).To(ContainElement(cloudProviderConfigVolumeMount))
-	Expect(c.VolumeMounts).To(ContainElement(cloudProviderSecretVolumeMount))
 
 	// Check that the Pod spec contains all needed volumes
 	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderConfigVolume))
-	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderSecretVolume))
+
+	// Check that the Pod template contains all needed checksum annotations
+	Expect(dep.Spec.Template.Annotations).To(Equal(annotations))
+}
+
+func clientGet(result runtime.Object) interface{} {
+	return func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+		switch obj.(type) {
+		case *corev1.Secret:
+			*obj.(*corev1.Secret) = *result.(*corev1.Secret)
+		case *corev1.ConfigMap:
+			*obj.(*corev1.ConfigMap) = *result.(*corev1.ConfigMap)
+		}
+		return nil
+	}
 }

--- a/controllers/provider-openstack/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-openstack/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -21,17 +21,26 @@ import (
 	"github.com/gardener/gardener-extensions/controllers/provider-openstack/pkg/apis/config"
 	"github.com/gardener/gardener-extensions/controllers/provider-openstack/pkg/openstack"
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
+	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener-extensions/pkg/util"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
 
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+const (
+	namespace = "test"
 )
 
 func TestController(t *testing.T) {
@@ -42,6 +51,8 @@ func TestController(t *testing.T) {
 var _ = Describe("Ensurer", func() {
 	Describe("#EnsureETCDStatefulSet", func() {
 		var (
+			ctrl *gomock.Controller
+
 			etcdBackup = &config.ETCDBackup{
 				Schedule: util.StringPtr("0 */24 * * *"),
 			}
@@ -63,28 +74,52 @@ var _ = Describe("Ensurer", func() {
 					},
 				},
 			}
+
+			secretKey = client.ObjectKey{Namespace: namespace, Name: openstack.BackupSecretName}
+			secret    = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: openstack.BackupSecretName, Namespace: namespace},
+				Data:       map[string][]byte{"foo": []byte("bar")},
+			}
+
+			annotations = map[string]string{
+				"checksum/secret-" + openstack.BackupSecretName: "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
+			}
 		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
 
 		It("should add or modify elements to etcd-main statefulset", func() {
 			var (
 				ss = &appsv1.StatefulSet{
-					ObjectMeta: metav1.ObjectMeta{Name: common.EtcdMainStatefulSetName},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: common.EtcdMainStatefulSetName},
 				}
 			)
 
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
+
 			// Create ensurer
 			ensurer := NewEnsurer(etcdBackup, imageVector, logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureETCDStatefulSet method and check the result
-			err := ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
 			Expect(err).To(Not(HaveOccurred()))
-			checkETCDMainStatefulSet(ss)
+			checkETCDMainStatefulSet(ss, annotations)
 		})
 
 		It("should modify existing elements of etcd-main statefulset", func() {
 			var (
 				ss = &appsv1.StatefulSet{
-					ObjectMeta: metav1.ObjectMeta{Name: common.EtcdMainStatefulSetName},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: common.EtcdMainStatefulSetName},
 					Spec: appsv1.StatefulSetSpec{
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
@@ -99,13 +134,19 @@ var _ = Describe("Ensurer", func() {
 				}
 			)
 
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
+
 			// Create ensurer
 			ensurer := NewEnsurer(etcdBackup, imageVector, logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureETCDStatefulSet method and check the result
-			err := ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
 			Expect(err).To(Not(HaveOccurred()))
-			checkETCDMainStatefulSet(ss)
+			checkETCDMainStatefulSet(ss, annotations)
 		})
 
 		It("should add or modify elements to etcd-events statefulset", func() {
@@ -153,7 +194,7 @@ var _ = Describe("Ensurer", func() {
 	})
 })
 
-func checkETCDMainStatefulSet(ss *appsv1.StatefulSet) {
+func checkETCDMainStatefulSet(ss *appsv1.StatefulSet, annotations map[string]string) {
 	var (
 		env = []corev1.EnvVar{
 			{
@@ -169,8 +210,8 @@ func checkETCDMainStatefulSet(ss *appsv1.StatefulSet) {
 				Name: "OS_AUTH_URL",
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
 						Key:                  openstack.AuthURL,
+						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
 					},
 				},
 			},
@@ -178,8 +219,8 @@ func checkETCDMainStatefulSet(ss *appsv1.StatefulSet) {
 				Name: "OS_DOMAIN_NAME",
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
 						Key:                  openstack.DomainName,
+						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
 					},
 				},
 			},
@@ -187,8 +228,8 @@ func checkETCDMainStatefulSet(ss *appsv1.StatefulSet) {
 				Name: "OS_USERNAME",
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
 						Key:                  openstack.UserName,
+						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
 					},
 				},
 			},
@@ -196,8 +237,8 @@ func checkETCDMainStatefulSet(ss *appsv1.StatefulSet) {
 				Name: "OS_PASSWORD",
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
 						Key:                  openstack.Password,
+						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
 					},
 				},
 			},
@@ -205,8 +246,8 @@ func checkETCDMainStatefulSet(ss *appsv1.StatefulSet) {
 				Name: "OS_TENANT_NAME",
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
 						Key:                  openstack.TenantName,
+						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
 					},
 				},
 			},
@@ -216,10 +257,21 @@ func checkETCDMainStatefulSet(ss *appsv1.StatefulSet) {
 	c := controlplane.ContainerWithName(ss.Spec.Template.Spec.Containers, "backup-restore")
 	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdMainStatefulSetName, "0 */24 * * *", openstack.StorageProviderName,
 		"test-repository:test-tag", nil, env, nil)))
+	Expect(ss.Spec.Template.Annotations).To(Equal(annotations))
 }
 
 func checkETCDEventsStatefulSet(ss *appsv1.StatefulSet) {
 	c := controlplane.ContainerWithName(ss.Spec.Template.Spec.Containers, "backup-restore")
 	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdEventsStatefulSetName, "0 */24 * * *", "",
 		"test-repository:test-tag", nil, nil, nil)))
+}
+
+func clientGet(result runtime.Object) interface{} {
+	return func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+		switch obj.(type) {
+		case *corev1.Secret:
+			*obj.(*corev1.Secret) = *result.(*corev1.Secret)
+		}
+		return nil
+	}
 }

--- a/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/pkg/controller/controlplane/genericactuator/actuator.go
@@ -259,7 +259,7 @@ func (a *actuator) computeChecksums(
 	// Get cloud provider secret and config from cluster
 	cpSecret := &corev1.Secret{}
 	if err := a.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: common.CloudProviderSecretName}, cpSecret); err != nil {
-		return nil, errors.Wrapf(err, "could not get secret '%s'", util.ObjectName(cpSecret))
+		return nil, errors.Wrapf(err, "could not get secret '%s/%s'", namespace, common.CloudProviderSecretName)
 	}
 
 	csSecrets := controlplane.MergeSecretMaps(deployedSecrets, map[string]*corev1.Secret{
@@ -270,7 +270,7 @@ func (a *actuator) computeChecksums(
 	if len(a.configName) != 0 {
 		cpConfigMap := &corev1.ConfigMap{}
 		if err := a.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: a.configName}, cpConfigMap); err != nil {
-			return nil, errors.Wrapf(err, "could not get configmap '%s'", util.ObjectName(cpConfigMap))
+			return nil, errors.Wrapf(err, "could not get configmap '%s/%s'", namespace, a.configName)
 		}
 
 		csConfigMaps = map[string]*corev1.ConfigMap{

--- a/pkg/webhook/controlplane/checksums.go
+++ b/pkg/webhook/controlplane/checksums.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane
+
+import (
+	"context"
+	"github.com/gardener/gardener-extensions/pkg/util"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// EnsureSecretChecksumAnnotation ensures that the given pod template has an annotation containing the checksum of the
+// secret with the given name and namespace.
+func EnsureSecretChecksumAnnotation(ctx context.Context, template *corev1.PodTemplateSpec, c client.Client, namespace, name string) error {
+	// Get secret from cluster
+	secret := &corev1.Secret{}
+	if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, secret); err != nil {
+		return errors.Wrapf(err, "could not get secret '%s/%s'", namespace, name)
+	}
+
+	// Add checksum annotation
+	metav1.SetMetaDataAnnotation(&template.ObjectMeta, "checksum/secret-"+name, util.ComputeChecksum(secret.Data))
+	return nil
+}
+
+// EnsureConfigMapChecksumAnnotation ensures that the given pod template has an annotation containing the checksum of the
+// configmap with the given name and namespace.
+func EnsureConfigMapChecksumAnnotation(ctx context.Context, template *corev1.PodTemplateSpec, c client.Client, namespace, name string) error {
+	// Get configmap from cluster
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, cm); err != nil {
+		return errors.Wrapf(err, "could not get configmap '%s/%s'", namespace, name)
+	}
+
+	// Add checksum annotation
+	metav1.SetMetaDataAnnotation(&template.ObjectMeta, "checksum/configmap-"+name, util.ComputeChecksum(cm.Data))
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Controlplane webhooks now add checksum annotations for all secrets / configmaps that are being mounted as volumes or used as a source of env vars.

**Which issue(s) this PR fixes**:
Fixes #115 

**Special notes for your reviewer**:
It also removes some volumes mounted by controlplane webhooks that are actually not needed.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
