### PR TITLE
Webhooks don't mutate objects if deletion timestamp is set

### DIFF
--- a/controllers/provider-aws/pkg/webhook/shoot/mutator.go
+++ b/controllers/provider-aws/pkg/webhook/shoot/mutator.go
@@ -20,7 +20,9 @@ import (
 	extensionswebhook "github.com/gardener/gardener-extensions/pkg/webhook"
 
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
@@ -38,6 +40,15 @@ func NewMutator() extensionswebhook.Mutator {
 
 // Mutate mutates resources.
 func (m *mutator) Mutate(ctx context.Context, obj runtime.Object) error {
+	acc, err := meta.Accessor(obj)
+	if err != nil {
+		return errors.Wrapf(err, "could not create accessor during webhook")
+	}
+	// If the object does have a deletion timestamp then we don't want to mutate anything.
+	if acc.GetDeletionTimestamp() != nil {
+		return nil
+	}
+
 	switch x := obj.(type) {
 	case *corev1.ConfigMap:
 		switch x.Name {

--- a/controllers/provider-packet/pkg/webhook/shoot/mutator.go
+++ b/controllers/provider-packet/pkg/webhook/shoot/mutator.go
@@ -20,7 +20,9 @@ import (
 	extensionswebhook "github.com/gardener/gardener-extensions/pkg/webhook"
 
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
@@ -37,6 +39,15 @@ func NewMutator() extensionswebhook.Mutator {
 }
 
 func (m *mutator) Mutate(ctx context.Context, obj runtime.Object) error {
+	acc, err := meta.Accessor(obj)
+	if err != nil {
+		return errors.Wrapf(err, "could not create accessor during webhook")
+	}
+	// If the object does have a deletion timestamp then we don't want to mutate anything.
+	if acc.GetDeletionTimestamp() != nil {
+		return nil
+	}
+
 	switch x := obj.(type) {
 	case *appsv1.Deployment:
 		switch x.Name {

--- a/pkg/webhook/network/mutator.go
+++ b/pkg/webhook/network/mutator.go
@@ -22,6 +22,8 @@ import (
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -50,6 +52,15 @@ func (m *mutator) InjectClient(client client.Client) error {
 
 // Mutate validates and if needed mutates the given object.
 func (m *mutator) Mutate(ctx context.Context, obj runtime.Object) error {
+	acc, err := meta.Accessor(obj)
+	if err != nil {
+		return errors.Wrapf(err, "could not create accessor during webhook")
+	}
+	// If the object does have a deletion timestamp then we don't want to mutate anything.
+	if acc.GetDeletionTimestamp() != nil {
+		return nil
+	}
+
 	network, ok := obj.(*extensionsv1alpha1.Network)
 	if !ok {
 		return fmt.Errorf("could not mutate, object is not of type \"Network\"")


### PR DESCRIPTION
**What this PR does / why we need it**:
Webhooks no longer mutate objects if deletion timestamp is set


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
All webhooks don't mutate any object anymore if the respective deletion timestamp is already set.
```
