### PR TITLE
[WIP] Jeos customization

### DIFF
--- a/controllers/os-suse-jeos/cmd/gardener-extension-os-suse-jeos/app/app.go
+++ b/controllers/os-suse-jeos/cmd/gardener-extension-os-suse-jeos/app/app.go
@@ -16,6 +16,7 @@ package app
 
 import (
 	"context"
+	"github.com/gardener/gardener-extensions/controllers/os-suse-jeos/pkg/customizer"
 	"github.com/gardener/gardener-extensions/controllers/os-suse-jeos/pkg/generator"
 	"github.com/gardener/gardener-extensions/pkg/controller/cmd"
 	"github.com/gardener/gardener-extensions/pkg/controller/operatingsystemconfig/oscommon/app"
@@ -24,10 +25,15 @@ import (
 
 // NewControllerCommand returns a new Command with a new Generator
 func NewControllerCommand(ctx context.Context) *cobra.Command {
+	c, err := customizer.NewCustomizer()
+	if err != nil {
+		cmd.LogErrAndExit(err, "Could not create JeOS CloudInit customizer")
+	}
+
 	g, err := generator.NewCloudInitGenerator()
 	if err != nil {
 		cmd.LogErrAndExit(err, "Could not create Generator")
 	}
 
-	return app.NewControllerCommand(ctx, "suse-jeos", g)
+	return app.NewControllerCommand(ctx, "suse-jeos", g, c)
 }

--- a/controllers/os-suse-jeos/pkg/customizer/customizer.go
+++ b/controllers/os-suse-jeos/pkg/customizer/customizer.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package customizer
+
+import (
+	customizer "github.com/gardener/gardener-extensions/pkg/controller/operatingsystemconfig/oscommon/customizer"
+	generator "github.com/gardener/gardener-extensions/pkg/controller/operatingsystemconfig/oscommon/generator"
+	yaml "gopkg.in/yaml.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+)
+
+type JeosCustomizer struct {
+}
+
+func NewCustomizer() (customizer.Customizer, error) {
+	return &JeosCustomizer{}, nil
+}
+
+func (c *JeosCustomizer) Customize(osconf *generator.OperatingSystemConfig, extension *runtime.RawExtension) (*generator.OperatingSystemConfig, error) {
+
+	customization := JeosOperatingSystemCustomization{}
+	err := yaml.Unmarshal(extension.Raw, &customization)
+	if err != nil {
+		return nil, err
+	}
+
+	var units []*generator.Unit
+	var files []*generator.File
+	var commands []string
+
+	var customized = &generator.OperatingSystemConfig{}
+
+	for _, service := range customization.EnableServices {
+		cmd := "systemctl enable " + service
+		commands = append(commands, cmd)
+	}
+
+	for _, cmd := range customization.BootCommands {
+		commands = append(commands, cmd)
+	}
+
+	customized.Files = append(osconf.Files, files...)
+	customized.Units = append(osconf.Units, units...)
+	customized.Commands = append(osconf.Commands, commands...)
+	customized.Bootstrap = osconf.Bootstrap
+	customized.Path = osconf.Path
+
+	return customized, nil
+}
+
+type JeosOperatingSystemCustomization struct {
+	metav1.TypeMeta `json:",inline"`
+	// +optional
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	// systmctl services to enable
+	EnableServices []string
+
+	// commands to execute at boot time
+	BootCommands []string
+}

--- a/controllers/os-suse-jeos/pkg/generator/templates/cloud-init-suse-jeos.template
+++ b/controllers/os-suse-jeos/pkg/generator/templates/cloud-init-suse-jeos.template
@@ -34,3 +34,6 @@ runcmd:
 {{ range $_, $unit := .Units -}}
 - systemctl enable '{{ $unit.Name }}' && systemctl restart '{{ $unit.Name }}'
 {{ end -}}
+{{ range $_, $command := .Commands -}}
+- '{{ command }}'
+{{ end -}}

--- a/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator.go
+++ b/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator.go
@@ -16,6 +16,7 @@ package actuator
 
 import (
 	"github.com/gardener/gardener-extensions/pkg/controller/operatingsystemconfig"
+	"github.com/gardener/gardener-extensions/pkg/controller/operatingsystemconfig/oscommon/customizer"
 	"github.com/gardener/gardener-extensions/pkg/controller/operatingsystemconfig/oscommon/generator"
 
 	"github.com/go-logr/logr"
@@ -28,19 +29,21 @@ import (
 
 // Actuator uses a generator to render an OperatingSystemConfiguration for an Operating System
 type Actuator struct {
-	scheme    *runtime.Scheme
-	client    client.Client
-	logger    logr.Logger
-	osName    string
-	generator generator.Generator
+	scheme     *runtime.Scheme
+	client     client.Client
+	logger     logr.Logger
+	osName     string
+	customizer customizer.Customizer
+	generator  generator.Generator
 }
 
 // NewActuator creates a new actuator with the given logger.
-func NewActuator(osName string, generator generator.Generator) operatingsystemconfig.Actuator {
+func NewActuator(osName string, generator generator.Generator, customizer customizer.Customizer) operatingsystemconfig.Actuator {
 	return &Actuator{
-		logger:    log.Log.WithName(osName + "-operatingsystemconfig-actuator"),
-		osName:    osName,
-		generator: generator,
+		logger:     log.Log.WithName(osName + "-operatingsystemconfig-actuator"),
+		osName:     osName,
+		customizer: customizer,
+		generator:  generator,
 	}
 }
 

--- a/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_reconcile.go
+++ b/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_reconcile.go
@@ -24,7 +24,7 @@ import (
 // Reconcile reconciles the update of a OperatingSystemConfig regenerating the os-specific format
 func (a *Actuator) Reconcile(ctx context.Context, config *extensionsv1alpha1.OperatingSystemConfig) ([]byte, *string, []string, error) {
 
-	cloudConfig, cmd, err := CloudConfigFromOperatingSystemConfig(ctx, a.client, config, a.generator)
+	cloudConfig, cmd, err := CloudConfigFromOperatingSystemConfig(ctx, a.client, config, a.customizer, a.generator)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("could not generate cloud config: %v", err)
 	}

--- a/pkg/controller/operatingsystemconfig/oscommon/add.go
+++ b/pkg/controller/operatingsystemconfig/oscommon/add.go
@@ -17,6 +17,7 @@ package oscommon
 import (
 	"github.com/gardener/gardener-extensions/pkg/controller/operatingsystemconfig"
 	"github.com/gardener/gardener-extensions/pkg/controller/operatingsystemconfig/oscommon/actuator"
+	"github.com/gardener/gardener-extensions/pkg/controller/operatingsystemconfig/oscommon/customizer"
 	"github.com/gardener/gardener-extensions/pkg/controller/operatingsystemconfig/oscommon/generator"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -36,15 +37,15 @@ type AddOptions struct {
 
 // AddToManagerWithOptions adds a controller with the given Options to the given manager.
 // The opts.Reconciler is being set with a newly instantiated actuator.
-func AddToManagerWithOptions(mgr manager.Manager, os string, generator generator.Generator, opts AddOptions) error {
+func AddToManagerWithOptions(mgr manager.Manager, os string, generator generator.Generator, customizer customizer.Customizer, opts AddOptions) error {
 	return operatingsystemconfig.Add(mgr, operatingsystemconfig.AddArgs{
-		Actuator:          actuator.NewActuator(os, generator),
+		Actuator:          actuator.NewActuator(os, generator, customizer),
 		Predicates:        operatingsystemconfig.DefaultPredicates(os, opts.IgnoreOperationAnnotation),
 		ControllerOptions: opts.Controller,
 	})
 }
 
 // AddToManager adds a controller with the default Options.
-func AddToManager(mgr manager.Manager, os string, generator generator.Generator) error {
-	return AddToManagerWithOptions(mgr, os, generator, DefaultAddOptions)
+func AddToManager(mgr manager.Manager, os string, generator generator.Generator, customizer customizer.Customizer) error {
+	return AddToManagerWithOptions(mgr, os, generator, customizer, DefaultAddOptions)
 }

--- a/pkg/controller/operatingsystemconfig/oscommon/app/app.go
+++ b/pkg/controller/operatingsystemconfig/oscommon/app/app.go
@@ -22,6 +22,7 @@ import (
 	controllercmd "github.com/gardener/gardener-extensions/pkg/controller/cmd"
 	"github.com/gardener/gardener-extensions/pkg/controller/operatingsystemconfig/oscommon"
 	oscommoncmd "github.com/gardener/gardener-extensions/pkg/controller/operatingsystemconfig/oscommon/cmd"
+	"github.com/gardener/gardener-extensions/pkg/controller/operatingsystemconfig/oscommon/customizer"
 	"github.com/gardener/gardener-extensions/pkg/controller/operatingsystemconfig/oscommon/generator"
 	"github.com/gardener/gardener-extensions/pkg/util"
 
@@ -31,7 +32,7 @@ import (
 )
 
 // NewControllerCommand creates a new command for running an OS controller.
-func NewControllerCommand(ctx context.Context, osName string, generator generator.Generator) *cobra.Command {
+func NewControllerCommand(ctx context.Context, osName string, generator generator.Generator, customizer customizer.Customizer) *cobra.Command {
 	var (
 		restOpts = &controllercmd.RESTOptions{}
 		mgrOpts  = &controllercmd.ManagerOptions{
@@ -45,7 +46,7 @@ func NewControllerCommand(ctx context.Context, osName string, generator generato
 
 		reconcileOpts = &controllercmd.ReconcilerOptions{}
 
-		controllerSwitches = oscommoncmd.SwitchOptions(osName, generator)
+		controllerSwitches = oscommoncmd.SwitchOptions(osName, generator, customizer)
 
 		aggOption = controllercmd.NewOptionAggregator(
 			restOpts,

--- a/pkg/controller/operatingsystemconfig/oscommon/customizer/customizer.go
+++ b/pkg/controller/operatingsystemconfig/oscommon/customizer/customizer.go
@@ -12,22 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmd
+package customizer
 
 import (
-	"github.com/gardener/gardener-extensions/pkg/controller/cmd"
-	"github.com/gardener/gardener-extensions/pkg/controller/operatingsystemconfig"
-	"github.com/gardener/gardener-extensions/pkg/controller/operatingsystemconfig/oscommon"
-	"github.com/gardener/gardener-extensions/pkg/controller/operatingsystemconfig/oscommon/customizer"
 	"github.com/gardener/gardener-extensions/pkg/controller/operatingsystemconfig/oscommon/generator"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// SwitchOptions are the cmd.SwitchOptions for the provider controllers.
-func SwitchOptions(os string, generator generator.Generator, customizer customizer.Customizer) *cmd.SwitchOptions {
-	return cmd.NewSwitchOptions(
-		cmd.Switch(operatingsystemconfig.ControllerName, func(mgr manager.Manager) error {
-			return oscommon.AddToManager(mgr, os, generator, customizer)
-		}),
-	)
+// Customizer customizes an OperatingSystemConfig
+// using a ProviderConfig
+type Customizer interface {
+	Customize(*generator.OperatingSystemConfig, *runtime.RawExtension) (*generator.OperatingSystemConfig, error)
 }

--- a/pkg/controller/operatingsystemconfig/oscommon/generator/generator.go
+++ b/pkg/controller/operatingsystemconfig/oscommon/generator/generator.go
@@ -45,6 +45,7 @@ type DropIn struct {
 type OperatingSystemConfig struct {
 	Files     []*File
 	Units     []*Unit
+	Commands  []string
 	Bootstrap bool
 	Path      *string
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Gardener allows the specification of per-worker set customization of OSC. 

When reconciling the OSC, the actuator retrieves the provider config and passes it to a customizer, which adds additional units, files, and commands to the cloudconfig before passing it to the generator.

This is a work in progress. Some tasks still pending:
- [ ] Define the customization options for JeOS based on actual use cases from users
- [ ] Translate the customization options to cloudconfig elements
- [ ] Change the brute force-based decoding used for ProviderConfig to JeOS OSC customization, by an schema-based approach.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This PR has not yet been tested due to issues setting a development environment.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Customization options defined in the JeOS configuration for a worker pool will be applied to the cloudconfig for worker nodes. 
```
