### PR TITLE
[ci:component:github.com/gardener/machine-controller-manager:0.19.0->0.20.1]

### DIFF
--- a/controllers/provider-alicloud/charts/images.yaml
+++ b/controllers/provider-alicloud/charts/images.yaml
@@ -6,7 +6,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.19.0"
+  tag: "0.20.1"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl

--- a/controllers/provider-aws/charts/images.yaml
+++ b/controllers/provider-aws/charts/images.yaml
@@ -9,7 +9,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.19.0"
+  tag: "0.20.1"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl

--- a/controllers/provider-azure/charts/images.yaml
+++ b/controllers/provider-azure/charts/images.yaml
@@ -9,7 +9,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.19.0"
+  tag: "0.20.1"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl

--- a/controllers/provider-gcp/charts/images.yaml
+++ b/controllers/provider-gcp/charts/images.yaml
@@ -9,7 +9,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.19.0"
+  tag: "0.20.1"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl

--- a/controllers/provider-openstack/charts/images.yaml
+++ b/controllers/provider-openstack/charts/images.yaml
@@ -6,7 +6,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.19.0"
+  tag: "0.20.1"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl

--- a/controllers/provider-packet/charts/images.yaml
+++ b/controllers/provider-packet/charts/images.yaml
@@ -10,7 +10,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.19.0"
+  tag: "0.20.1"
 - name: csi-attacher
   sourceRepository: https://github.com/kubernetes-csi/external-attacher
   repository: quay.io/k8scsi/csi-attacher


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/machine-controller-manager #301 @prashanth26
Bugfix: Allows force deletion of pods who have no controllers backing them
```

``` noteworthy operator github.com/gardener/machine-controller-manager #288 @amshuman-kr
Changes the drain logic to honour the individual `pods`' `terminationGracePeriodSeconds` instead of a fixed(though configurable) `timeout`. For the `pods` without volumes, the timeout would be a bit longer than the maximum of `terminationGracePeriodSeconds` of the `pods` without volume. For the `pods` with volumes, the timeout is its own `terminationGracePeriodSeconds` and a **fixed** (but configurable) volume detach timeout for each pod.

The command-line flags `machine-max-evict-retries` and `machine-pv-detach-timeout` can be used to customize the default behaviour of the number of retries for eviction and wait period for the detaching of volumes after pods are evicted/deleted.

The default value for the existing command-line flag `machine-drain-timeout` has been increased to `12h` which should be enough for most work-loads.
```

``` improvement operator github.com/gardener/machine-controller-manager #286 @kayrus
Increased OpenStack server status wait for a timeout during server creation from 5 to 10 mins.
```

``` improvement operator github.com/gardener/machine-controller-manager #286 @kayrus
Improved the server status handling - It no longer waits for the timeout if the server status is different from `BUILD` during server creation.
```

``` improvement operator github.com/gardener/machine-controller-manager #283 @prashanth26
Force deletion of machine succeeds even on drain failures
```

``` improvement operator github.com/gardener/machine-controller-manager #280 @ialidzhikov
`dep` is replaced by `go mod`.
```

``` improvement operator github.com/gardener/machine-controller-manager #275 @ggaurav10
When draining a node, pods with PVCs are evicted serially. Next pod eviction waits for PV of the previously evicted pod to detach from the node. Operators can expect faster machine drains for their machines.
```

``` noteworthy user github.com/gardener/machine-controller-manager #275 @ggaurav10
MCM now needs permissions to GET/LIST PV and PVCs on target cluster while draining machines
```