### PR TITLE
Added delay before removing OpenStack cloud controller manager

### DIFF
--- a/controllers/provider-openstack/pkg/controller/controlplane/add.go
+++ b/controllers/provider-openstack/pkg/controller/controlplane/add.go
@@ -37,9 +37,9 @@ var (
 // The opts.Reconciler is being set with a newly instantiated actuator.
 func AddToManagerWithOptions(mgr manager.Manager, opts controller.Options) error {
 	return controlplane.Add(mgr, controlplane.AddArgs{
-		Actuator: genericactuator.NewActuator(controlPlaneSecrets, configChart, ccmChart, ccmShootChart,
+		Actuator: &wrapper{genericactuator.NewActuator(controlPlaneSecrets, configChart, ccmChart, ccmShootChart,
 			NewValuesProvider(logger), genericactuator.ChartRendererFactoryFunc(util.NewChartRendererForShoot),
-			imagevector.ImageVector(), openstack.CloudProviderConfigName, logger),
+			imagevector.ImageVector(), openstack.CloudProviderConfigName, logger)},
 		Type:              openstack.Type,
 		ControllerOptions: opts,
 	})

--- a/controllers/provider-openstack/pkg/controller/controlplane/wrapper.go
+++ b/controllers/provider-openstack/pkg/controller/controlplane/wrapper.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane
+
+import (
+	"context"
+	"github.com/gardener/gardener-extensions/pkg/controller"
+	"github.com/gardener/gardener-extensions/pkg/controller/controlplane"
+	"github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"time"
+)
+
+type wrapper struct {
+	controlplane.Actuator
+}
+
+func (w *wrapper) Delete(ctx context.Context, cp *v1alpha1.ControlPlane, cluster *controller.Cluster) error {
+	// TODO: Dirty fix. Nothing to see here. This needs to be refactored!!!!
+	// 		 In the future use gophercloud to check whether there are LoadBalancers which belong to any
+	// 		 Shoot worker subnet work (have ports in the worker subnetwork).
+	time.Sleep(4 * time.Minute)
+	return w.Actuator.Delete(ctx, cp, cluster)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a 4 minute delay before removing the OpenStack control plane. That way we give the `cloud-controller-manager` enough time to properly cleanup services with their corresponding load balancer instances.

**Which issue(s) this PR fixes**:
Needed due to #161 

**Special notes for your reviewer**:
This is just a temporary fix to mitigate the issues we are currently experiencing. Should be refactored in the future.

**Release note**:
```improvement operator
Added a 4 minutes delay before removing OpenStack cloud controller manager
```
