### PR TITLE
Fix dep ensure

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -240,7 +240,7 @@
   revision = "d6023ce2651d8eafb5c75bb0c7167536102ec9f5"
 
 [[projects]]
-  digest = "1:c2432108a9b93c9c6921e48daeecedb9761f12d0e940781de94feccb2797ced8"
+  digest = "1:afd5968376dffe6c6020a0cd70278738b8c452cb3519183a23c33f0c8265c07b"
   name = "github.com/gardener/gardener"
   packages = [
     "pkg/apis/core",
@@ -276,7 +276,7 @@
     "pkg/utils/secrets",
   ]
   pruneopts = "NUT"
-  revision = "0fe4fccadc48e62b6f7d7a4a6965dfa369f90531"
+  revision = "641367fd36d54086712027f337effcb6c9f950cf"
 
 [[projects]]
   digest = "1:786c4c7a02ae4fe79962043b651dc0d187cc3935f7d2e33451b4cd7ca8c21f90"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,7 +9,7 @@ required = [
 
 [[override]]
   name = "github.com/gardener/gardener"
-  revision = "0fe4fccadc48e62b6f7d7a4a6965dfa369f90531"
+  revision = "641367fd36d54086712027f337effcb6c9f950cf"
 
 [[override]]
   name = "github.com/gardener/machine-controller-manager"

--- a/vendor/github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/types_network.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/types_network.go
@@ -48,10 +48,8 @@ type NetworkList struct {
 type NetworkSpec struct {
 	// DefaultSpec is a structure containing common fields used by all extension resources.
 	DefaultSpec `json:",inline"`
-	// CloudProvider is the type of the cloud provider (e.g., aws, azure, gcp,...)
-	CloudProvider string `json:"cloudProvider,omitempty"`
-	// ClusterCIDR defines the CIDR that will be used for pods.
-	ClusterCIDR string `json:"clusterCIDR"`
+	// PodCIDR defines the CIDR that will be used for pods.
+	PodCIDR string `json:"podCIDR"`
 	// ServiceCIDR defines the CIDR that will be used for services.
 	ServiceCIDR string `json:"serviceNetworkCIDR"`
 	// ProviderConfig contains plugin-specific configuration.


### PR DESCRIPTION
**What this PR does / why we need it**:
Trying locally `dep ensure -v` was failing with:
```
$ dep ensure -v
[...]
Solving failure: No versions of github.com/gardener/gardener met constraints:
    0fe4fccadc48e62b6f7d7a4a6965dfa369f90531: unable to update checked out version: fatal: reference is not a tree: 0fe4fccadc48e62b6f7d7a4a6965dfa369f90531
: command failed: [git checkout 0fe4fccadc48e62b6f7d7a4a6965dfa369f90531]: exit status 128
```

On a newly cloned g/gardener:
```
git read-tree 0fe4fccadc48e62b6f7d7a4a6965dfa369f90531
fatal: failed to unpack tree object 0fe4fccadc48e62b6f7d7a4a6965dfa369f90531
```

I changed the revision to point https://github.com/gardener/gardener/commit/641367fd36d54086712027f337effcb6c9f950cf (on branch `gardener-extension-fixes`).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
