### PR TITLE
Ensure Cloud provider config as part of kubelet configuration

### DIFF
--- a/controllers/provider-azure/pkg/azure/types.go
+++ b/controllers/provider-azure/pkg/azure/types.go
@@ -54,6 +54,8 @@ const (
 
 	// CloudProviderConfigName is the name of the configmap containing the cloud provider config.
 	CloudProviderConfigName = "cloud-provider-config"
+	// CloudProviderConfigMapKey is the key storing the cloud provider config as value in the cloud provider configmap.
+	CloudProviderConfigMapKey = "cloudprovider.conf"
 	// BackupSecretName is the name of the secret containing the credentials for storing the backups of Shoot clusters.
 	BackupSecretName = "etcd-backup"
 )

--- a/controllers/provider-azure/pkg/webhook/controlplane/ensurer.go
+++ b/controllers/provider-azure/pkg/webhook/controlplane/ensurer.go
@@ -16,12 +16,14 @@ package controlplane
 
 import (
 	"context"
+	"github.com/pkg/errors"
 
 	"github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/azure"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane/genericmutator"
 
 	"github.com/coreos/go-systemd/unit"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -141,5 +143,29 @@ func (e *ensurer) EnsureKubeletConfiguration(ctx context.Context, kubeletConfig 
 	delete(kubeletConfig.FeatureGates, "VolumeSnapshotDataSource")
 	delete(kubeletConfig.FeatureGates, "CSINodeInfo")
 	delete(kubeletConfig.FeatureGates, "CSIDriverRegistry")
+	return nil
+}
+
+//ShouldProvisionKubeletCloudProviderConfig returns if the cloudprovider.config file should be added to the kubelet configuration.
+func (e *ensurer) ShouldProvisionKubeletCloudProviderConfig() bool {
+	return true
+}
+
+//EnsureKubeletCloudProviderConfig ensures that the cloudprovider.config file conforms to the provider requirements.
+func (e *ensurer) EnsureKubeletCloudProviderConfig(ctx context.Context, data *string, namespace string) error {
+	// Get `cloud-provider-config` ConfigMap
+	var cm corev1.ConfigMap
+	err := e.client.Get(ctx, kutil.Key(namespace, azure.CloudProviderConfigName), &cm)
+	if err != nil {
+		return errors.Wrapf(err, "could not get configmap with name '%s' and namespace '%s'", azure.CloudProviderConfigName, namespace)
+	}
+
+	// Check if the data has "cloudprovider.conf" key
+	if cm.Data == nil || cm.Data[azure.CloudProviderConfigMapKey] == "" {
+		return nil
+	}
+
+	// Overwrite data variable
+	*data = cm.Data[azure.CloudProviderConfigMapKey]
 	return nil
 }

--- a/controllers/provider-openstack/pkg/openstack/types.go
+++ b/controllers/provider-openstack/pkg/openstack/types.go
@@ -47,6 +47,8 @@ const (
 
 	// CloudProviderConfigName is the name of the configmap containing the cloud provider config.
 	CloudProviderConfigName = "cloud-provider-config"
+	// CloudProviderConfigMapKey is the key storing the cloud provider config as value in the cloud provider configmap.
+	CloudProviderConfigMapKey = "cloudprovider.conf"
 	// MachineControllerManagerName is a constant for the name of the machine-controller-manager.
 	MachineControllerManagerName = "machine-controller-manager"
 	// BackupSecretName defines the name of the secret containing the credentials which are required to

--- a/pkg/mock/gardener-extensions/webhook/controlplane/genericmutator/mocks.go
+++ b/pkg/mock/gardener-extensions/webhook/controlplane/genericmutator/mocks.go
@@ -108,6 +108,20 @@ func (mr *MockEnsurerMockRecorder) EnsureKubeSchedulerDeployment(arg0, arg1 inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeSchedulerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeSchedulerDeployment), arg0, arg1)
 }
 
+// EnsureKubeletCloudProviderConfig mocks base method
+func (m *MockEnsurer) EnsureKubeletCloudProviderConfig(arg0 context.Context, arg1 *string, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureKubeletCloudProviderConfig", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureKubeletCloudProviderConfig indicates an expected call of EnsureKubeletCloudProviderConfig
+func (mr *MockEnsurerMockRecorder) EnsureKubeletCloudProviderConfig(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeletCloudProviderConfig", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeletCloudProviderConfig), arg0, arg1, arg2)
+}
+
 // EnsureKubeletConfiguration mocks base method
 func (m *MockEnsurer) EnsureKubeletConfiguration(arg0 context.Context, arg1 *v1beta1.KubeletConfiguration) error {
 	m.ctrl.T.Helper()
@@ -149,4 +163,18 @@ func (m *MockEnsurer) EnsureKubernetesGeneralConfiguration(arg0 context.Context,
 func (mr *MockEnsurerMockRecorder) EnsureKubernetesGeneralConfiguration(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubernetesGeneralConfiguration", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubernetesGeneralConfiguration), arg0, arg1)
+}
+
+// ShouldProvisionKubeletCloudProviderConfig mocks base method
+func (m *MockEnsurer) ShouldProvisionKubeletCloudProviderConfig() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShouldProvisionKubeletCloudProviderConfig")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// ShouldProvisionKubeletCloudProviderConfig indicates an expected call of ShouldProvisionKubeletCloudProviderConfig
+func (mr *MockEnsurerMockRecorder) ShouldProvisionKubeletCloudProviderConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldProvisionKubeletCloudProviderConfig", reflect.TypeOf((*MockEnsurer)(nil).ShouldProvisionKubeletCloudProviderConfig))
 }

--- a/pkg/webhook/controlplane/genericmutator/noopensurer.go
+++ b/pkg/webhook/controlplane/genericmutator/noopensurer.go
@@ -67,3 +67,13 @@ func (e *NoopEnsurer) EnsureKubeletConfiguration(context.Context, *kubeletconfig
 func (e *NoopEnsurer) EnsureKubernetesGeneralConfiguration(context.Context, *string) error {
 	return nil
 }
+
+//ShouldProvisionKubeletCloudProviderConfig returns if the cloudprovider.conf file should be added to the kubelet configuration.
+func (e *NoopEnsurer) ShouldProvisionKubeletCloudProviderConfig() bool {
+	return false
+}
+
+//EnsureKubeletCloudProviderConfig ensures that the cloudprovider.conf file conforms to the provider requirements.
+func (e *NoopEnsurer) EnsureKubeletCloudProviderConfig(context.Context, *string, string) error {
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
* Ensure Kubelet Service unit option `ExecStartPre` (CloudConfigUserDataConfig.HostnameOverride)
* Ensure Cloud provider config as part of kubelet configuration

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Issues related to Openstack and Azure extension controller
```
