### PR TITLE
Set hostname on AWS VMs to be the FQDN

### DIFF
--- a/controllers/provider-aws/pkg/webhook/controlplane/ensurer.go
+++ b/controllers/provider-aws/pkg/webhook/controlplane/ensurer.go
@@ -165,6 +165,11 @@ func (e *ensurer) EnsureKubeletServiceUnitOptions(ctx context.Context, opts []*u
 		command = ensureKubeletCommandLineArgs(command)
 		opt.Value = controlplane.SerializeCommandLine(command, 1, " \\\n    ")
 	}
+	opts = controlplane.EnsureUnitOption(opts, &unit.UnitOption{
+		Section: "Service",
+		Name:    "ExecStartPre",
+		Value:   `/bin/sh -c 'hostnamectl set-hostname $(hostname -f)'`,
+	})
 	return opts, nil
 }
 

--- a/controllers/provider-aws/pkg/webhook/controlplane/ensurer_test.go
+++ b/controllers/provider-aws/pkg/webhook/controlplane/ensurer_test.go
@@ -273,6 +273,11 @@ var _ = Describe("Ensurer", func() {
     --config=/var/lib/kubelet/config/kubelet \
     --cloud-provider=aws`,
 					},
+					{
+						Section: "Service",
+						Name:    "ExecStartPre",
+						Value:   `/bin/sh -c 'hostnamectl set-hostname $(hostname -f)'`,
+					},
 				}
 			)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
So far we were using only CoreOS which has by default hostname set to FQDN.
With Ubuntu and JeOS this is not the case and it causes issues with the AWS services.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @pablochacin @timuthy @rfranzke 
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
`provider-aws` sets the hostname of the VMs to be their FQDN.
```
