### PR TITLE
[ci:component:github.com/gardener/machine-controller-manager:0.18.0->0.19.0]

### DIFF
--- a/controllers/provider-alicloud/charts/images.yaml
+++ b/controllers/provider-alicloud/charts/images.yaml
@@ -6,7 +6,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.18.0"
+  tag: "0.19.0"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl

--- a/controllers/provider-aws/charts/images.yaml
+++ b/controllers/provider-aws/charts/images.yaml
@@ -9,7 +9,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.18.0"
+  tag: "0.19.0"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl

--- a/controllers/provider-azure/charts/images.yaml
+++ b/controllers/provider-azure/charts/images.yaml
@@ -9,7 +9,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.18.0"
+  tag: "0.19.0"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl

--- a/controllers/provider-gcp/charts/images.yaml
+++ b/controllers/provider-gcp/charts/images.yaml
@@ -9,7 +9,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.18.0"
+  tag: "0.19.0"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl

--- a/controllers/provider-openstack/charts/images.yaml
+++ b/controllers/provider-openstack/charts/images.yaml
@@ -9,7 +9,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.18.0"
+  tag: "0.19.0"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl

--- a/controllers/provider-packet/charts/images.yaml
+++ b/controllers/provider-packet/charts/images.yaml
@@ -10,11 +10,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-# The machine-controller-manager contains a fix in commit 67239235d15eb3d8d0b384bb1ff4067ae5b0e153 for Packet which is required.
-# However, there is not yet a new release of MCM. Thus, we keep referencing the latest MCM (0.18.0) without the fix to make the
-# component descriptor work properly. The Packet worker controller, however, requires the mentioned fix to function properly.
-# tag: "0.19.0-dev-67239235d15eb3d8d0b384bb1ff4067ae5b0e153"
-  tag: "0.18.0"
+  tag: "0.19.0"
 - name: csi-attacher
   sourceRepository: https://github.com/kubernetes-csi/external-attacher
   repository: quay.io/k8scsi/csi-attacher


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/machine-controller-manager #279 @amshuman-kr
Fix panic in AWS driver if AMI not found.
```

``` improvement operator github.com/gardener/machine-controller-manager #273 @deitch
Fixes packet driver
```

``` noteworthy operator github.com/gardener/machine-controller-manager #261 @prashanth26
Update Azure SDK from 12.5-beta to 26.1
```

``` improvement operator github.com/gardener/machine-controller-manager #261 @prashanth26
Ensure 'x-ms-request-id' header is logged in case of Azure API failures.
```

``` noteworthy user github.com/gardener/machine-controller-manager #261 @prashanth26
Orphan VMs/disks/NICs handler has been fixed
```