### PR TITLE
Adapt requests for etcd backup-restore sidecar based on VPA recommendations

### DIFF
--- a/pkg/webhook/controlplane/etcd.go
+++ b/pkg/webhook/controlplane/etcd.go
@@ -68,7 +68,7 @@ func GetBackupRestoreContainer(
 		},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceCPU:    resource.MustParse("23m"),
 				corev1.ResourceMemory: resource.MustParse("128Mi"),
 			},
 			Limits: corev1.ResourceList{


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to better utilize the Seed nodes, the pods of the Shoot control plane should only request the resources they really need.
Based on the evaluation of the VPA recommendations for all Shoots on our Canary and Live landscape over a few weeks, the new value reflects the maximum recommendation for the ETCD backup-restore container.
This maximum value also ensures that the ETCD pods aren't evicted from a node at normal scenarios because of exhausted node resources.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@swapnilgm 

**Release note**:
```
NONE
```
