### PR TITLE
Adapt CCM pod requests based on VPA recommendations

### DIFF
--- a/controllers/provider-aws/charts/internal/cloud-controller-manager/values.yaml
+++ b/controllers/provider-aws/charts/internal/cloud-controller-manager/values.yaml
@@ -10,8 +10,8 @@ images:
   hyperkube: image-repository:image-tag
 resources:
   requests:
-    cpu: 100m
-    memory: 64Mi
+    cpu: 11m
+    memory: 75Mi
   limits:
     cpu: 500m
     memory: 512Mi

--- a/controllers/provider-azure/charts/internal/cloud-controller-manager/values.yaml
+++ b/controllers/provider-azure/charts/internal/cloud-controller-manager/values.yaml
@@ -10,8 +10,8 @@ images:
   hyperkube: image-repository:image-tag
 resources:
   requests:
-    cpu: 100m
-    memory: 64Mi
+    cpu: 11m
+    memory: 75Mi
   limits:
     cpu: 500m
     memory: 512Mi

--- a/controllers/provider-gcp/charts/internal/cloud-controller-manager/values.yaml
+++ b/controllers/provider-gcp/charts/internal/cloud-controller-manager/values.yaml
@@ -10,8 +10,8 @@ images:
   hyperkube: image-repository:image-tag
 resources:
   requests:
-    cpu: 100m
-    memory: 64Mi
+    cpu: 23m
+    memory: 75Mi
   limits:
     cpu: 500m
     memory: 512Mi


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to better utilize the Seed nodes and thus also save costs, the pods of the Shoot control plane should only request the resources they really need.
Based on the evaluation of the VPA recommendations for all Shoots on our Canary and Live landscape over a few weeks, the new values reflects the average CPU and memory recommendations for the cloud controller manager pod.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```NONE```
