### PR TITLE
Enable SSE of buckets on Alicloud

### DIFF
--- a/controllers/provider-alicloud/pkg/alicloud/client/client.go
+++ b/controllers/provider-alicloud/pkg/alicloud/client/client.go
@@ -117,6 +117,12 @@ func (c *storageClient) CreateBucketIfNotExists(ctx context.Context, bucketName 
 		}
 		return err
 	}
+
+	config := oss.ServerEncryptionRule{SSEDefault: oss.SSEDefaultRule{SSEAlgorithm: "KMS"}}
+	if err := c.client.SetBucketEncryption(bucketName, config); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to enable Server Side Encryption (SSE) of OSS buckets on Alicloud. 
**Which issue(s) this PR fixes**:
Fixes #
None
**Special notes for your reviewer**:
Buckets already created will not be affected, which means only buckets created after the change will enable SSE.