### PR TITLE
Add Network CRD to provider-azure/examples

### DIFF
--- a/controllers/provider-azure/example/20-crd-network.yaml
+++ b/controllers/provider-azure/example/20-crd-network.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networks.extensions.gardener.cloud
+spec:
+  group: extensions.gardener.cloud
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: networks
+    singular: network
+    kind: Network
+    shortNames:
+    - nw
+  additionalPrinterColumns:
+  - name: Type
+    type: string
+    description: The type of the network plugin for this resource.
+    JSONPath: .spec.type
+  - name: STATE
+    type: string
+    description: The state of the last operation.
+    JSONPath: .status.lastOperation.state
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}

--- a/extensions.yaml
+++ b/extensions.yaml
@@ -37,3 +37,6 @@ extensions:
 - name: dns-external
   gitHubRepo: https://github.com/gardener/external-dns-management
   examplePath: examples/gardener-controllerregistration.yaml
+- name: networking-calico
+  gitHubRepo: https://github.com/gardener/gardener-extensions
+  path: controllers/networking-calico


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add Network CRD to provider-azure/examples.
- Add `controllers/networking-calico` to `extensions.yaml`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
