### PR TITLE
Ensure wake-up of provider specific components when hibernated shoot is deleted

### DIFF
--- a/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/pkg/controller/controlplane/genericactuator/actuator.go
@@ -17,6 +17,7 @@ package genericactuator
 import (
 	"bytes"
 	"context"
+
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	"github.com/gardener/gardener-extensions/pkg/controller/controlplane"
 	"github.com/gardener/gardener-extensions/pkg/util"
@@ -265,20 +266,33 @@ func (a *actuator) reconcileControlPlane(
 		return false, err
 	}
 
-	// If the cluster is hibernated, check if kube-apiserver has been already scaled down
-	requeue := false
-	scaledDown := false
+	var (
+		requeue    = false
+		scaledDown = false
+	)
+
 	if extensionscontroller.IsHibernated(cluster.Shoot) {
 		dep := &appsv1.Deployment{}
 		if err := a.client.Get(ctx, client.ObjectKey{Namespace: cp.Namespace, Name: gardencorev1alpha1.DeploymentNameKubeAPIServer}, dep); err != nil {
 			return false, errors.Wrapf(err, "could not get deployment '%s/%s'", cp.Namespace, gardencorev1alpha1.DeploymentNameKubeAPIServer)
 		}
 
-		// If kube-apiserver has not been already scaled down, requeue. Otherwise, set the scaledDown flag so the value provider could scale CCM down.
-		if dep.Spec.Replicas != nil && *dep.Spec.Replicas > 0 {
-			requeue = true
+		// If the cluster is hibernated, check if kube-apiserver has been already scaled down. If it is not yet scaled down
+		// then we requeue the `ControlPlane` CRD in order to give the provider-specific control plane components time to
+		// properly prepare the cluster for hibernation (whatever needs to be done). If the kube-apiserver is already scaled down
+		// then we allow continuing the reconciliation.
+		if cluster.Shoot.DeletionTimestamp == nil {
+			if dep.Spec.Replicas != nil && *dep.Spec.Replicas > 0 {
+				requeue = true
+			} else {
+				scaledDown = true
+			}
+			// Similarly, if a hibernated shoot is deleted then we might need to wake up all the provider-specific components. We
+			// wait until the kube-apiserver is woken up again before we wake up the provider-specific components.
 		} else {
-			scaledDown = true
+			if dep.Spec.Replicas == nil || *dep.Spec.Replicas == 0 {
+				return true, nil
+			}
 		}
 	}
 

--- a/pkg/controller/controlplane/reconciler.go
+++ b/pkg/controller/controlplane/reconciler.go
@@ -43,7 +43,7 @@ const (
 	EventControlPlaneDeletion string = "ControlPlaneDeletion"
 
 	// RequeueAfter is the duration to requeue a controlplane reconciliation if indicated by the actuator.
-	RequeueAfter time.Duration = 10 * time.Second
+	RequeueAfter time.Duration = 2 * time.Second
 )
 
 type reconciler struct {

--- a/pkg/controller/shoot.go
+++ b/pkg/controller/shoot.go
@@ -77,7 +77,7 @@ func GetReplicas(shoot *gardenv1beta1.Shoot, wokenUp int) int {
 // GetControlPlaneReplicas returns the woken up replicas for controlplane components of the given Shoot
 // that should only be scaled down at the end of the flow.
 func GetControlPlaneReplicas(shoot *gardenv1beta1.Shoot, scaledDown bool, wokenUp int) int {
-	if IsHibernated(shoot) && scaledDown {
+	if shoot.DeletionTimestamp == nil && IsHibernated(shoot) && scaledDown {
 		return 0
 	}
 	return wokenUp


### PR DESCRIPTION
**What this PR does / why we need it**:
After #178 the provider-specific control plane components are no longer woken up when a hibernated shoot is deleted. This PR fixes this.

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The generic control plane actuator does now correctly wake up provider-specific control plane components when a hibernated shoot is deleted.
```
