### PR TITLE
Add export also for gnu-tar in hack/install-requirements.sh

### DIFF
--- a/hack/install-requirements.sh
+++ b/hack/install-requirements.sh
@@ -39,6 +39,7 @@ $ brew install coreutils gnu-tar
 
 Please allow them to be used without their "g" prefix:
 $ export PATH=/usr/local/opt/coreutils/libexec/gnubin:\$PATH
+$ export PATH=/usr/local/opt/gnu-tar/libexec/gnubin:\$PATH
 
 EOM
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Add export also for gnu-tar in `hack/install-requirements.sh`.

/kind flake

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
