### PR TITLE
Qualify image names

### DIFF
--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -2,7 +2,7 @@
 
 set -e
 
-descriptor_file="${COMPONENT_DESCRIPTOR_PATH}"
+descriptor_out_file="${COMPONENT_DESCRIPTOR_PATH}"
 dir="$(dirname "$0")"
 
 for images_yaml_path in "$dir/../controllers/"*"/charts/images.yaml"; do
@@ -22,4 +22,4 @@ for images_yaml_path in "$dir/../controllers/"*"/charts/images.yaml"; do
     join(\" \\\\\n\")" <<< "$images")"
 done
 
-cp "${BASE_DEFINITION_PATH}" "${COMPONENT_DESCRIPTOR_PATH}"
+cp "${BASE_DEFINITION_PATH}" "${descriptor_out_file}"

--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -9,6 +9,7 @@ for images_yaml_path in "$dir/../controllers/"*"/charts/images.yaml"; do
   images="$(yaml2json < $images_yaml_path)"
 
   echo "enriching creating component descriptor from ${BASE_DEFINITION_PATH}"
+  controller_dir="$(basename "$(dirname "$(dirname "${images_yaml_path}")")")"
 
   eval "$(jq -r ".images |
     map(if (.name == \"hyperkube\") then
@@ -16,7 +17,7 @@ for images_yaml_path in "$dir/../controllers/"*"/charts/images.yaml"; do
     elif (.repository | startswith(\"eu.gcr.io/gardener-project/gardener\")) then
       \"--component-dependencies '{\\\"name\\\": \\\"\" + .sourceRepository + \"\\\", \\\"version\\\": \\\"\" + .tag + \"\\\"}'\"
     else
-      \"--container-image-dependencies '{\\\"name\\\": \\\"\" + .name + \"\\\", \\\"image_reference\\\": \\\"\" + .repository + \":\" + .tag + \"\\\", \\\"version\\\": \\\"\" + .tag + \"\\\"}'\"
+      \"--container-image-dependencies '{\\\"name\\\": \\\"${controller_dir}-\" + .name + \"\\\", \\\"image_reference\\\": \\\"\" + .repository + \":\" + .tag + \"\\\", \\\"version\\\": \\\"\" + .tag + \"\\\"}'\"
     end) |
     \"${ADD_DEPENDENCIES_CMD} \\\\\n\" +
     join(\" \\\\\n\")" <<< "$images")"


### PR DESCRIPTION
**What this PR does / why we need it**:

Controllers are independent components. They are currently grouped in
one common repository temporarily for pragmatic reasons (planned to be
split into multiple repositories "soon").

For the time being, include component names into logical image names so
that the declaring component is expressed in the `component_descriptor`
emitted from release builds.