### PR TITLE
Implement support for OSC customization

### DIFF
--- a/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_types.go
+++ b/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_types.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actuator
+
+import (
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type OperatingSystemCustomization struct {
+	metav1.TypeMeta `json:",inline"`
+	// +optional
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	// Units is a list of unit for the operating system configuration (usually, a systemd unit).
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	// +optional
+	Units []extensionsv1alpha1.Unit `json:"units,omitempty"`
+	// Files is a list of files that should get written to the host's file system.
+	// +optional
+	Files []extensionsv1alpha1.File `json:"files,omitempty"`
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Gardener allows the specification of per-worker set customization
of OSC. This customization may contain additional files and units
to be added to the cloudconfig.

When reconciling the OSC, the actuator retrieves the
customization and adds to the cloudconfig before passing
it to the generator.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This PR has not yet been tested due to issues setting a development environment.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Additional units and files defined in the OSC configuration customizations for a worker pool will be applied to the cloudconfig for worker nodes. 
```
