### PR TITLE
Remove redundant security context flags for CSI plugin for AliCloud

### DIFF
--- a/controllers/provider-alicloud/charts/internal/shoot-system-components/charts/csi-alicloud/templates/csi-diskplugin-ds.yaml
+++ b/controllers/provider-alicloud/charts/internal/shoot-system-components/charts/csi-alicloud/templates/csi-diskplugin-ds.yaml
@@ -49,9 +49,6 @@ spec:
       - name: csi-diskplugin
         securityContext:
           privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-          allowPrivilegeEscalation: true
         image: {{ index .Values.images "csi-plugin-alicloud" }}
         args:
         - "--endpoint=$(CSI_ENDPOINT)"


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove redundant security context flags for CSI plugin for AliCloud
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Priviliged option is in god mode. Don't need other security context flags.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
