### PR TITLE
Azure: Move to standard loadbalancer

### DIFF
--- a/controllers/provider-azure/charts/internal/cloud-provider-config/templates/cloud-provider-config.tpl
+++ b/controllers/provider-azure/charts/internal/cloud-provider-config/templates/cloud-provider-config.tpl
@@ -1,12 +1,13 @@
 {{- define "cloud-provider-config"}}
 cloud: AZUREPUBLICCLOUD
-resourceGroup: "{{ .Values.resourceGroup }}"
 location: "{{ .Values.region }}"
-vnetName: "{{ .Values.vnetName }}"
-subnetName: "{{ .Values.subnetName }}"
-securityGroupName: "{{ .Values.securityGroupName }}"
-routeTableName: "{{ .Values.routeTableName }}"
 primaryAvailabilitySetName: "{{ .Values.availabilitySetName }}"
+resourceGroup: "{{ .Values.resourceGroup }}"
+routeTableName: "{{ .Values.routeTableName }}"
+securityGroupName: "{{ .Values.securityGroupName }}"
+loadBalancerSku: "{{ .Values.loadBalancerSku }}"
+subnetName: "{{ .Values.subnetName }}"
+vnetName: "{{ .Values.vnetName }}"
 cloudProviderBackoff: true
 cloudProviderBackoffRetries: 6
 cloudProviderBackoffExponent: 1.5

--- a/controllers/provider-azure/charts/internal/cloud-provider-config/values.yaml
+++ b/controllers/provider-azure/charts/internal/cloud-provider-config/values.yaml
@@ -9,4 +9,5 @@ availabilitySetName: av-set
 subnetName: sname
 routeTableName: rtname
 securityGroupName: sgname
+loadBalancerSku: standard
 region: location

--- a/controllers/provider-azure/docs/migrate-loadbalancer.md
+++ b/controllers/provider-azure/docs/migrate-loadbalancer.md
@@ -1,0 +1,89 @@
+# Migrate Azure Shoot Load Balancer from basic to standard SKU
+
+This guide descibes how to migrate the Load Balancer of an Azure Shoot cluster from the basic SKU to the standard SKU.<br/>
+**Be aware:** You need to delete and recreate all services of type Load Balancer, which means that the public ip addresses of your service endpoints will change.<br/>
+Please do this only if the Stakeholder really needs to migrate this Shoot to use standard Load Balancers. All new Shoot clusters will automatically use Azure Standard Load Balancers.
+
+1. Disable temporarily Gardeners reconciliation.<br>
+The Gardener Controller Manager need to be configured to allow ignoring Shoot clusters.
+This can be configured in its the `ControllerManagerConfiguration` via the field `.controllers.shoot.respectSyncPeriodOverwrite="true"`.
+
+```sh
+# In the Garden cluster.
+kubectl annotate shoot <shoot-name> shoot.garden.sapcloud.io/ignore="true"
+
+# In the Seed cluster.
+kubectl -n <shoot-namespace> scale deployment gardener-resource-manager --replicas=0
+```
+
+2. Backup all Kubernetes services of type Load Balancer.
+```sh
+# In the Shoot cluster.
+# Determine all Load Balancer services.
+kubectl get service --all-namespaces | grep LoadBalancer
+
+# Backup each Load Balancer service.
+echo "---" >> service-backup.yaml && kubectl -n <namespace> get service <service-name> -o yaml >> service-backup.yaml
+```
+
+3. Delete all Load Balancer services.
+```sh
+# In the Shoot cluster.
+kubectl -n <namespace> delete service <service-name>
+```
+
+4. Wait until until Load Balancer is deleted.
+Wait until all services of type Load Balancer are deleted and the Azure Load Balancer resource is also deleted.
+Check via the Azure Portal if the Load Balancer within the Shoot Resource Group has been deleted.
+This should happen automatically after all Kubernetes Load Balancer service are gone within a few minutes.
+
+Alternatively the Azure cli can be used to check the Load Balancer in the Shoot Resource Group.
+The credentials to configure the cli are available on the Seed cluster in the Shoot namespace.
+```sh
+# In the Seed cluster.
+# Fetch the credentials from cloudprovider secret.
+kubectl -n <shoot-namespace> get secret cloudprovider -o yaml
+
+# Configure the Azure cli, with the base64 decoded values of the cloudprovider secret.
+az login --service-principal --username <clientID> --password <clientSecret> --tenant <tenantID>
+az account set -s <subscriptionID>
+
+# Fetch the constantly the Shoot Load Balancer in the Shoot Resource Group. Wait until the resource is gone.
+watch 'az network lb show -g shoot--<project-name>--<shoot-name> -n shoot--<project-name>--<shoot-name>'
+
+# Logout.
+az logout
+```
+
+5. Modify the `cloud-povider-config` configmap in the Seed namespace of the Shoot.<br/>
+The key `cloudprovider.conf` contains the Kubernetes cloud-provider configuration.
+The value is a multiline string. Please change the value of the field `loadBalancerSku` from `basic` to `standard`.
+Iff the field does not exists then append `loadBalancerSku: \"standard\"\n` to the value/string.
+```sh
+# In the Seed cluster.
+kubectl -n <shoot-namespace> edit cm cloud-provider-config
+```
+
+6. Enable Gardeners reconcilation and trigger a reconciliation.
+```
+# In the Garden cluster
+# Enable reconcilation
+kubectl annotate shoot <shoot-name> shoot.garden.sapcloud.io/ignore-
+
+# Trigger reconcilation
+kubectl annotate shoot <shoot-name> shoot.garden.sapcloud.io/operation="reconcile"
+```
+Wait until the cluster has been reconciled.
+
+6. Recreate the services from the backup file.<br/>
+Probably you need to remove some fields from the service defintions e.g. `.spec.clusterIP`, `.metadata.uid` or `.status` etc.
+```sh
+kubectl apply -f service-backup.yaml
+```
+
+7. If successful remove backup file.
+```sh
+# Delete the backup file.
+rm -f service-backup.yaml
+```
+

--- a/controllers/provider-azure/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-azure/pkg/controller/controlplane/valuesprovider.go
@@ -17,6 +17,7 @@ package controlplane
 import (
 	"context"
 	"path/filepath"
+	"strings"
 
 	apisazure "github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/apis/azure"
 	azureapihelper "github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/apis/azure/helper"
@@ -26,6 +27,7 @@ import (
 	"github.com/gardener/gardener-extensions/pkg/controller/controlplane"
 	"github.com/gardener/gardener-extensions/pkg/controller/controlplane/genericactuator"
 	"github.com/gardener/gardener-extensions/pkg/util"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -36,6 +38,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -46,6 +49,8 @@ import (
 const (
 	cloudControllerManagerDeploymentName = "cloud-controller-manager"
 	cloudControllerManagerServerName     = "cloud-controller-manager-server"
+	cloudProviderConfigMapName           = "cloud-provider-config"
+	cloudProviderConfigMapKey            = "cloudprovider.conf"
 )
 
 var controlPlaneSecrets = &secrets.Secrets{
@@ -174,8 +179,14 @@ func (vp *valuesProvider) GetConfigChartValues(
 		return nil, errors.Wrapf(err, "could not get service account from secret '%s/%s'", cp.Spec.SecretRef.Namespace, cp.Spec.SecretRef.Name)
 	}
 
+	// Determine which kind of LoadBalancer should be configured in the cloud-provider-config.
+	loadBalancerType, err := determineLoadBalancerType(ctx, vp.client, cp.Namespace)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not determine which type of loadbalancer should be used")
+	}
+
 	// Get config chart values
-	return getConfigChartValues(infraStatus, cp, cluster, auth)
+	return getConfigChartValues(infraStatus, cp, cluster, auth, loadBalancerType)
 }
 
 // GetControlPlaneChartValues returns the values for the control plane chart applied by the generic actuator.
@@ -202,6 +213,7 @@ func getConfigChartValues(
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 	ca *internal.ClientAuth,
+	loadBalancerType string,
 ) (map[string]interface{}, error) {
 	subnetName, availabilitySetName, routeTableName, securityGroupName, err := getInfraNames(infraStatus)
 	if err != nil {
@@ -221,6 +233,7 @@ func getConfigChartValues(
 		"availabilitySetName": availabilitySetName,
 		"routeTableName":      routeTableName,
 		"securityGroupName":   securityGroupName,
+		"loadBalancerSku":     loadBalancerType,
 		"region":              cp.Spec.Region,
 	}, nil
 }
@@ -273,4 +286,31 @@ func getInfraNames(infraStatus *apisazure.InfrastructureStatus) (string, string,
 	}
 
 	return nodesSubnet.Name, nodesAvailabilitySet.Name, nodesRouteTable.Name, nodesSecurityGroup.Name, nil
+}
+
+func determineLoadBalancerType(ctx context.Context, c client.Client, namespace string) (string, error) {
+	var (
+		cm    = &corev1.ConfigMap{}
+		cmRef = kutil.Key(namespace, cloudProviderConfigMapName)
+	)
+	// Check if a cloud-provider-config configmap already exists.
+	// If this is not the case it can assume this is a new cluster and use standard LoadBalancers.
+	if err := c.Get(ctx, cmRef, cm); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "standard", nil
+		}
+		return "", errors.Wrapf(err, "could not fetch existing %s configmap", cloudProviderConfigMapName)
+	}
+	data, ok := cm.Data[cloudProviderConfigMapKey]
+	if !ok {
+		return "standard", nil
+	}
+	// If the cloud-provider-config does not contain a LoadBalancer type configuration
+	// then it choose the basic LoadBalancers as they were the former default and
+	// there is no automatic migration path implemented.
+	// Anyways it writes the usedLoadBalancer type now explictly to the cloud-privider-config.
+	if !strings.Contains(data, "loadBalancerSku") || strings.Contains(data, "loadBalancerSku: \"basic\"") {
+		return "basic", nil
+	}
+	return "standard", nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
As prerequisite to support Availability Zones on Azure (#135) we need to move to LoadBalancers with the `standard` SKU instead of the `basic` SKU, because only this type of LoadBalancer supports load balancing across zones.

**Which issue(s) this PR fixes**:
Fixes #207

**Special notes for your reviewer**:
Update the `ControllerRegistration` for the Azure Provider extension to use a custom build image which contains this PR (dominickistner/gardener-extension-hyper:0.11.0-az-standard-lb).
After the Azure extensions on the Seed cluster are updated, create an Azure Shoot and check after creation has been completed, if the LoadBalancer is of sku `standard`.

To test the upgrade procedure. Create upfront an Azure Shoot with basic LoadBalancer SKU.
Then upgrade the `ControllerRegistration` as above described and follow the instruction in the guide controllers/provider-azure/docs/migrate-loadbalancer.md

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Gardener supports now load balancers with standard sku. New cluster use automatically standard sku load balancers. Existing clusters remain with basic sku load balancers until they are manually migrated.
```
```action user
Gardener supports now load balancers with standard sku. To migrate the LoadBalancer from the basic sku to standard sku follow the instructions in https://github.com/gardener/gardener-extensions/tree/master/controllers/provider-azure/docs/migrate-loadbalancer.md
```