### PR TITLE
Fix Ensuring kubernetes general configuration for AWS and GCP

### DIFF
--- a/controllers/provider-aws/pkg/webhook/controlplane/ensurer_test.go
+++ b/controllers/provider-aws/pkg/webhook/controlplane/ensurer_test.go
@@ -310,6 +310,31 @@ var _ = Describe("Ensurer", func() {
 	Describe("#EnsureKubernetesGeneralConfiguration", func() {
 		It("should modify existing elements of kubernetes general configuration", func() {
 			var (
+				modifiedData = util.StringPtr("# Default Socket Send Buffer\n" +
+					"net.core.wmem_max = 16777216\n" +
+					"# AWS specific settings\n" +
+					"# See https://github.com/kubernetes/kubernetes/issues/23395\n" +
+					"net.ipv4.neigh.default.gc_thresh1 = 67" +
+					"# For persistent HTTP connections\n" +
+					"net.ipv4.tcp_slow_start_after_idle = 0")
+				result = "# Default Socket Send Buffer\n" +
+					"net.core.wmem_max = 16777216\n" +
+					"# AWS specific settings\n" +
+					"# See https://github.com/kubernetes/kubernetes/issues/23395\n" +
+					"net.ipv4.neigh.default.gc_thresh1 = 0" +
+					"# For persistent HTTP connections\n" +
+					"net.ipv4.tcp_slow_start_after_idle = 0"
+			)
+			// Create ensurer
+			ensurer := NewEnsurer(logger)
+
+			// Call EnsureKubernetesGeneralConfiguration method and check the result
+			err := ensurer.EnsureKubernetesGeneralConfiguration(context.TODO(), modifiedData)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(*modifiedData).To(Equal(result))
+		})
+		It("should add needed elements of kubernetes general configuration", func() {
+			var (
 				data   = util.StringPtr("# Default Socket Send Buffer\nnet.core.wmem_max = 16777216")
 				result = "# Default Socket Send Buffer\n" +
 					"net.core.wmem_max = 16777216\n" +

--- a/controllers/provider-gcp/pkg/webhook/controlplane/ensurer_test.go
+++ b/controllers/provider-gcp/pkg/webhook/controlplane/ensurer_test.go
@@ -320,6 +320,29 @@ var _ = Describe("Ensurer", func() {
 	Describe("#EnsureKubernetesGeneralConfiguration", func() {
 		It("should modify existing elements of kubernetes general configuration", func() {
 			var (
+				modifiedData = util.StringPtr("# Default Socket Send Buffer\n" +
+					"net.core.wmem_max = 16777216\n" +
+					"# GCE specific settings\n" +
+					"net.ipv4.ip_forward = 5\n" +
+					"# For persistent HTTP connections\n" +
+					"net.ipv4.tcp_slow_start_after_idle = 0")
+				result = "# Default Socket Send Buffer\n" +
+					"net.core.wmem_max = 16777216\n" +
+					"# GCE specific settings\n" +
+					"net.ipv4.ip_forward = 1\n" +
+					"# For persistent HTTP connections\n" +
+					"net.ipv4.tcp_slow_start_after_idle = 0"
+			)
+			// Create ensurer
+			ensurer := NewEnsurer(logger)
+
+			// Call EnsureKubernetesGeneralConfiguration method and check the result
+			err := ensurer.EnsureKubernetesGeneralConfiguration(context.TODO(), modifiedData)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(*modifiedData).To(Equal(result))
+		})
+		It("should add needed elements of kubernetes general configuration", func() {
+			var (
 				data   = util.StringPtr("# Default Socket Send Buffer\nnet.core.wmem_max = 16777216")
 				result = "# Default Socket Send Buffer\n" +
 					"net.core.wmem_max = 16777216\n" +


### PR DESCRIPTION
**What this PR does / why we need it**:
EnsureKubernetesGeneralConfiguration() function in GCP and AWS always applied the needed kubernetes configuration despite the fact that it can be there already. 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Fix Ensuring kubernetes general configuration for AWS and GCP
```
