### PR TITLE
Deploy MCM during Worker deletion

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -264,7 +264,7 @@
   revision = "d6023ce2651d8eafb5c75bb0c7167536102ec9f5"
 
 [[projects]]
-  digest = "1:92add65e821b01c8afeda93e3c596711bdf71ea24743ad89edfda7030a8946de"
+  digest = "1:6eceb113b7b20911587e774e0604de686384694e7ddfdf548743a4785aee2eac"
   name = "github.com/gardener/gardener"
   packages = [
     "pkg/api/extensions",
@@ -1841,9 +1841,9 @@
     "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1",
     "github.com/gardener/machine-controller-manager/pkg/client/clientset/versioned/scheme",
     "github.com/go-logr/logr",
+    "github.com/go-logr/zapr",
     "github.com/gobuffalo/packr",
     "github.com/gobuffalo/packr/v2",
-    "github.com/gobuffalo/packr/v2/file/resolver",
     "github.com/golang/mock/gomock",
     "github.com/onsi/ginkgo",
     "github.com/onsi/ginkgo/extensions/table",
@@ -1855,6 +1855,8 @@
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",
     "github.com/spf13/pflag",
+    "go.uber.org/zap",
+    "go.uber.org/zap/zapcore",
     "golang.org/x/oauth2",
     "golang.org/x/oauth2/google",
     "google.golang.org/api/compute/v1",
@@ -1897,7 +1899,6 @@
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/kubernetes/typed/core/v1",
     "k8s.io/client-go/rest",
-    "k8s.io/client-go/tools/cache",
     "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/tools/record",
     "k8s.io/client-go/util/retry",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -132,6 +132,18 @@ version = "0.40.0"
   name = "github.com/golang/mock"
   version = "1.2.0"
 
+[[constraint]]
+  name = "github.com/go-logr/logr"
+  version = "v0.1.0"
+
+[[constraint]]
+  name = "github.com/go-logr/zapr"
+  version = "v0.1.0"
+
+[[constraint]]
+  name = "go.uber.org/zap"
+  version = "v1.9.1"
+
 [prune]
   unused-packages = true
   go-tests = true

--- a/controllers/extension-certificate-service/cmd/main.go
+++ b/controllers/extension-certificate-service/cmd/main.go
@@ -17,13 +17,14 @@ package main
 import (
 	"github.com/gardener/gardener-extensions/controllers/extension-certificate-service/cmd/app"
 	"github.com/gardener/gardener-extensions/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"github.com/gardener/gardener-extensions/pkg/log"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	controllercmd "github.com/gardener/gardener-extensions/pkg/controller/cmd"
 )
 
 func main() {
-	log.SetLogger(log.ZapLogger(false))
+	runtimelog.SetLogger(log.ZapLogger(false))
 
 	cmd := app.NewServiceControllerCommand(controller.SetupSignalHandlerContext())
 	if err := cmd.Execute(); err != nil {

--- a/controllers/hyper/cmd/gardener-extension-hyper/main.go
+++ b/controllers/hyper/cmd/gardener-extension-hyper/main.go
@@ -3,13 +3,14 @@ package main
 import (
 	"github.com/gardener/gardener-extensions/controllers/hyper/cmd/gardener-extension-hyper/app"
 	"github.com/gardener/gardener-extensions/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"github.com/gardener/gardener-extensions/pkg/log"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	controllercmd "github.com/gardener/gardener-extensions/pkg/controller/cmd"
 )
 
 func main() {
-	log.SetLogger(log.ZapLogger(false))
+	runtimelog.SetLogger(log.ZapLogger(false))
 	cmd := app.NewHyperCommand(controller.SetupSignalHandlerContext())
 
 	if err := cmd.Execute(); err != nil {

--- a/controllers/os-coreos-alicloud/cmd/gardener-extension-os-coreos-alicloud/main.go
+++ b/controllers/os-coreos-alicloud/cmd/gardener-extension-os-coreos-alicloud/main.go
@@ -18,11 +18,12 @@ import (
 	"github.com/gardener/gardener-extensions/controllers/os-coreos-alicloud/cmd/gardener-extension-os-coreos-alicloud/app"
 	"github.com/gardener/gardener-extensions/pkg/controller"
 	controllercmd "github.com/gardener/gardener-extensions/pkg/controller/cmd"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"github.com/gardener/gardener-extensions/pkg/log"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 func main() {
-	log.SetLogger(log.ZapLogger(false))
+	runtimelog.SetLogger(log.ZapLogger(false))
 	cmd := app.NewControllerCommand(controller.SetupSignalHandlerContext())
 
 	if err := cmd.Execute(); err != nil {

--- a/controllers/os-coreos/cmd/gardener-extension-os-coreos/main.go
+++ b/controllers/os-coreos/cmd/gardener-extension-os-coreos/main.go
@@ -17,13 +17,14 @@ package main
 import (
 	"github.com/gardener/gardener-extensions/controllers/os-coreos/cmd/gardener-extension-os-coreos/app"
 	"github.com/gardener/gardener-extensions/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"github.com/gardener/gardener-extensions/pkg/log"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	controllercmd "github.com/gardener/gardener-extensions/pkg/controller/cmd"
 )
 
 func main() {
-	log.SetLogger(log.ZapLogger(false))
+	runtimelog.SetLogger(log.ZapLogger(false))
 	cmd := app.NewControllerCommand(controller.SetupSignalHandlerContext())
 
 	if err := cmd.Execute(); err != nil {

--- a/controllers/os-suse-jeos/cmd/gardener-extension-os-suse-jeos/main.go
+++ b/controllers/os-suse-jeos/cmd/gardener-extension-os-suse-jeos/main.go
@@ -18,11 +18,12 @@ import (
 	"github.com/gardener/gardener-extensions/controllers/os-suse-jeos/cmd/gardener-extension-os-suse-jeos/app"
 	extcontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	controllercmd "github.com/gardener/gardener-extensions/pkg/controller/cmd"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"github.com/gardener/gardener-extensions/pkg/log"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 func main() {
-	log.SetLogger(log.ZapLogger(false))
+	runtimelog.SetLogger(log.ZapLogger(false))
 
 	cmd := app.NewControllerCommand(extcontroller.SetupSignalHandlerContext())
 

--- a/controllers/os-ubuntu/cmd/gardener-extension-os-ubuntu/main.go
+++ b/controllers/os-ubuntu/cmd/gardener-extension-os-ubuntu/main.go
@@ -20,11 +20,12 @@ import (
 
 	"github.com/gardener/gardener-extensions/controllers/os-ubuntu/cmd/gardener-extension-os-ubuntu/app"
 	extcontroller "github.com/gardener/gardener-extensions/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"github.com/gardener/gardener-extensions/pkg/log"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 func main() {
-	log.SetLogger(log.ZapLogger(false))
+	runtimelog.SetLogger(log.ZapLogger(false))
 
 	cmd := app.NewControllerCommand(extcontroller.SetupSignalHandlerContext())
 

--- a/controllers/provider-alicloud/cmd/gardener-extension-provider-alicloud/main.go
+++ b/controllers/provider-alicloud/cmd/gardener-extension-provider-alicloud/main.go
@@ -19,11 +19,12 @@ import (
 	"github.com/gardener/gardener-extensions/pkg/controller"
 
 	controllercmd "github.com/gardener/gardener-extensions/pkg/controller/cmd"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"github.com/gardener/gardener-extensions/pkg/log"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 func main() {
-	log.SetLogger(log.ZapLogger(false))
+	runtimelog.SetLogger(log.ZapLogger(false))
 	cmd := app.NewControllerManagerCommand(controller.SetupSignalHandlerContext())
 
 	if err := cmd.Execute(); err != nil {

--- a/controllers/provider-aws/cmd/gardener-extension-provider-aws/main.go
+++ b/controllers/provider-aws/cmd/gardener-extension-provider-aws/main.go
@@ -19,11 +19,12 @@ import (
 	"github.com/gardener/gardener-extensions/pkg/controller"
 
 	controllercmd "github.com/gardener/gardener-extensions/pkg/controller/cmd"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"github.com/gardener/gardener-extensions/pkg/log"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 func main() {
-	log.SetLogger(log.ZapLogger(false))
+	runtimelog.SetLogger(log.ZapLogger(false))
 	cmd := app.NewControllerManagerCommand(controller.SetupSignalHandlerContext())
 
 	if err := cmd.Execute(); err != nil {

--- a/controllers/provider-azure/cmd/gardener-extension-provider-azure/main.go
+++ b/controllers/provider-azure/cmd/gardener-extension-provider-azure/main.go
@@ -19,11 +19,12 @@ import (
 	"github.com/gardener/gardener-extensions/pkg/controller"
 
 	controllercmd "github.com/gardener/gardener-extensions/pkg/controller/cmd"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"github.com/gardener/gardener-extensions/pkg/log"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 func main() {
-	log.SetLogger(log.ZapLogger(false))
+	runtimelog.SetLogger(log.ZapLogger(false))
 	cmd := app.NewControllerManagerCommand(controller.SetupSignalHandlerContext())
 
 	if err := cmd.Execute(); err != nil {

--- a/controllers/provider-gcp/cmd/gardener-extension-provider-gcp/main.go
+++ b/controllers/provider-gcp/cmd/gardener-extension-provider-gcp/main.go
@@ -19,11 +19,12 @@ import (
 	"github.com/gardener/gardener-extensions/pkg/controller"
 	controllercmd "github.com/gardener/gardener-extensions/pkg/controller/cmd"
 
-	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"github.com/gardener/gardener-extensions/pkg/log"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 func main() {
-	log.SetLogger(log.ZapLogger(false))
+	runtimelog.SetLogger(log.ZapLogger(false))
 	cmd := app.NewControllerManagerCommand(controller.SetupSignalHandlerContext())
 
 	if err := cmd.Execute(); err != nil {

--- a/controllers/provider-openstack/cmd/gardener-extension-provider-openstack/main.go
+++ b/controllers/provider-openstack/cmd/gardener-extension-provider-openstack/main.go
@@ -18,11 +18,13 @@ import (
 	"github.com/gardener/gardener-extensions/controllers/provider-openstack/cmd/gardener-extension-provider-openstack/app"
 	"github.com/gardener/gardener-extensions/pkg/controller"
 	controllercmd "github.com/gardener/gardener-extensions/pkg/controller/cmd"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	"github.com/gardener/gardener-extensions/pkg/log"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 func main() {
-	log.SetLogger(log.ZapLogger(false))
+	runtimelog.SetLogger(log.ZapLogger(false))
 	cmd := app.NewControllerManagerCommand(controller.SetupSignalHandlerContext())
 
 	if err := cmd.Execute(); err != nil {

--- a/controllers/provider-packet/cmd/gardener-extension-provider-packet/main.go
+++ b/controllers/provider-packet/cmd/gardener-extension-provider-packet/main.go
@@ -19,11 +19,12 @@ import (
 	"github.com/gardener/gardener-extensions/pkg/controller"
 	controllercmd "github.com/gardener/gardener-extensions/pkg/controller/cmd"
 
-	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"github.com/gardener/gardener-extensions/pkg/log"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 func main() {
-	log.SetLogger(log.ZapLogger(false))
+	runtimelog.SetLogger(log.ZapLogger(false))
 	cmd := app.NewControllerManagerCommand(controller.SetupSignalHandlerContext())
 
 	if err := cmd.Execute(); err != nil {

--- a/pkg/controller/worker/genericactuator/actuator_delete.go
+++ b/pkg/controller/worker/genericactuator/actuator_delete.go
@@ -48,16 +48,10 @@ func (a *genericActuator) Delete(ctx context.Context, worker *extensionsv1alpha1
 		return 1, nil
 	}
 
-	// Deploy the machine-controller-manager into the cluster to make sure
+	// Deploy the machine-controller-manager into the cluster to make sure worker nodes can be removed.
 	a.logger.Info("Deploying the machine-controller-manager", "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
 	if err := a.deployMachineControllerManager(ctx, worker, cluster, workerDelegate, replicaFunc); err != nil {
 		return err
-	}
-
-	// Make sure that all RBAC roles required by the machine-controller-manager exist in the shoot cluster.
-	// This code can be removed as soon as the RBAC roles are managed by the gardener-resource-manager.
-	if err := a.applyMachineControllerManagerShootChart(ctx, workerDelegate, worker, cluster); err != nil {
-		return errors.Wrapf(err, "could not apply machine-controller-manager shoot chart")
 	}
 
 	// Mark all existing machines to become forcefully deleted.

--- a/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -68,12 +68,6 @@ func (a *genericActuator) Reconcile(ctx context.Context, worker *extensionsv1alp
 		return err
 	}
 
-	if !controller.IsHibernated(cluster.Shoot) {
-		if err := a.applyMachineControllerManagerShootChart(ctx, workerDelegate, worker, cluster); err != nil {
-			return err
-		}
-	}
-
 	// Generate the desired machine deployments.
 	wantedMachineDeployments, err := workerDelegate.GenerateMachineDeployments(ctx)
 	if err != nil {

--- a/pkg/controller/worker/genericactuator/machine_controller_manager.go
+++ b/pkg/controller/worker/genericactuator/machine_controller_manager.go
@@ -23,19 +23,19 @@ import (
 	"github.com/gardener/gardener-extensions/pkg/util"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/pkg/errors"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const mcmShootResourceName = "extension-worker-mcm-shoot"
 
-func (a *genericActuator) deployMachineControllerManager(ctx context.Context, workerObj *extensionsv1alpha1.Worker, cluster *controller.Cluster, workerDelegate WorkerDelegate) error {
+// ReplicaCount determines the number of replicas.
+type ReplicaCount func() (int32, error)
+
+func (a *genericActuator) deployMachineControllerManager(ctx context.Context, workerObj *extensionsv1alpha1.Worker, cluster *controller.Cluster, workerDelegate WorkerDelegate, replicas ReplicaCount) error {
 	mcmValues, err := workerDelegate.GetMachineControllerManagerChartValues(ctx)
 	if err != nil {
 		return err
@@ -48,27 +48,15 @@ func (a *genericActuator) deployMachineControllerManager(ctx context.Context, wo
 	}
 	injectPodAnnotation(mcmValues, "checksum/secret-machine-controller-manager", util.ComputeChecksum(mcmKubeconfigSecret.Data))
 
-	// If the shoot is hibernated then we want to scale down the machine-controller-manager. However, we want to first allow it to delete
-	// all remaining worker nodes. Hence, we cannot set the replicas=0 here (otherwise it would be offline and not able to delete the nodes).
-	if extensionscontroller.IsHibernated(cluster.Shoot) {
-		deployment := &appsv1.Deployment{}
-		if err := a.client.Get(ctx, kutil.Key(workerObj.Namespace, a.mcmName), deployment); err != nil && !apierrors.IsNotFound(err) {
-			return err
-		}
-		if replicas := deployment.Spec.Replicas; replicas != nil {
-			mcmValues["replicas"] = *replicas
-		}
+	replicaCount, err := replicas()
+	if err != nil {
+		return err
 	}
+	mcmValues["replicas"] = replicaCount
 
 	if err := a.mcmSeedChart.Apply(ctx, a.chartApplier, workerObj.Namespace,
 		a.imageVector, a.gardenerClientset.Version(), cluster.Shoot.Spec.Kubernetes.Version, mcmValues); err != nil {
 		return errors.Wrapf(err, "could not apply MCM chart in seed for worker '%s'", util.ObjectName(workerObj))
-	}
-
-	if !controller.IsHibernated(cluster.Shoot) {
-		if err := a.applyMachineControllerManagerShootChart(ctx, workerDelegate, workerObj, cluster); err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/pkg/controller/worker/genericactuator/machine_controller_manager.go
+++ b/pkg/controller/worker/genericactuator/machine_controller_manager.go
@@ -59,6 +59,10 @@ func (a *genericActuator) deployMachineControllerManager(ctx context.Context, wo
 		return errors.Wrapf(err, "could not apply MCM chart in seed for worker '%s'", util.ObjectName(workerObj))
 	}
 
+	if err := a.applyMachineControllerManagerShootChart(ctx, workerDelegate, workerObj, cluster); err != nil {
+		return errors.Wrapf(err, "could not apply machine-controller-manager shoot chart")
+	}
+
 	return nil
 }
 

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"io"
+	"os"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+// ConfigFunc sets configuration Options for `zapcore.EncoderConfig`.
+type ConfigFunc func(config *zapcore.EncoderConfig)
+
+// ZapLoggerTo returns a new Logger implementation using Zap which logs
+// to the given destination, instead of stderr.  It otherise behaves like
+// ZapLogger.
+// This function is mainly copied from controller-runtime `sigs.k8s.io/controller-runtime/pkg/runtime/log`
+// and extended to pass options for log encoding.
+// TODO: Switch back to `sigs.k8s.io/controller-runtime/pkg/runtime/log` once proper options are exposed:
+// https://github.com/kubernetes-sigs/controller-runtime/issues/442
+func ZapLoggerTo(destWriter io.Writer, development bool, configFuncs ...ConfigFunc) logr.Logger {
+	// this basically mimics New<type>Config, but with a custom sink
+	sink := zapcore.AddSync(destWriter)
+
+	var enc zapcore.Encoder
+	var lvl zap.AtomicLevel
+	var opts []zap.Option
+	if development {
+		encCfg := zap.NewDevelopmentEncoderConfig()
+		for _, f := range configFuncs {
+			f(&encCfg)
+		}
+		enc = zapcore.NewConsoleEncoder(encCfg)
+		lvl = zap.NewAtomicLevelAt(zap.DebugLevel)
+		opts = append(opts, zap.Development(), zap.AddStacktrace(zap.ErrorLevel))
+	} else {
+		encCfg := zap.NewProductionEncoderConfig()
+		for _, f := range configFuncs {
+			f(&encCfg)
+		}
+		enc = zapcore.NewJSONEncoder(encCfg)
+		lvl = zap.NewAtomicLevelAt(zap.InfoLevel)
+		opts = append(opts, zap.AddStacktrace(zap.WarnLevel),
+			zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+				return zapcore.NewSampler(core, time.Second, 100, 100)
+			}))
+	}
+	opts = append(opts, zap.AddCallerSkip(1), zap.ErrorOutput(sink))
+	log := zap.New(zapcore.NewCore(&log.KubeAwareEncoder{Encoder: enc, Verbose: development}, sink, lvl))
+	log = log.WithOptions(opts...)
+	return zapr.NewLogger(log)
+}
+
+// ZapLogger is a Logger implementation.
+// If development is true, a Zap development config will be used
+// (stacktraces on warnings, no sampling), otherwise a Zap production
+// config will be used (stacktraces on errors, sampling).
+// Additionally, the time encoding is adjusted to `zapcore.ISO8601TimeEncoder`.
+// This function is mainly copied from controller-runtime `sigs.k8s.io/controller-runtime/pkg/runtime/log`
+// and extended to pass options for log encoding.
+// TODO: Switch back to `sigs.k8s.io/controller-runtime/pkg/runtime/log` once proper options are exposed:
+// https://github.com/kubernetes-sigs/controller-runtime/issues/442
+func ZapLogger(development bool) logr.Logger {
+	timestampConfig := func(config *zapcore.EncoderConfig) {
+		config.EncodeTime = zapcore.ISO8601TimeEncoder
+	}
+	return ZapLoggerTo(os.Stderr, development, timestampConfig)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR (re)deploys MCM when when `Worker` resources are deleted. This is a precaution to ensure that existing worker nodes are deleted properly.

/cc @DockToFuture 

**Special notes for your reviewer**:
The timestamp in the controller logs have been adjusted to a human readable format.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The worker actuator does now re-apply the `machine-controller-manager` deployment during worker deletion to ensure a proper worker node deletion.
```
