### PR TITLE
update csi plugin docker image for AliCloud

### DIFF
--- a/controllers/provider-alicloud/charts/images.yaml
+++ b/controllers/provider-alicloud/charts/images.yaml
@@ -58,4 +58,4 @@ images:
 - name: csi-plugin-alicloud
   sourceRepository: https://github.com/AliyunContainerService/csi-plugin
   repository: registry.eu-central-1.aliyuncs.com/gardener-de/csi-plugin-alicloud
-  tag: v1.13.2-1
+  tag: v1.13.2-3


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix volume attach issue on AliCloud. The root cause is the volume is not formatted because of mis-judge whether the disk is formatted.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Refer to https://github.com/gardener/gardener-extensions/pull/221. Unfortuanately, #221 didn't fix this issue thoroughly. This is a continuous fix.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Upgrade AliCloud CSI diskplugin to latest version [v1.13.2-3](https://github.com/jia-jerry/csi-plugin/blob/v1.13.2-3/aliyun-dockerfile)
```
