### PR TITLE
Updated timeout and log levels for MCM

### DIFF
--- a/controllers/provider-alicloud/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/controllers/provider-alicloud/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - --namespace={{ .Release.Namespace }}
         - --port={{ .Values.metricsPort }}
         - --machine-creation-timeout=20m
-        - --machine-drain-timeout=12h
+        - --machine-drain-timeout=2h
         - --machine-health-timeout=10m
         - --machine-safety-apiserver-statuscheck-timeout=30s
         - --machine-safety-apiserver-statuscheck-period=1m
@@ -54,7 +54,7 @@ spec:
         - --machine-safety-overshooting-period=1m
         - --safety-up=2
         - --safety-down=1
-        - --v=2
+        - --v=3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/controllers/provider-aws/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/controllers/provider-aws/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - --namespace={{ .Release.Namespace }}
         - --port={{ .Values.metricsPort }}
         - --machine-creation-timeout=20m
-        - --machine-drain-timeout=12h
+        - --machine-drain-timeout=2h
         - --machine-health-timeout=10m
         - --machine-safety-apiserver-statuscheck-timeout=30s
         - --machine-safety-apiserver-statuscheck-period=1m
@@ -54,7 +54,7 @@ spec:
         - --machine-safety-overshooting-period=1m
         - --safety-up=2
         - --safety-down=1
-        - --v=2
+        - --v=3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/controllers/provider-azure/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/controllers/provider-azure/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - --namespace={{ .Release.Namespace }}
         - --port={{ .Values.metricsPort }}
         - --machine-creation-timeout=20m
-        - --machine-drain-timeout=12h
+        - --machine-drain-timeout=2h
         - --machine-health-timeout=10m
         - --machine-safety-apiserver-statuscheck-timeout=30s
         - --machine-safety-apiserver-statuscheck-period=1m
@@ -54,7 +54,7 @@ spec:
         - --machine-safety-overshooting-period=1m
         - --safety-up=2
         - --safety-down=1
-        - --v=2
+        - --v=3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/controllers/provider-gcp/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/controllers/provider-gcp/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - --namespace={{ .Release.Namespace }}
         - --port={{ .Values.metricsPort }}
         - --machine-creation-timeout=20m
-        - --machine-drain-timeout=12h
+        - --machine-drain-timeout=2h
         - --machine-health-timeout=10m
         - --machine-safety-apiserver-statuscheck-timeout=30s
         - --machine-safety-apiserver-statuscheck-period=1m
@@ -54,7 +54,7 @@ spec:
         - --machine-safety-overshooting-period=1m
         - --safety-up=2
         - --safety-down=1
-        - --v=2
+        - --v=3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/controllers/provider-openstack/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/controllers/provider-openstack/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - --namespace={{ .Release.Namespace }}
         - --port={{ .Values.metricsPort }}
         - --machine-creation-timeout=20m
-        - --machine-drain-timeout=12h
+        - --machine-drain-timeout=2h
         - --machine-health-timeout=10m
         - --machine-safety-apiserver-statuscheck-timeout=30s
         - --machine-safety-apiserver-statuscheck-period=1m
@@ -54,7 +54,7 @@ spec:
         - --machine-safety-overshooting-period=1m
         - --safety-up=2
         - --safety-down=1
-        - --v=2
+        - --v=3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/controllers/provider-packet/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/controllers/provider-packet/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - --namespace={{ .Release.Namespace }}
         - --port={{ .Values.metricsPort }}
         - --machine-creation-timeout=20m
-        - --machine-drain-timeout=12h
+        - --machine-drain-timeout=2h
         - --machine-health-timeout=10m
         - --machine-safety-apiserver-statuscheck-timeout=30s
         - --machine-safety-apiserver-statuscheck-period=1m
@@ -54,7 +54,7 @@ spec:
         - --machine-safety-overshooting-period=1m
         - --safety-up=2
         - --safety-down=1
-        - --v=2
+        - --v=3
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:

- We need more logs for debugging MCM with issues. 
- Changes
  - Reduced drain timeouts to `2hrs`
  - Increase log level for MCM to `v=3`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Reduced maximum drain timeout for a machine in MCM to 2hrs
```
