### PR TITLE
Create Credentialless Cloud-Config for Azure Workers

### DIFF
--- a/controllers/provider-azure/charts/internal/cloud-provider-config/templates/azure-credentials.tpl
+++ b/controllers/provider-azure/charts/internal/cloud-provider-config/templates/azure-credentials.tpl
@@ -1,0 +1,6 @@
+{{- define "azure-credentials"}}
+aadClientId: "{{ .Values.aadClientId }}"
+aadClientSecret: "{{ .Values.aadClientSecret }}"
+tenantId: "{{ .Values.tenantId }}"
+subscriptionId: "{{ .Values.subscriptionId }}"
+{{- end }}

--- a/controllers/provider-azure/charts/internal/cloud-provider-config/templates/cloud-provider-config.tpl
+++ b/controllers/provider-azure/charts/internal/cloud-provider-config/templates/cloud-provider-config.tpl
@@ -1,0 +1,23 @@
+{{- define "cloud-provider-config"}}
+cloud: AZUREPUBLICCLOUD
+resourceGroup: "{{ .Values.resourceGroup }}"
+location: "{{ .Values.region }}"
+vnetName: "{{ .Values.vnetName }}"
+subnetName: "{{ .Values.subnetName }}"
+securityGroupName: "{{ .Values.securityGroupName }}"
+routeTableName: "{{ .Values.routeTableName }}"
+primaryAvailabilitySetName: "{{ .Values.availabilitySetName }}"
+cloudProviderBackoff: true
+cloudProviderBackoffRetries: 6
+cloudProviderBackoffExponent: 1.5
+cloudProviderBackoffDuration: 5
+cloudProviderBackoffJitter: 1.0
+cloudProviderRateLimit: true
+cloudProviderRateLimitQPS: 10.0
+cloudProviderRateLimitBucket: 100
+cloudProviderRateLimitQPSWrite: 10.0
+cloudProviderRateLimitBucketWrite: 100
+{{- if semverCompare ">= 1.14" .Values.kubernetesVersion }}
+cloudProviderBackoffMode: v2
+{{- end }}
+{{- end }}

--- a/controllers/provider-azure/charts/internal/cloud-provider-config/templates/cloud-provider-config.yaml
+++ b/controllers/provider-azure/charts/internal/cloud-provider-config/templates/cloud-provider-config.yaml
@@ -5,28 +5,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   cloudprovider.conf: |
-    cloud: AZUREPUBLICCLOUD
-    tenantId: "{{ .Values.tenantId }}"
-    subscriptionId: "{{ .Values.subscriptionId }}"
-    resourceGroup: "{{ .Values.resourceGroup }}"
-    location: "{{ .Values.region }}"
-    vnetName: "{{ .Values.vnetName }}"
-    subnetName: "{{ .Values.subnetName }}"
-    securityGroupName: "{{ .Values.securityGroupName }}"
-    routeTableName: "{{ .Values.routeTableName }}"
-    primaryAvailabilitySetName: "{{ .Values.availabilitySetName }}"
-    aadClientId: "{{ .Values.aadClientId }}"
-    aadClientSecret: "{{ .Values.aadClientSecret }}"
-    cloudProviderBackoff: true
-    cloudProviderBackoffRetries: 6
-    cloudProviderBackoffExponent: 1.5
-    cloudProviderBackoffDuration: 5
-    cloudProviderBackoffJitter: 1.0
-    cloudProviderRateLimit: true
-    cloudProviderRateLimitQPS: 10.0
-    cloudProviderRateLimitBucket: 100
-    cloudProviderRateLimitQPSWrite: 10.0
-    cloudProviderRateLimitBucketWrite: 100
-{{- if semverCompare ">= 1.14" .Values.kubernetesVersion }}
-    cloudProviderBackoffMode: v2
-{{end}}
+    {{- include "azure-credentials" . | indent 4 }}
+    {{- include "cloud-provider-config" . | indent 4 }}

--- a/controllers/provider-azure/charts/internal/cloud-provider-config/templates/cloud-provider-worker-config.yaml
+++ b/controllers/provider-azure/charts/internal/cloud-provider-config/templates/cloud-provider-worker-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloud-provider-worker-config
+  namespace: {{ .Release.Namespace }}
+data:
+  cloudprovider.conf: |
+    {{- include "cloud-provider-config" .  | indent 4}}
+    {{- if semverCompare "< 1.15" .Values.kubernetesVersion }}
+    {{- include "azure-credentials" .   | indent 4 }}
+    {{- else }}
+    useInstanceMetadata: true
+    {{- end}}

--- a/controllers/provider-azure/pkg/azure/types.go
+++ b/controllers/provider-azure/pkg/azure/types.go
@@ -65,6 +65,8 @@ const (
 
 	// CloudProviderConfigName is the name of the configmap containing the cloud provider config.
 	CloudProviderConfigName = "cloud-provider-config"
+	// CloudProviderKubeletConfigName is the name of the configmap containing the cloud provider config for the shoot nodes.
+	CloudProviderKubeletConfigName = "cloud-provider-kubelet-config"
 	// CloudProviderConfigMapKey is the key storing the cloud provider config as value in the cloud provider configmap.
 	CloudProviderConfigMapKey = "cloudprovider.conf"
 	// BackupSecretName is the name of the secret containing the credentials for storing the backups of Shoot clusters.

--- a/controllers/provider-azure/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-azure/pkg/controller/controlplane/valuesprovider.go
@@ -16,8 +16,9 @@ package controlplane
 
 import (
 	"context"
-	"github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/azure"
 	"path/filepath"
+
+	"github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/azure"
 
 	apisazure "github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/apis/azure"
 	azureapihelper "github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/apis/azure/helper"
@@ -96,6 +97,10 @@ var configChart = &chart.Chart{
 		{
 			Type: &corev1.ConfigMap{},
 			Name: azure.CloudProviderConfigName,
+		},
+		{
+			Type: &corev1.ConfigMap{},
+			Name: azure.CloudProviderKubeletConfigName,
 		},
 	},
 }

--- a/controllers/provider-azure/pkg/webhook/controlplane/ensurer.go
+++ b/controllers/provider-azure/pkg/webhook/controlplane/ensurer.go
@@ -162,13 +162,13 @@ func (e *ensurer) ShouldProvisionKubeletCloudProviderConfig() bool {
 func (e *ensurer) EnsureKubeletCloudProviderConfig(ctx context.Context, data *string, namespace string) error {
 	// Get `cloud-provider-config` ConfigMap
 	var cm corev1.ConfigMap
-	err := e.client.Get(ctx, kutil.Key(namespace, azure.CloudProviderConfigName), &cm)
+	err := e.client.Get(ctx, kutil.Key(namespace, azure.CloudProviderKubeletConfigName), &cm)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			e.logger.Info("configmap not found", "name", azure.CloudProviderConfigName, "namespace", namespace)
+			e.logger.Info("configmap not found", "name", azure.CloudProviderKubeletConfigName, "namespace", namespace)
 			return nil
 		}
-		return errors.Wrapf(err, "could not get configmap '%s/%s'", namespace, azure.CloudProviderConfigName)
+		return errors.Wrapf(err, "could not get configmap '%s/%s'", namespace, azure.CloudProviderKubeletConfigName)
 	}
 
 	// Check if the data has "cloudprovider.conf" key

--- a/controllers/provider-azure/pkg/webhook/controlplane/ensurer_test.go
+++ b/controllers/provider-azure/pkg/webhook/controlplane/ensurer_test.go
@@ -301,6 +301,12 @@ var _ = Describe("Ensurer", func() {
 
 	Describe("#EnsureKubeletCloudProviderConfig", func() {
 		var (
+			cmKey = client.ObjectKey{Namespace: namespace, Name: azure.CloudProviderKubeletConfigName}
+			cm    = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: azure.CloudProviderKubeletConfigName},
+				Data:       map[string]string{"abc": "xyz", azure.CloudProviderConfigMapKey: cloudProviderConfigContent},
+			}
+
 			existingData = util.StringPtr("[LoadBalancer]\nlb-version=v2\nlb-provider:\n")
 			emptydata    = util.StringPtr("")
 		)


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove Azure credentials from cloud-config for 1.15 as they are not needed anymore. For more informtaion, please refer to: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.15.md#azure 

**Release note**:

```noteworthy operator
Azure cloud-config no longer requires credentials. 
```
