### PR TITLE
Fix volume claim template name

### DIFF
--- a/controllers/provider-alicloud/pkg/webhook/controlplanebackup/ensurer.go
+++ b/controllers/provider-alicloud/pkg/webhook/controlplanebackup/ensurer.go
@@ -94,8 +94,9 @@ func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscont
 	// Determine provider and container env variables
 	// They are only specified for the etcd-main stateful set (backup is enabled)
 	var (
-		provider string
-		env      []corev1.EnvVar
+		provider                string
+		env                     []corev1.EnvVar
+		volumeClaimTemplateName = name
 	)
 	if name == common.EtcdMainStatefulSetName {
 		provider = alicloud.StorageProviderName
@@ -139,6 +140,7 @@ func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscont
 				},
 			},
 		}
+		volumeClaimTemplateName = controlplane.EtcdMainVolumeClaimTemplateName
 	}
 
 	// Determine schedule
@@ -147,5 +149,5 @@ func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscont
 		schedule = defaultSchedule
 	}
 
-	return controlplane.GetBackupRestoreContainer(name, schedule, provider, image.String(), nil, env, nil), nil
+	return controlplane.GetBackupRestoreContainer(name, volumeClaimTemplateName, schedule, provider, image.String(), nil, env, nil), nil
 }

--- a/controllers/provider-alicloud/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-alicloud/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -237,14 +237,14 @@ func checkETCDMainStatefulSet(ss *appsv1.StatefulSet, annotations map[string]str
 	)
 
 	c := controlplane.ContainerWithName(ss.Spec.Template.Spec.Containers, "backup-restore")
-	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdMainStatefulSetName, "0 */24 * * *", alicloud.StorageProviderName,
+	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdMainStatefulSetName, controlplane.EtcdMainVolumeClaimTemplateName, "0 */24 * * *", alicloud.StorageProviderName,
 		"test-repository:test-tag", nil, env, nil)))
 	Expect(ss.Spec.Template.Annotations).To(Equal(annotations))
 }
 
 func checkETCDEventsStatefulSet(ss *appsv1.StatefulSet) {
 	c := controlplane.ContainerWithName(ss.Spec.Template.Spec.Containers, "backup-restore")
-	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdEventsStatefulSetName, "0 */24 * * *", "",
+	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdEventsStatefulSetName, common.EtcdEventsStatefulSetName, "0 */24 * * *", "",
 		"test-repository:test-tag", nil, nil, nil)))
 }
 

--- a/controllers/provider-aws/pkg/webhook/controlplanebackup/ensurer.go
+++ b/controllers/provider-aws/pkg/webhook/controlplanebackup/ensurer.go
@@ -94,8 +94,9 @@ func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscont
 	// Determine provider and container env variables
 	// They are only specified for the etcd-main stateful set (backup is enabled)
 	var (
-		provider string
-		env      []corev1.EnvVar
+		provider                string
+		env                     []corev1.EnvVar
+		volumeClaimTemplateName = name
 	)
 	if name == common.EtcdMainStatefulSetName {
 		provider = aws.StorageProviderName
@@ -139,6 +140,7 @@ func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscont
 				},
 			},
 		}
+		volumeClaimTemplateName = controlplane.EtcdMainVolumeClaimTemplateName
 	}
 
 	// Determine schedule
@@ -147,5 +149,5 @@ func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscont
 		schedule = defaultSchedule
 	}
 
-	return controlplane.GetBackupRestoreContainer(name, schedule, provider, image.String(), nil, env, nil), nil
+	return controlplane.GetBackupRestoreContainer(name, volumeClaimTemplateName, schedule, provider, image.String(), nil, env, nil), nil
 }

--- a/controllers/provider-aws/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-aws/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -237,14 +237,14 @@ func checkETCDMainStatefulSet(ss *appsv1.StatefulSet, annotations map[string]str
 	)
 
 	c := controlplane.ContainerWithName(ss.Spec.Template.Spec.Containers, "backup-restore")
-	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdMainStatefulSetName, "0 */24 * * *", aws.StorageProviderName,
+	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdMainStatefulSetName, controlplane.EtcdMainVolumeClaimTemplateName, "0 */24 * * *", aws.StorageProviderName,
 		"test-repository:test-tag", nil, env, nil)))
 	Expect(ss.Spec.Template.Annotations).To(Equal(annotations))
 }
 
 func checkETCDEventsStatefulSet(ss *appsv1.StatefulSet) {
 	c := controlplane.ContainerWithName(ss.Spec.Template.Spec.Containers, "backup-restore")
-	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdEventsStatefulSetName, "0 */24 * * *", "",
+	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdEventsStatefulSetName, common.EtcdEventsStatefulSetName, "0 */24 * * *", "",
 		"test-repository:test-tag", nil, nil, nil)))
 }
 

--- a/controllers/provider-azure/pkg/webhook/controlplanebackup/ensurer.go
+++ b/controllers/provider-azure/pkg/webhook/controlplanebackup/ensurer.go
@@ -94,8 +94,9 @@ func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscont
 	// Determine provider, container env variables, and volume mounts
 	// They are only specified for the etcd-main stateful set (backup is enabled)
 	var (
-		provider string
-		env      []corev1.EnvVar
+		provider                string
+		env                     []corev1.EnvVar
+		volumeClaimTemplateName = name
 	)
 	if name == common.EtcdMainStatefulSetName {
 		provider = azure.StorageProviderName
@@ -130,6 +131,7 @@ func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscont
 				},
 			},
 		}
+		volumeClaimTemplateName = controlplane.EtcdMainVolumeClaimTemplateName
 	}
 
 	// Determine schedule
@@ -138,5 +140,5 @@ func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscont
 		schedule = defaultSchedule
 	}
 
-	return controlplane.GetBackupRestoreContainer(name, schedule, provider, image.String(), nil, env, nil), nil
+	return controlplane.GetBackupRestoreContainer(name, volumeClaimTemplateName, schedule, provider, image.String(), nil, env, nil), nil
 }

--- a/controllers/provider-azure/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-azure/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -228,14 +228,14 @@ func checkETCDMainStatefulSet(ss *appsv1.StatefulSet, annotations map[string]str
 	)
 
 	c := controlplane.ContainerWithName(ss.Spec.Template.Spec.Containers, "backup-restore")
-	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdMainStatefulSetName, "0 */24 * * *", azure.StorageProviderName,
+	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdMainStatefulSetName, controlplane.EtcdMainVolumeClaimTemplateName, "0 */24 * * *", azure.StorageProviderName,
 		"test-repository:test-tag", nil, env, nil)))
 	Expect(ss.Spec.Template.Annotations).To(Equal(annotations))
 }
 
 func checkETCDEventsStatefulSet(ss *appsv1.StatefulSet) {
 	c := controlplane.ContainerWithName(ss.Spec.Template.Spec.Containers, "backup-restore")
-	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdEventsStatefulSetName, "0 */24 * * *", "",
+	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdEventsStatefulSetName, common.EtcdEventsStatefulSetName, "0 */24 * * *", "",
 		"test-repository:test-tag", nil, nil, nil)))
 }
 

--- a/controllers/provider-gcp/pkg/webhook/controlplanebackup/ensurer.go
+++ b/controllers/provider-gcp/pkg/webhook/controlplanebackup/ensurer.go
@@ -97,9 +97,10 @@ func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscont
 	// Determine provider, container env variables, and volume mounts
 	// They are only specified for the etcd-main stateful set (backup is enabled)
 	var (
-		provider     string
-		env          []corev1.EnvVar
-		volumeMounts []corev1.VolumeMount
+		provider                string
+		env                     []corev1.EnvVar
+		volumeMounts            []corev1.VolumeMount
+		volumeClaimTemplateName = name
 	)
 	if name == common.EtcdMainStatefulSetName {
 		provider = gcp.StorageProviderName
@@ -126,6 +127,7 @@ func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscont
 				MountPath: mountPath,
 			},
 		}
+		volumeClaimTemplateName = controlplane.EtcdMainVolumeClaimTemplateName
 	}
 
 	// Determine schedule
@@ -134,7 +136,7 @@ func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscont
 		schedule = defaultSchedule
 	}
 
-	return controlplane.GetBackupRestoreContainer(name, schedule, provider, image.String(), nil, env, volumeMounts), nil
+	return controlplane.GetBackupRestoreContainer(name, volumeClaimTemplateName, schedule, provider, image.String(), nil, env, volumeMounts), nil
 }
 
 func (e *ensurer) ensureVolumes(ps *corev1.PodSpec, name string) {

--- a/controllers/provider-gcp/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-gcp/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -229,7 +229,7 @@ func checkETCDMainStatefulSet(ss *appsv1.StatefulSet, annotations map[string]str
 	)
 
 	c := controlplane.ContainerWithName(ss.Spec.Template.Spec.Containers, "backup-restore")
-	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdMainStatefulSetName, "0 */24 * * *", gcp.StorageProviderName,
+	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdMainStatefulSetName, controlplane.EtcdMainVolumeClaimTemplateName, "0 */24 * * *", gcp.StorageProviderName,
 		"test-repository:test-tag", nil, env, volumeMounts)))
 	Expect(ss.Spec.Template.Spec.Volumes).To(ContainElement(etcdBackupSecretVolume))
 
@@ -237,7 +237,7 @@ func checkETCDMainStatefulSet(ss *appsv1.StatefulSet, annotations map[string]str
 
 func checkETCDEventsStatefulSet(ss *appsv1.StatefulSet) {
 	c := controlplane.ContainerWithName(ss.Spec.Template.Spec.Containers, "backup-restore")
-	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdEventsStatefulSetName, "0 */24 * * *", "",
+	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdEventsStatefulSetName, common.EtcdEventsStatefulSetName, "0 */24 * * *", "",
 		"test-repository:test-tag", nil, nil, nil)))
 	Expect(ss.Spec.Template.Spec.Volumes).To(BeEmpty())
 }

--- a/controllers/provider-openstack/pkg/webhook/controlplanebackup/ensurer.go
+++ b/controllers/provider-openstack/pkg/webhook/controlplanebackup/ensurer.go
@@ -94,8 +94,9 @@ func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscont
 	// Determine provider and container env variables
 	// They are only specified for the etcd-main stateful set (backup is enabled)
 	var (
-		provider string
-		env      []corev1.EnvVar
+		provider                string
+		env                     []corev1.EnvVar
+		volumeClaimTemplateName = name
 	)
 	if name == common.EtcdMainStatefulSetName {
 		provider = openstack.StorageProviderName
@@ -157,6 +158,7 @@ func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscont
 				},
 			},
 		}
+		volumeClaimTemplateName = controlplane.EtcdMainVolumeClaimTemplateName
 	}
 
 	// Determine schedule
@@ -165,5 +167,5 @@ func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscont
 		schedule = defaultSchedule
 	}
 
-	return controlplane.GetBackupRestoreContainer(name, schedule, provider, image.String(), nil, env, nil), nil
+	return controlplane.GetBackupRestoreContainer(name, volumeClaimTemplateName, schedule, provider, image.String(), nil, env, nil), nil
 }

--- a/controllers/provider-openstack/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-openstack/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -255,14 +255,14 @@ func checkETCDMainStatefulSet(ss *appsv1.StatefulSet, annotations map[string]str
 	)
 
 	c := controlplane.ContainerWithName(ss.Spec.Template.Spec.Containers, "backup-restore")
-	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdMainStatefulSetName, "0 */24 * * *", openstack.StorageProviderName,
+	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdMainStatefulSetName, controlplane.EtcdMainVolumeClaimTemplateName, "0 */24 * * *", openstack.StorageProviderName,
 		"test-repository:test-tag", nil, env, nil)))
 	Expect(ss.Spec.Template.Annotations).To(Equal(annotations))
 }
 
 func checkETCDEventsStatefulSet(ss *appsv1.StatefulSet) {
 	c := controlplane.ContainerWithName(ss.Spec.Template.Spec.Containers, "backup-restore")
-	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdEventsStatefulSetName, "0 */24 * * *", "",
+	Expect(c).To(Equal(controlplane.GetBackupRestoreContainer(common.EtcdEventsStatefulSetName, common.EtcdEventsStatefulSetName, "0 */24 * * *", "",
 		"test-repository:test-tag", nil, nil, nil)))
 }
 

--- a/pkg/webhook/controlplane/etcd.go
+++ b/pkg/webhook/controlplane/etcd.go
@@ -30,7 +30,7 @@ const EtcdMainVolumeClaimTemplateName = "main-etcd"
 // GetBackupRestoreContainer returns an etcd backup-restore container with the given name, schedule, provider, image,
 // and additional provider-specific command line args and env variables.
 func GetBackupRestoreContainer(
-	name, schedule, provider, image string,
+	name, volumeClaimTemplateName, schedule, provider, image string,
 	args map[string]string,
 	env []corev1.EnvVar,
 	volumeMounts []corev1.VolumeMount,
@@ -78,7 +78,7 @@ func GetBackupRestoreContainer(
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
-				Name:      name,
+				Name:      volumeClaimTemplateName,
 				MountPath: "/var/etcd/data",
 			},
 			{


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes volume claim template name in etcd backup container volume mounts

**Special notes for your reviewer**:
Depends on #127 which should be merged first.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
