### PR TITLE
[ci:component:github.com/gardener/machine-controller-manager:0.20.1->0.21.0]

### DIFF
--- a/controllers/provider-alicloud/charts/images.yaml
+++ b/controllers/provider-alicloud/charts/images.yaml
@@ -6,7 +6,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.20.1"
+  tag: "0.21.0"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl

--- a/controllers/provider-aws/charts/images.yaml
+++ b/controllers/provider-aws/charts/images.yaml
@@ -9,7 +9,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.20.1"
+  tag: "0.21.0"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl

--- a/controllers/provider-azure/charts/images.yaml
+++ b/controllers/provider-azure/charts/images.yaml
@@ -9,7 +9,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.20.1"
+  tag: "0.21.0"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl

--- a/controllers/provider-gcp/charts/images.yaml
+++ b/controllers/provider-gcp/charts/images.yaml
@@ -9,7 +9,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.20.1"
+  tag: "0.21.0"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl

--- a/controllers/provider-openstack/charts/images.yaml
+++ b/controllers/provider-openstack/charts/images.yaml
@@ -6,7 +6,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.20.1"
+  tag: "0.21.0"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl

--- a/controllers/provider-packet/charts/images.yaml
+++ b/controllers/provider-packet/charts/images.yaml
@@ -10,7 +10,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.20.1"
+  tag: "0.21.0"
 - name: csi-attacher
   sourceRepository: https://github.com/kubernetes-csi/external-attacher
   repository: quay.io/k8scsi/csi-attacher


### PR DESCRIPTION
*Release Notes*:
``` noteworthy user github.com/gardener/machine-controller-manager #320 @prashanth26
Fixes issues while draining nodes in unknown state.
```

``` improvement user github.com/gardener/machine-controller-manager #320 @prashanth26
Fixes issues while overriding termination grace periods for pods with larger values.
```

``` noteworthy operator github.com/gardener/machine-controller-manager #319 @hardikdr
Fixes consistency issues with machine-deployments, machine-classes, and secrets.
```

``` improvement operator github.com/gardener/machine-controller-manager #319 @hardikdr
Better error handling while adding/removing the finalizers on machine classes & secrets.
```

``` improvement operator github.com/gardener/machine-controller-manager #319 @hardikdr
Re-enqueues the machine classes and secrets periodically(~10mins).
```

``` improvement user github.com/gardener/machine-controller-manager #316 @prashanth26
Deletes nodes object on machine (object) deletion
```

``` improvement operator github.com/gardener/machine-controller-manager #313 @prashanth26
Bugfix: Eliminates creation of orphan NICs when VM creation fails on Azure
```

``` improvement operator github.com/gardener/machine-controller-manager #311 @afritzler
Added additional OpenStack credentials for DomainID, TenantID, UserDomainName
```

``` improvement operator github.com/gardener/machine-controller-manager #300 @prashanth26
Bugfix: Allows force deletion of pods who have no controllers backing them
```