### PR TITLE
[ci:component:github.com/gardener/etcd-backup-restore:0.6.4->0.7.0]

### DIFF
--- a/controllers/provider-alicloud/charts/images.yaml
+++ b/controllers/provider-alicloud/charts/images.yaml
@@ -10,7 +10,7 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "0.6.4"
+  tag: "0.7.0"
 - name: alicloud-controller-manager
   sourceRepository: https://github.com/kubernetes/cloud-provider-alibaba-cloud
   repository: registry.eu-central-1.aliyuncs.com/gardener-de/alibaba-cloud-controller-manager

--- a/controllers/provider-aws/charts/images.yaml
+++ b/controllers/provider-aws/charts/images.yaml
@@ -13,4 +13,4 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "0.6.4"
+  tag: "0.7.0"

--- a/controllers/provider-azure/charts/images.yaml
+++ b/controllers/provider-azure/charts/images.yaml
@@ -13,4 +13,4 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "0.6.4"
+  tag: "0.7.0"

--- a/controllers/provider-gcp/charts/images.yaml
+++ b/controllers/provider-gcp/charts/images.yaml
@@ -13,4 +13,4 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "0.6.4"
+  tag: "0.7.0"

--- a/controllers/provider-openstack/charts/images.yaml
+++ b/controllers/provider-openstack/charts/images.yaml
@@ -10,7 +10,7 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "0.6.4"
+  tag: "0.7.0"
 - name: openstack-cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager

--- a/controllers/provider-packet/charts/images.yaml
+++ b/controllers/provider-packet/charts/images.yaml
@@ -48,7 +48,7 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "0.6.4"
+  tag: "0.7.0"
 - name: metabot
   sourceRepository: https://github.com/packethost/metabot
   repository: packethost/metabot


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/etcd-backup-restore #184 @swapnilgm
Added new flag `experimental-fail-below-revision` flag for initializer and `/initialization/start` http call
```

``` improvement operator github.com/gardener/etcd-backup-restore #182 @amshuman-kr
The health status changes are now logged at `INFO` level to help debug issues with etcd readiness.
```

``` improvement user github.com/gardener/etcd-backup-restore #180 @shreyas-s-rao
All exposed metrics are initialised to zero values.
```

``` improvement operator github.com/gardener/etcd-backup-restore #176 @kayrus
Etcd-backup-restore now uses the go modules for its dependecy management.
```

``` improvement operator github.com/gardener/etcd-backup-restore #172 @shreyas-s-rao
Fixed liveness probe command in helm chart.
```

``` improvement user github.com/gardener/etcd-backup-restore #165 @shreyas-s-rao
In the case that initial delta snapshot fails, a full snapshot is tried instead.
```

``` improvement user github.com/gardener/etcd-backup-restore #161 @swapnilgm
Fixed the sorting of snapshots.
```

``` improvement operator github.com/gardener/etcd-backup-restore #155 @shreyas-s-rao
Optimized WAL verification memory usage.
```

``` noteworthy user github.com/gardener/etcd-backup-restore #155 @shreyas-s-rao
Updated etcd vendoring version to 3.3.13.
```

``` noteworthy user github.com/gardener/etcd-backup-restore #154 @shreyas-s-rao
Full snapshot on etcd startup will now be deferred in favour of an initial delta snapshot, followed by a full snapshot and subsequent delta snapshots.
```

``` improvement operator github.com/gardener/etcd-backup-restore #151 @shreyas-s-rao
Reduced etcd downtime by optimizing readiness probe.
```

``` improvement operator github.com/gardener/etcd-backup-restore #146 @swapnilgm
Updated the base image of alpine in docker container to 3.9.3.
```

``` noteworthy user github.com/gardener/etcd-backup-restore #143 @shreyas-s-rao
Added functionality to trigger on-demand full snapshots via the HTTP endpoint `/snapshot/full`.
```