### PR TITLE
Fix contains string with prefix bug

### DIFF
--- a/controllers/provider-alicloud/pkg/webhook/controlplane/ensurer.go
+++ b/controllers/provider-alicloud/pkg/webhook/controlplane/ensurer.go
@@ -65,6 +65,14 @@ func ensureKubeAPIServerCommandLineArgs(c *corev1.Container) {
 		"PersistentVolumeLabel", ",")
 
 	// Ensure CSI-related feature gates
+	c.Command = controlplane.EnsureNoStringWithPrefixContains(c.Command, "--feature-gates=",
+		"VolumeSnapshotDataSource=false", ",")
+	c.Command = controlplane.EnsureNoStringWithPrefixContains(c.Command, "--feature-gates=",
+		"CSINodeInfo=false", ",")
+	c.Command = controlplane.EnsureNoStringWithPrefixContains(c.Command, "--feature-gates=",
+		"CSIDriverRegistry=false", ",")
+	c.Command = controlplane.EnsureNoStringWithPrefixContains(c.Command, "--feature-gates=",
+		"KubeletPluginsWatcher=false", ",")
 	c.Command = controlplane.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
 		"VolumeSnapshotDataSource=true", ",")
 	c.Command = controlplane.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",

--- a/controllers/provider-packet/pkg/webhook/controlplane/ensurer.go
+++ b/controllers/provider-packet/pkg/webhook/controlplane/ensurer.go
@@ -75,6 +75,14 @@ func ensureKubeAPIServerCommandLineArgs(c *corev1.Container) {
 		"PersistentVolumeLabel", ",")
 
 	// Ensure CSI-related feature gates
+	c.Command = controlplane.EnsureNoStringWithPrefixContains(c.Command, "--feature-gates=",
+		"VolumeSnapshotDataSource=false", ",")
+	c.Command = controlplane.EnsureNoStringWithPrefixContains(c.Command, "--feature-gates=",
+		"CSINodeInfo=false", ",")
+	c.Command = controlplane.EnsureNoStringWithPrefixContains(c.Command, "--feature-gates=",
+		"CSIDriverRegistry=false", ",")
+	c.Command = controlplane.EnsureNoStringWithPrefixContains(c.Command, "--feature-gates=",
+		"KubeletPluginsWatcher=false", ",")
 	c.Command = controlplane.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
 		"VolumeSnapshotDataSource=true", ",")
 	c.Command = controlplane.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",

--- a/pkg/webhook/controlplane/utils.go
+++ b/pkg/webhook/controlplane/utils.go
@@ -108,7 +108,11 @@ func EnsureStringWithPrefixContains(items []string, prefix, value, sep string) [
 	if i := StringWithPrefixIndex(items, prefix); i < 0 {
 		items = append(items, prefix+value)
 	} else {
-		values := strings.Split(strings.TrimPrefix(items[i], prefix), sep)
+		valuesList := strings.TrimPrefix(items[i], prefix)
+		var values []string
+		if valuesList != "" {
+			values = strings.Split(valuesList, sep)
+		}
 		if j := StringIndex(values, value); j < 0 {
 			values = append(values, value)
 			items = append(append(items[:i], prefix+strings.Join(values, sep)), items[i+1:]...)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a possible bug/Makes it easier to read when there is need to ensure an element in a string list with no elements to remove a leading comma.
Removes duplication elements with wrong value for the command line arg "--feature-gates=" in the kube apiserver for packet and alicloud providers.

**Release note**:
```improvement operator
NONE
```
