### PR TITLE
Add aws-lb-readvertiser-vpa to AWS

### DIFF
--- a/controllers/provider-aws/charts/internal/aws-lb-readvertiser/templates/aws-lb-readvertiser-vpa.yaml
+++ b/controllers/provider-aws/charts/internal/aws-lb-readvertiser/templates/aws-lb-readvertiser-vpa.yaml
@@ -1,0 +1,12 @@
+apiVersion: "autoscaling.k8s.io/v1beta2"
+kind: VerticalPodAutoscaler
+metadata:
+    name: aws-lb-readvertiser-vpa
+    namespace: {{ .Release.Namespace }}
+spec:
+    targetRef:
+        apiVersion: {{ include "deploymentversion" . }}
+        kind: Deployment
+        name: aws-lb-readvertiser
+    updatePolicy:
+        updateMode: "Auto"

--- a/controllers/provider-aws/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-aws/pkg/controller/controlplane/valuesprovider.go
@@ -36,6 +36,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -156,6 +157,7 @@ var cpExposureChart = &chart.Chart{
 	Images: []string{aws.AWSLBReadvertiserImageName},
 	Objects: []*chart.Object{
 		{Type: &appsv1.Deployment{}, Name: "aws-lb-readvertiser"},
+		{Type: &unstructured.Unstructured{}, Name: "aws-lb-readvertiser-vpa"},
 	},
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds aws-lb-readvertiser-vpa chart to provider-aws controller

**Which issue(s) this PR fixes**:
Fixes #233 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Add aws-lb-readvertiser-vpa to provider-aws
```
