### PR TITLE
Fix controlplane hibernation issue

### DIFF
--- a/controllers/provider-alicloud/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-alicloud/pkg/controller/controlplane/valuesprovider.go
@@ -233,6 +233,7 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 	checksums map[string]string,
+	scaledDown bool,
 ) (map[string]interface{}, error) {
 	// Decode providerConfig
 	cpConfig := &apisalicloud.ControlPlaneConfig{}
@@ -241,7 +242,7 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	}
 
 	// Get control plane chart values
-	return getControlPlaneChartValues(cpConfig, cp, cluster, checksums)
+	return getControlPlaneChartValues(cpConfig, cp, cluster, checksums, scaledDown)
 }
 
 // GetControlPlaneShootChartValues returns the values for the control plane shoot chart applied by the generic actuator.
@@ -331,10 +332,11 @@ func getControlPlaneChartValues(
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 	checksums map[string]string,
+	scaledDown bool,
 ) (map[string]interface{}, error) {
 	values := map[string]interface{}{
 		"alicloud-cloud-controller-manager": map[string]interface{}{
-			"replicas":          extensionscontroller.GetReplicas(cluster.Shoot, 1),
+			"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster.Shoot, scaledDown, 1),
 			"clusterName":       cp.Namespace,
 			"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
 			"podNetwork":        extensionscontroller.GetPodNetwork(cluster.Shoot),

--- a/controllers/provider-alicloud/pkg/controller/controlplane/valuesprovider_test.go
+++ b/controllers/provider-alicloud/pkg/controller/controlplane/valuesprovider_test.go
@@ -212,7 +212,7 @@ var _ = Describe("ValuesProvider", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Call GetControlPlaneChartValues method and check the result
-			values, err := vp.GetControlPlaneChartValues(context.TODO(), cp, cluster, checksums)
+			values, err := vp.GetControlPlaneChartValues(context.TODO(), cp, cluster, checksums, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(controlPlaneChartValues))
 		})

--- a/controllers/provider-aws/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-aws/pkg/controller/controlplane/valuesprovider.go
@@ -156,6 +156,7 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 	checksums map[string]string,
+	scaledDown bool,
 ) (map[string]interface{}, error) {
 	// Decode providerConfig
 	cpConfig := &apisaws.ControlPlaneConfig{}
@@ -164,7 +165,7 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	}
 
 	// Get CCM chart values
-	return getCCMChartValues(cpConfig, cp, cluster, checksums)
+	return getCCMChartValues(cpConfig, cp, cluster, checksums, scaledDown)
 }
 
 // GetControlPlaneShootChartValues returns the values for the control plane shoot chart applied by the generic actuator.
@@ -202,9 +203,10 @@ func getCCMChartValues(
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 	checksums map[string]string,
+	scaledDown bool,
 ) (map[string]interface{}, error) {
 	values := map[string]interface{}{
-		"replicas":          extensionscontroller.GetReplicas(cluster.Shoot, 1),
+		"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster.Shoot, scaledDown, 1),
 		"clusterName":       cp.Namespace,
 		"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
 		"podNetwork":        extensionscontroller.GetPodNetwork(cluster.Shoot),

--- a/controllers/provider-aws/pkg/controller/controlplane/valuesprovider_test.go
+++ b/controllers/provider-aws/pkg/controller/controlplane/valuesprovider_test.go
@@ -168,7 +168,7 @@ var _ = Describe("ValuesProvider", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Call GetControlPlaneChartValues method and check the result
-			values, err := vp.GetControlPlaneChartValues(context.TODO(), cp, cluster, checksums)
+			values, err := vp.GetControlPlaneChartValues(context.TODO(), cp, cluster, checksums, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(ccmChartValues))
 		})

--- a/controllers/provider-azure/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-azure/pkg/controller/controlplane/valuesprovider.go
@@ -178,6 +178,7 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 	checksums map[string]string,
+	scaledDown bool,
 ) (map[string]interface{}, error) {
 	// Decode providerConfig
 	cpConfig := &apisazure.ControlPlaneConfig{}
@@ -186,7 +187,7 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	}
 
 	// Get CCM chart values
-	return getCCMChartValues(cpConfig, cp, cluster, checksums)
+	return getCCMChartValues(cpConfig, cp, cluster, checksums, scaledDown)
 }
 
 // GetControlPlaneShootChartValues returns the values for the control plane shoot chart applied by the generic actuator.
@@ -230,11 +231,12 @@ func getCCMChartValues(
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 	checksums map[string]string,
+	scaledDown bool,
 ) (map[string]interface{}, error) {
 	values := map[string]interface{}{
-		"replicas":          extensionscontroller.GetReplicas(cluster.Shoot, 1),
-		"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
+		"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster.Shoot, scaledDown, 1),
 		"clusterName":       cp.Namespace,
+		"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
 		"podNetwork":        extensionscontroller.GetPodNetwork(cluster.Shoot),
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-cloud-controller-manager":        checksums[cloudControllerManagerDeploymentName],

--- a/controllers/provider-azure/pkg/controller/controlplane/valuesprovider_test.go
+++ b/controllers/provider-azure/pkg/controller/controlplane/valuesprovider_test.go
@@ -209,7 +209,7 @@ var _ = Describe("ValuesProvider", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Call GetControlPlaneChartValues method and check the result
-			values, err := vp.GetControlPlaneChartValues(context.TODO(), cp, cluster, checksums)
+			values, err := vp.GetControlPlaneChartValues(context.TODO(), cp, cluster, checksums, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(ccmChartValues))
 		})

--- a/controllers/provider-gcp/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-gcp/pkg/controller/controlplane/valuesprovider.go
@@ -179,6 +179,7 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 	checksums map[string]string,
+	scaledDown bool,
 ) (map[string]interface{}, error) {
 	// Decode providerConfig
 	cpConfig := &apisgcp.ControlPlaneConfig{}
@@ -187,7 +188,7 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	}
 
 	// Get CCM chart values
-	return getCCMChartValues(cpConfig, cp, cluster, checksums)
+	return getCCMChartValues(cpConfig, cp, cluster, checksums, scaledDown)
 }
 
 // GetControlPlaneShootChartValues returns the values for the control plane shoot chart applied by the generic actuator.
@@ -225,11 +226,12 @@ func getCCMChartValues(
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 	checksums map[string]string,
+	scaledDown bool,
 ) (map[string]interface{}, error) {
 	values := map[string]interface{}{
-		"replicas":          extensionscontroller.GetReplicas(cluster.Shoot, 1),
-		"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
+		"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster.Shoot, scaledDown, 1),
 		"clusterName":       cp.Namespace,
+		"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
 		"podNetwork":        extensionscontroller.GetPodNetwork(cluster.Shoot),
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-cloud-controller-manager":        checksums[cloudControllerManagerDeploymentName],

--- a/controllers/provider-gcp/pkg/controller/controlplane/valuesprovider_test.go
+++ b/controllers/provider-gcp/pkg/controller/controlplane/valuesprovider_test.go
@@ -197,7 +197,7 @@ var _ = Describe("ValuesProvider", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Call GetControlPlaneChartValues method and check the result
-			values, err := vp.GetControlPlaneChartValues(context.TODO(), cp, cluster, checksums)
+			values, err := vp.GetControlPlaneChartValues(context.TODO(), cp, cluster, checksums, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(ccmChartValues))
 		})

--- a/controllers/provider-openstack/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-openstack/pkg/controller/controlplane/valuesprovider.go
@@ -175,6 +175,7 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 	checksums map[string]string,
+	scaledDown bool,
 ) (map[string]interface{}, error) {
 	// Decode providerConfig
 	cpConfig := &openstack.ControlPlaneConfig{}
@@ -183,7 +184,7 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	}
 
 	// Get CCM chart values
-	return getCCMChartValues(cpConfig, cp, cluster, checksums)
+	return getCCMChartValues(cpConfig, cp, cluster, checksums, scaledDown)
 }
 
 // GetControlPlaneShootChartValues returns the values for the control plane shoot chart applied by this actuator.
@@ -231,9 +232,10 @@ func getCCMChartValues(
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 	checksums map[string]string,
+	scaledDown bool,
 ) (map[string]interface{}, error) {
 	values := map[string]interface{}{
-		"replicas":          extensionscontroller.GetReplicas(cluster.Shoot, 1),
+		"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster.Shoot, scaledDown, 1),
 		"clusterName":       cp.Namespace,
 		"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
 		"podNetwork":        extensionscontroller.GetPodNetwork(cluster.Shoot),

--- a/controllers/provider-openstack/pkg/controller/controlplane/valuesprovider_test.go
+++ b/controllers/provider-openstack/pkg/controller/controlplane/valuesprovider_test.go
@@ -217,7 +217,7 @@ var _ = Describe("ValuesProvider", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Call GetControlPlaneChartValues method and check the result
-			values, err := vp.GetControlPlaneChartValues(context.TODO(), cp, cluster, checksums)
+			values, err := vp.GetControlPlaneChartValues(context.TODO(), cp, cluster, checksums, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(ccmChartValues))
 		})

--- a/controllers/provider-packet/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-packet/pkg/controller/controlplane/valuesprovider.go
@@ -199,6 +199,7 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 	checksums map[string]string,
+	scaledDown bool,
 ) (map[string]interface{}, error) {
 	// Decode providerConfig
 	cpConfig := &apispacket.ControlPlaneConfig{}
@@ -207,7 +208,7 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	}
 
 	// Get control plane chart values
-	return getControlPlaneChartValues(cp, cluster, checksums)
+	return getControlPlaneChartValues(cp, cluster, checksums, scaledDown)
 }
 
 // GetControlPlaneShootChartValues returns the values for the control plane shoot chart applied by the generic actuator.
@@ -247,10 +248,11 @@ func getControlPlaneChartValues(
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 	checksums map[string]string,
+	scaledDown bool,
 ) (map[string]interface{}, error) {
 	values := map[string]interface{}{
 		"packet-cloud-controller-manager": map[string]interface{}{
-			"replicas":          extensionscontroller.GetReplicas(cluster.Shoot, 1),
+			"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster.Shoot, scaledDown, 1),
 			"clusterName":       cp.Namespace,
 			"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
 			"podNetwork":        extensionscontroller.GetPodNetwork(cluster.Shoot),

--- a/controllers/provider-packet/pkg/controller/controlplane/valuesprovider_test.go
+++ b/controllers/provider-packet/pkg/controller/controlplane/valuesprovider_test.go
@@ -174,7 +174,7 @@ var _ = Describe("ValuesProvider", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Call GetControlPlaneChartValues method and check the result
-			values, err := vp.GetControlPlaneChartValues(context.TODO(), cp, cluster, checksums)
+			values, err := vp.GetControlPlaneChartValues(context.TODO(), cp, cluster, checksums, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(controlPlaneChartValues))
 		})

--- a/pkg/controller/controlplane/actuator.go
+++ b/pkg/controller/controlplane/actuator.go
@@ -25,7 +25,7 @@ import (
 // Actuator acts upon ControlPlane resources.
 type Actuator interface {
 	// Reconcile reconciles the ControlPlane.
-	Reconcile(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster) error
+	Reconcile(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster) (bool, error)
 	// Delete deletes the ControlPlane.
 	Delete(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster) error
 }

--- a/pkg/controller/controlplane/genericactuator/actuator_test.go
+++ b/pkg/controller/controlplane/genericactuator/actuator_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Actuator", func() {
 			// Create mock values provider
 			vp := mockgenericactuator.NewMockValuesProvider(ctrl)
 			vp.EXPECT().GetConfigChartValues(context.TODO(), cp, cluster).Return(configChartValues, nil)
-			vp.EXPECT().GetControlPlaneChartValues(context.TODO(), cp, cluster, checksums).Return(controlPlaneChartValues, nil)
+			vp.EXPECT().GetControlPlaneChartValues(context.TODO(), cp, cluster, checksums, false).Return(controlPlaneChartValues, nil)
 			// vp.EXPECT().GetControlPlaneShootChartValues(context.TODO(), cp, cluster).Return(controlPlaneShootChartValues, nil)
 
 			// Create mock shoot clients factory
@@ -162,7 +162,8 @@ var _ = Describe("Actuator", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Call Reconcile method and check the result
-			err = a.Reconcile(context.TODO(), cp, cluster)
+			requeue, err := a.Reconcile(context.TODO(), cp, cluster)
+			Expect(requeue).To(Equal(false))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -181,7 +182,7 @@ var _ = Describe("Actuator", func() {
 
 			// Create mock values provider
 			vp := mockgenericactuator.NewMockValuesProvider(ctrl)
-			vp.EXPECT().GetControlPlaneChartValues(context.TODO(), cp, cluster, checksumsWithoutConfig).Return(controlPlaneChartValues, nil)
+			vp.EXPECT().GetControlPlaneChartValues(context.TODO(), cp, cluster, checksumsWithoutConfig, false).Return(controlPlaneChartValues, nil)
 			// vp.EXPECT().GetControlPlaneShootChartValues(context.TODO(), cp, cluster).Return(controlPlaneShootChartValues, nil)
 
 			// Create mock shoot clients factory
@@ -197,7 +198,8 @@ var _ = Describe("Actuator", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Call Reconcile method and check the result
-			err = a.Reconcile(context.TODO(), cp, cluster)
+			requeue, err := a.Reconcile(context.TODO(), cp, cluster)
+			Expect(requeue).To(Equal(false))
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/pkg/controller/shoot.go
+++ b/pkg/controller/shoot.go
@@ -52,3 +52,12 @@ func GetReplicas(shoot *gardenv1beta1.Shoot, wokenUp int) int {
 	}
 	return wokenUp
 }
+
+// GetControlPlaneReplicas returns the woken up replicas for controlplane components of the given Shoot
+// that should only be scaled down at the end of the flow.
+func GetControlPlaneReplicas(shoot *gardenv1beta1.Shoot, scaledDown bool, wokenUp int) int {
+	if IsHibernated(shoot) && scaledDown {
+		return 0
+	}
+	return wokenUp
+}

--- a/pkg/mock/gardener-extensions/controller/controlplane/genericactuator/mocks.go
+++ b/pkg/mock/gardener-extensions/controller/controlplane/genericactuator/mocks.go
@@ -53,18 +53,18 @@ func (mr *MockValuesProviderMockRecorder) GetConfigChartValues(arg0, arg1, arg2 
 }
 
 // GetControlPlaneChartValues mocks base method
-func (m *MockValuesProvider) GetControlPlaneChartValues(arg0 context.Context, arg1 *v1alpha1.ControlPlane, arg2 *controller.Cluster, arg3 map[string]string) (map[string]interface{}, error) {
+func (m *MockValuesProvider) GetControlPlaneChartValues(arg0 context.Context, arg1 *v1alpha1.ControlPlane, arg2 *controller.Cluster, arg3 map[string]string, arg4 bool) (map[string]interface{}, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetControlPlaneChartValues", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "GetControlPlaneChartValues", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(map[string]interface{})
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetControlPlaneChartValues indicates an expected call of GetControlPlaneChartValues
-func (mr *MockValuesProviderMockRecorder) GetControlPlaneChartValues(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockValuesProviderMockRecorder) GetControlPlaneChartValues(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetControlPlaneChartValues", reflect.TypeOf((*MockValuesProvider)(nil).GetControlPlaneChartValues), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetControlPlaneChartValues", reflect.TypeOf((*MockValuesProvider)(nil).GetControlPlaneChartValues), arg0, arg1, arg2, arg3, arg4)
 }
 
 // GetControlPlaneShootChartValues mocks base method


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a controlplane hibernation issue on Alicloud and all providers after 1.14

**Special notes for your reviewer**:
When the shoot is hibernated, the controlplane controllers scale down the CCM only if kube-apiserver is already scaled down, and requeue the `ControlPlane` resource until this condition holds true.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
