### PR TITLE
Fix Openstack/Azure controlplane ensurer in deletion context

### DIFF
--- a/controllers/provider-azure/pkg/webhook/controlplane/ensurer.go
+++ b/controllers/provider-azure/pkg/webhook/controlplane/ensurer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -155,6 +156,10 @@ func (e *ensurer) EnsureKubeletCloudProviderConfig(ctx context.Context, data *st
 	var cm corev1.ConfigMap
 	err := e.client.Get(ctx, kutil.Key(namespace, azure.CloudProviderConfigName), &cm)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			e.logger.Info("configmap not found", "name", azure.CloudProviderConfigName, "namespace", namespace)
+			return nil
+		}
 		return errors.Wrapf(err, "could not get configmap '%s/%s'", namespace, azure.CloudProviderConfigName)
 	}
 

--- a/controllers/provider-azure/pkg/webhook/controlplane/ensurer_test.go
+++ b/controllers/provider-azure/pkg/webhook/controlplane/ensurer_test.go
@@ -16,6 +16,8 @@ package controlplane
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"testing"
 
 	"github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/azure"
@@ -296,6 +298,21 @@ var _ = Describe("Ensurer", func() {
 			existingData = util.StringPtr("[LoadBalancer]\nlb-version=v2\nlb-provider:\n")
 			emptydata    = util.StringPtr("")
 		)
+		It("cloud provider configmap do not exist", func() {
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).Return(errors.NewNotFound(schema.GroupResource{}, cm.Name))
+
+			// Create ensurer
+			ensurer := NewEnsurer(logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Call EnsureKubeletConfiguration method and check the result
+			err = ensurer.EnsureKubeletCloudProviderConfig(context.TODO(), emptydata, namespace)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(*emptydata).To(Equal(""))
+		})
 		It("should create element containing cloud provider config content", func() {
 			// Create mock client
 			client := mockclient.NewMockClient(ctrl)

--- a/controllers/provider-openstack/pkg/webhook/controlplane/ensurer.go
+++ b/controllers/provider-openstack/pkg/webhook/controlplane/ensurer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -161,6 +162,10 @@ func (e *ensurer) EnsureKubeletCloudProviderConfig(ctx context.Context, data *st
 	var cm corev1.ConfigMap
 	err := e.client.Get(ctx, kutil.Key(namespace, openstack.CloudProviderConfigName), &cm)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			e.logger.Info("configmap not found", "name", openstack.CloudProviderConfigName, "namespace", namespace)
+			return nil
+		}
 		return errors.Wrapf(err, "could not get configmap '%s/%s'", namespace, openstack.CloudProviderConfigName)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In case the deletion of shoot has been triggered, the controlplane webhook is trying to reconcile the OperatingSystemConfig, but some of the resources are already deleted. This leads to constant loop.

**Special notes for your reviewer**:
This behaviour is found in Openstack and Azure extension providers

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Fix Openstack/Azure controlplane ensurer when deleting shoot
```
