### PR TITLE
Fix MachineClass secrets cleanup for provider-aws

### DIFF
--- a/controllers/provider-aws/pkg/controller/worker/machines.go
+++ b/controllers/provider-aws/pkg/controller/worker/machines.go
@@ -26,6 +26,7 @@ import (
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	"github.com/gardener/gardener-extensions/pkg/controller/worker"
 	"github.com/gardener/gardener-extensions/pkg/util"
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -183,6 +184,9 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			})
 
 			machineClassSpec["name"] = className
+			machineClassSpec["labels"] = map[string]string{
+				gardencorev1alpha1.GardenPurpose: gardencorev1alpha1.GardenPurposeMachineClass,
+			}
 			machineClassSpec["secret"].(map[string]interface{})[aws.AccessKeyID] = string(machineClassSecretData[machinev1alpha1.AWSAccessKeyID])
 			machineClassSpec["secret"].(map[string]interface{})[aws.SecretAccessKey] = string(machineClassSecretData[machinev1alpha1.AWSSecretAccessKey])
 

--- a/controllers/provider-aws/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-aws/pkg/controller/worker/machines_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gardener/gardener-extensions/pkg/controller/worker"
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	mockkubernetes "github.com/gardener/gardener-extensions/pkg/mock/gardener/client/kubernetes"
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
@@ -606,6 +607,9 @@ func useDefaultMachineClass(def map[string]interface{}, key string, value interf
 
 func addNameAndSecretToMachineClass(class map[string]interface{}, awsAccessKeyID, awsSecretAccessKey, name string) {
 	class["name"] = name
+	class["labels"] = map[string]string{
+		gardencorev1alpha1.GardenPurpose: gardencorev1alpha1.GardenPurposeMachineClass,
+	}
 	class["secret"].(map[string]interface{})[aws.AccessKeyID] = awsAccessKeyID
 	class["secret"].(map[string]interface{})[aws.SecretAccessKey] = awsSecretAccessKey
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the <Provider>MachineClass secrets cleanup logic fetches all secrets using the label selector `garden.sapcloud.io/purpose=machineclass`. provider-aws was no adding this label to the secrets.
The PR adds this label to the machine class secrets to enable their cleanup. 


/kind bug

**Which issue(s) this PR fixes**:
Fixes #272

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The AWS extension controller now properly cleans up machine class secrets that are no longer used.
```
