### PR TITLE
remove runtimeVersion (>= 1.14.x) specification for alicloud

### DIFF
--- a/controllers/provider-alicloud/charts/images.yaml
+++ b/controllers/provider-alicloud/charts/images.yaml
@@ -24,7 +24,6 @@ images:
   sourceRepository: https://github.com/kubernetes-csi/external-attacher
   repository: quay.io/k8scsi/csi-attacher
   tag: v1.1.0
-  runtimeVersion: 1.14.x
 - name: csi-node-driver-registrar
   sourceRepository: https://github.com/kubernetes-csi/node-driver-registrar
   repository: quay.io/k8scsi/csi-node-driver-registrar
@@ -34,7 +33,6 @@ images:
   sourceRepository: https://github.com/kubernetes-csi/node-driver-registrar
   repository: quay.io/k8scsi/csi-node-driver-registrar
   tag: v1.1.0
-  runtimeVersion: 1.14.x
 - name: csi-provisioner
   sourceRepository: https://github.com/kubernetes-csi/external-provisioner
   repository: quay.io/k8scsi/csi-provisioner
@@ -44,7 +42,6 @@ images:
   sourceRepository: https://github.com/kubernetes-csi/external-provisioner
   repository: quay.io/k8scsi/csi-provisioner
   tag: v1.1.0
-  runtimeVersion: 1.14.x
 - name: csi-snapshotter
   sourceRepository: https://github.com/kubernetes-csi/external-snapshotter
   repository: quay.io/k8scsi/csi-snapshotter
@@ -54,7 +51,6 @@ images:
   sourceRepository: https://github.com/kubernetes-csi/external-snapshotter
   repository: quay.io/k8scsi/csi-snapshotter
   tag: v1.1.0
-  runtimeVersion: 1.14.x
 - name: csi-plugin-alicloud
   sourceRepository: https://github.com/AliyunContainerService/csi-plugin
   repository: registry.eu-central-1.aliyuncs.com/gardener-de/csi-plugin-alicloud


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove runtimeVersion specification in image lists of alicloud where runtimeVersion is not 1.13.x. Doing this avoids adding new specifically versioned items in images.yaml at the time of version update (every version shares the same image specification if it does not require a specific version of image).

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The provider extension controllers for Alicloud do now support Kubernetes v1.15.0.
```
