### PR TITLE
PR-Template: add developer target group

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ Fixes #
 Format of block header: <category> <target_group>
 Possible values:
 - category:       improvement|noteworthy|action
-- target_group:   user|operator
+- target_group:   user|operator|developer
 -->
 ```improvement operator
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the `developer` target group

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
`developer` target group was introduced with https://github.com/gardener/cc-utils/pull/303

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
