### PR TITLE
Added additional OpenStack Authentication Values 

### DIFF
--- a/controllers/provider-openstack/charts/internal/cloud-provider-config/templates/cloud-provider-config-global.tpl
+++ b/controllers/provider-openstack/charts/internal/cloud-provider-config/templates/cloud-provider-config-global.tpl
@@ -1,8 +1,24 @@
 {{- define "cloud-provider-config-global"}}
 [Global]
 auth-url="{{ .Values.authUrl }}"
+{{- if .Values.domainName }}
 domain-name="{{ .Values.domainName }}"
+{{- end }}
+{{- if .Values.domainID }}
+domain-id="{{ .Values.domainID }}"
+{{- end }}
+{{- if .Values.tenantName }}
 tenant-name="{{ .Values.tenantName }}"
+{{- end }}
+{{- if .Values.tenantID }}
+tenant-id="{{ .Values.tenantID }}"
+{{- end }}
+{{- if .Values.userDomainName }}
+user-domain-name="{{ .Values.userDomainName }}"
+{{- end }}
+{{- if .Values.userDomainID }}
+user-domain-id="{{ .Values.userDomainID }}"
+{{- end }}
 username="{{ .Values.username }}"
 password="{{ .Values.password }}"
 [LoadBalancer]

--- a/controllers/provider-openstack/charts/internal/cloud-provider-config/values.yaml
+++ b/controllers/provider-openstack/charts/internal/cloud-provider-config/values.yaml
@@ -1,8 +1,12 @@
 kubernetesVersion: 0.0.1
 #[Global]
 authUrl: fooURL
-domainName: fooDomain
-tenantName: fooTenant
+# domainName: fooDomain
+# domainID: foo-1234
+# tenantName: fooTenant
+# tenantID: foo-1234
+# userDomainName: fooDomain
+# userDomainID: foo-1234
 username: barUser
 password: barPass
 # [LoadBalancer]

--- a/controllers/provider-openstack/charts/internal/machineclass/templates/machineclass.yaml
+++ b/controllers/provider-openstack/charts/internal/machineclass/templates/machineclass.yaml
@@ -12,8 +12,24 @@ data:
   userData: {{ $machineClass.secret.cloudConfig | b64enc }}
   authURL: {{ $machineClass.secret.authURL | b64enc }}
   insecure: dHJ1ZQ== # true
+  {{- if $machineClass.secret.domainName }}
   domainName: {{ $machineClass.secret.domainName | b64enc }}
+  {{- end }}
+  {{- if $machineClass.secret.domainID }}
+  domainID: {{ $machineClass.secret.domainID | b64enc }}
+  {{- end }}
+  {{- if $machineClass.secret.tenantName }}
   tenantName: {{ $machineClass.secret.tenantName | b64enc }}
+  {{- end }}
+  {{- if $machineClass.secret.tenantID }}
+  tenantID: {{ $machineClass.secret.tenantID | b64enc }}
+  {{- end }}
+  {{- if $machineClass.secret.userDomainName }}
+  userDomainName: {{ $machineClass.secret.userDomainName }}
+  {{- end }}
+  {{- if $machineClass.secret.userDomainID }}
+  userDomainID: {{ $machineClass.secret.userDomainID }}
+  {{- end }}
   username: {{ $machineClass.secret.username | b64enc }}
   password: {{ $machineClass.secret.password | b64enc }}
 ---

--- a/controllers/provider-openstack/charts/internal/machineclass/values.yaml
+++ b/controllers/provider-openstack/charts/internal/machineclass/values.yaml
@@ -14,8 +14,14 @@ machineClasses:
     kubernetes.io/role/node: "1"
   secret:
     authURL: ABCD
-    domainName: ABCD
-    tenantName: abc
+    # at least one of domainName or domainID has to be provided
+    # domainName: ABCD
+    # domainID: abc-123
+    # at least one of tenantName or tenantID has to be provided
+    # tenantName: abc
+    # tenantID: abc-123
+    # userDomainName: ABCD # optional
+    # userDomainID: abc-123 # optional
     username: abc
     password: abc
     cloudConfig: abc

--- a/controllers/provider-openstack/charts/internal/openstack-infra/templates/main.tf
+++ b/controllers/provider-openstack/charts/internal/openstack-infra/templates/main.tf
@@ -1,7 +1,23 @@
 provider "openstack" {
   auth_url    = "{{ required "openstack.authURL is required" .Values.openstack.authURL }}"
-  domain_name = "{{ required "openstack.domainName is required" .Values.openstack.domainName }}"
-  tenant_name = "{{ required "openstack.tenantName is required" .Values.openstack.tenantName }}"
+  {{- if .Values.openstack.domainName }}
+  domain_name = "{{ .Values.openstack.domainName }}"
+  {{- end}}
+  {{- if .Values.openstack.domainID }}
+  domain_id   = "{{ .Values.openstack.domainID }}"
+  {{- end}}
+  {{- if .Values.openstack.tenantName }}
+  tenant_name = "{{ .Values.openstack.tenantName }}"
+  {{- end}}
+  {{- if .Values.openstack.tenantID }}
+  tenant_id = "{{ .Values.openstack.tenantID }}"
+  {{- end}}
+  {{- if .Values.openstack.userDomainName }}
+  user_domain_name = "{{ .Values.openstack.userDomainName }}"
+  {{- end}}
+  {{- if .Values.openstack.userDomainID }}
+  user_domain_id = "{{ .Values.openstack.userDomainID }}"
+  {{- end}}
   region      = "{{ required "openstack.region is required" .Values.openstack.region }}"
   user_name   = "${var.USER_NAME}"
   password    = "${var.PASSWORD}"

--- a/controllers/provider-openstack/charts/internal/openstack-infra/values.yaml
+++ b/controllers/provider-openstack/charts/internal/openstack-infra/values.yaml
@@ -1,7 +1,12 @@
 openstack:
   authURL: https://keystone/v3/
-  domainName: CP
-  tenantName: kubernetes
+  # at least on of domainName or domainID has to be provided
+  # domainName: CP
+  # domainID: abc-123
+  # tenantName: kubernetes
+  # tenantID: abc-123
+  # userDomainName: ABC # optional
+  # userDomainID: abc-123 # optional
   region: eu-de-1
   floatingPoolName: my-pool
 

--- a/controllers/provider-openstack/example/30-backupbucket.yaml
+++ b/controllers/provider-openstack/example/30-backupbucket.yaml
@@ -8,9 +8,13 @@ type: Opaque
 data:
 # authURL: base64(authentication-url)
 # domainName: base64(domain-name)
+# domainID: base64(domain-id)
 # tenantName: base64(tenant-name)
+# tenantID: base64(tenant-id)
 # username: base64(username)
 # password: base64(password)
+# userDomainName: base64(user-domain-name)
+# userDomainID: base64(user-domain-id)
 ---
 apiVersion: extensions.gardener.cloud/v1alpha1
 kind: BackupBucket

--- a/controllers/provider-openstack/example/30-backupentry.yaml
+++ b/controllers/provider-openstack/example/30-backupentry.yaml
@@ -8,9 +8,13 @@ type: Opaque
 data:
 # authURL: base64(authentication-url)
 # domainName: base64(domain-name)
+# domainID: base64(domain-id)
 # tenantName: base64(tenant-name)
+# tenantID: base64(tenant-id)
 # username: base64(username)
 # password: base64(password)
+# userDomainName: base64(user-domain-name)
+# userDomainID: base64(user-domain-id)
 ---
 apiVersion: extensions.gardener.cloud/v1alpha1
 kind: BackupEntry

--- a/controllers/provider-openstack/example/30-infrastructure.yaml
+++ b/controllers/provider-openstack/example/30-infrastructure.yaml
@@ -12,10 +12,14 @@ metadata:
   namespace: shoot--foobar--openstack
 type: Opaque
 data:
-  domainName: AAAA
-  tenantName: AAAA
-  username: AAAA
-  password: AAAA
+# domainName: base64(domain-name)
+# domainID: base64(domain-id)
+# tenantName: base64(tenant-name)
+# tenantID: base64(tenant-id)
+# username: base64(username)
+# password: base64(password)
+# userDomainName: base64(user-domain-name)
+# userDomainID: base64(user-domain-id)
 
 ---
 apiVersion: extensions.gardener.cloud/v1alpha1

--- a/controllers/provider-openstack/example/30-worker.yaml
+++ b/controllers/provider-openstack/example/30-worker.yaml
@@ -7,9 +7,14 @@ metadata:
 type: Opaque
 data:
 # domainName: base64(domain-name)
+# domainID: base64(domain-id)
 # tenantName: base64(tenant-name)
+# tenantID: base64(tenant-id)
 # username: base64(username)
 # password: base64(password)
+# userDomainName: base64(user-domain-name)
+# userDomainID: base64(user-domain-id)
+
 ---
 apiVersion: extensions.gardener.cloud/v1alpha1
 kind: Cluster

--- a/controllers/provider-openstack/pkg/controller/backupentry/actuator.go
+++ b/controllers/provider-openstack/pkg/controller/backupentry/actuator.go
@@ -29,8 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const ()
-
 type actuator struct {
 	client client.Client
 	logger logr.Logger

--- a/controllers/provider-openstack/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-openstack/pkg/controller/controlplane/valuesprovider.go
@@ -246,7 +246,7 @@ func getConfigChartValues(
 
 	// Only the 1.15 out of tree provider for OpenStack support the OS_DOMAIN_NAME/ID
 	// https://github.com/kubernetes/cloud-provider-openstack/pull/733
-	ok, err := gutils.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, ">=", "1.15")
+	ok, _ := gutils.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, ">=", "1.15")
 	if ok {
 		values["userDomainName"] = c.UserDomainName
 		values["userDomainID"] = c.UserDomainID

--- a/controllers/provider-openstack/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-openstack/pkg/controller/controlplane/valuesprovider.go
@@ -236,8 +236,6 @@ func getConfigChartValues(
 		"tenantID":          c.TenantID,
 		"username":          c.Username,
 		"password":          c.Password,
-		"userDomainID":      c.UserDomainID,
-		"userDomainName":    c.UserDomainName,
 		"lbProvider":        cpConfig.LoadBalancerProvider,
 		"floatingNetworkID": infraStatus.Networks.FloatingPool.ID,
 		"subnetID":          subnet.ID,
@@ -250,10 +248,8 @@ func getConfigChartValues(
 	// https://github.com/kubernetes/cloud-provider-openstack/pull/733
 	ok, err := gutils.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, ">=", "1.15")
 	if ok {
-		values = map[string]interface{}{
-			"userDomainName": c.UserDomainName,
-			"userDomainID":   c.UserDomainID,
-		}
+		values["userDomainName"] = c.UserDomainName
+		values["userDomainID"] = c.UserDomainID
 	}
 
 	if cpConfig.LoadBalancerClasses == nil {

--- a/controllers/provider-openstack/pkg/internal/credentials.go
+++ b/controllers/provider-openstack/pkg/internal/credentials.go
@@ -27,11 +27,15 @@ import (
 
 // Credentials contains the necessary OpenStack credential information.
 type Credentials struct {
-	DomainName string
-	TenantName string
-	Username   string
-	Password   string
-	AuthURL    string
+	DomainName     string
+	DomainID       string
+	TenantName     string
+	TenantID       string
+	UserDomainName string
+	UserDomainID   string
+	Username       string
+	Password       string
+	AuthURL        string
 }
 
 // GetCredentials computes for a given context and infrastructure the corresponding credentials object.
@@ -48,13 +52,15 @@ func ExtractCredentials(secret *corev1.Secret) (*Credentials, error) {
 	if secret.Data == nil {
 		return nil, fmt.Errorf("secret does not contain any data")
 	}
-	domainName, err := getRequired(secret.Data, openstack.DomainName)
-	if err != nil {
-		return nil, err
+	domainName, ok := getRequired(secret.Data, openstack.DomainName)
+	domainID, ok2 := getRequired(secret.Data, openstack.DomainID)
+	if ok != nil && ok2 != nil {
+		return nil, fmt.Errorf("at least one of %s or %s has to be provided", openstack.DomainName, openstack.DomainID)
 	}
-	tenantName, err := getRequired(secret.Data, openstack.TenantName)
-	if err != nil {
-		return nil, err
+	tenantName, ok := getRequired(secret.Data, openstack.TenantName)
+	tenantID, ok2 := getRequired(secret.Data, openstack.TenantID)
+	if ok != nil && ok2 != nil {
+		return nil, fmt.Errorf("at least one of %s or %s has to be provided", openstack.TenantName, openstack.TenantID)
 	}
 	userName, err := getRequired(secret.Data, openstack.UserName)
 	if err != nil {
@@ -65,13 +71,19 @@ func ExtractCredentials(secret *corev1.Secret) (*Credentials, error) {
 		return nil, err
 	}
 	authURL := secret.Data[openstack.AuthURL]
+	userDomainName := secret.Data[openstack.UserDomainName]
+	userDomainID := secret.Data[openstack.UserDomainID]
 
 	return &Credentials{
-		DomainName: domainName,
-		TenantName: tenantName,
-		Username:   userName,
-		Password:   password,
-		AuthURL:    string(authURL),
+		DomainName:     domainName,
+		DomainID:       domainID,
+		TenantName:     tenantName,
+		TenantID:       tenantID,
+		UserDomainName: string(userDomainName),
+		UserDomainID:   string(userDomainID),
+		Username:       userName,
+		Password:       password,
+		AuthURL:        string(authURL),
 	}, nil
 }
 

--- a/controllers/provider-openstack/pkg/internal/infrastructure/terraform.go
+++ b/controllers/provider-openstack/pkg/internal/infrastructure/terraform.go
@@ -80,7 +80,11 @@ func ComputeTerraformerChartValues(
 		"openstack": map[string]interface{}{
 			"authURL":          cluster.CloudProfile.Spec.OpenStack.KeyStoneURL,
 			"domainName":       credentials.DomainName,
+			"domainID":         credentials.DomainID,
 			"tenantName":       credentials.TenantName,
+			"tenantID":         credentials.TenantID,
+			"userDomainName":   credentials.UserDomainName,
+			"userDomainID":     credentials.UserDomainID,
 			"region":           infra.Spec.Region,
 			"floatingPoolName": config.FloatingPoolName,
 		},

--- a/controllers/provider-openstack/pkg/internal/infrastructure/terraform_test.go
+++ b/controllers/provider-openstack/pkg/internal/infrastructure/terraform_test.go
@@ -106,7 +106,11 @@ var _ = Describe("Terraform", func() {
 				"openstack": map[string]interface{}{
 					"authURL":          cluster.CloudProfile.Spec.OpenStack.KeyStoneURL,
 					"domainName":       credentials.DomainName,
+					"domainID":         credentials.DomainID,
 					"tenantName":       credentials.TenantName,
+					"tenantID":         credentials.TenantID,
+					"userDomainID":     credentials.UserDomainID,
+					"userDomainName":   credentials.UserDomainName,
 					"region":           infra.Spec.Region,
 					"floatingPoolName": config.FloatingPoolName,
 				},
@@ -142,7 +146,11 @@ var _ = Describe("Terraform", func() {
 				"openstack": map[string]interface{}{
 					"authURL":          cluster.CloudProfile.Spec.OpenStack.KeyStoneURL,
 					"domainName":       credentials.DomainName,
+					"domainID":         credentials.DomainID,
 					"tenantName":       credentials.TenantName,
+					"tenantID":         credentials.TenantID,
+					"userDomainID":     credentials.UserDomainID,
+					"userDomainName":   credentials.UserDomainName,
 					"region":           infra.Spec.Region,
 					"floatingPoolName": config.FloatingPoolName,
 				},

--- a/controllers/provider-openstack/pkg/openstack/client/swift.go
+++ b/controllers/provider-openstack/pkg/openstack/client/swift.go
@@ -43,11 +43,15 @@ func NewStorageClientFromSecretRef(ctx context.Context, c client.Client, secretR
 func newStorageClientFromCredentials(credentials *internal.Credentials, region string) (*StorageClient, error) {
 	opts := &clientconfig.ClientOpts{
 		AuthInfo: &clientconfig.AuthInfo{
-			AuthURL:     credentials.AuthURL,
-			Username:    credentials.Username,
-			Password:    credentials.Password,
-			ProjectName: credentials.TenantName,
-			DomainName:  credentials.DomainName,
+			AuthURL:        credentials.AuthURL,
+			Username:       credentials.Username,
+			Password:       credentials.Password,
+			ProjectName:    credentials.TenantName,
+			ProjectID:      credentials.TenantID,
+			DomainName:     credentials.DomainName,
+			DomainID:       credentials.DomainID,
+			UserDomainName: credentials.UserDomainName,
+			UserDomainID:   credentials.UserDomainID,
 		},
 		RegionName: region,
 	}

--- a/controllers/provider-openstack/pkg/openstack/types.go
+++ b/controllers/provider-openstack/pkg/openstack/types.go
@@ -51,7 +51,7 @@ const (
 	Region = "region"
 	// CloudYAML is a constant for the key in the backup or cloud provider secret that holds the access information for
 	// the etcd backup infrastructure.
-	CloudYAML = "cloudYAML"
+	CloudYAML = "clouds.yaml"
 	// CloudYAMLKey is a constant for the credential key inside the CloudYAML.
 	CloudYAMLKey = "cloudYAMLKey"
 	// CloudYAMLDefaultKey is a constant for the default credentials key inside the CloudYAML.

--- a/controllers/provider-openstack/pkg/openstack/types.go
+++ b/controllers/provider-openstack/pkg/openstack/types.go
@@ -33,8 +33,16 @@ const (
 	AuthURL = "authURL"
 	// DomainName is a constant for the key in a cloud provider secret that holds the OpenStack domain name.
 	DomainName = "domainName"
+	// DomainID is a constant for the key in a cloud provider secret that holds the OpenStack domain name.
+	DomainID = "domainID"
 	// TenantName is a constant for the key in a cloud provider secret that holds the OpenStack tenant name.
 	TenantName = "tenantName"
+	// TenantID is a constant for the key in a cloud provider secret that holds the OpenStack tenant name.
+	TenantID = "tenantID"
+	// UserDomainName is a constant for the key in a cloud provider secret that holds the OpenStack tenant name.
+	UserDomainName = "userDomainName"
+	// UserDomainID is a constant for the key in a cloud provider secret that holds the OpenStack tenant name.
+	UserDomainID = "userDomainID"
 	// UserName is a constant for the key in a cloud provider secret and backup secret that holds the OpenStack username.
 	UserName = "username"
 	// Password is a constant for the key in a cloud provider secret and backup secret that holds the OpenStack password.
@@ -46,9 +54,9 @@ const (
 	// TODO In the future, the bucket name should come from a BackupBucket resource (see https://github.com/gardener/gardener/blob/master/docs/proposals/02-backupinfra.md)
 	BucketName = "bucketName"
 
-	// CloudProviderConfigName is the name of the configmap containing the cloud provider config.
+	// CloudProviderConfigCloudControllerManagerName is the name of the configmap containing the cloud provider config.
 	CloudProviderConfigCloudControllerManagerName = "cloud-provider-config-cloud-controller-manager"
-	// CloudProviderConfigNameInTree is the name of the original configmap containing the cloud provider config (for compatibility reasons).
+	// CloudProviderConfigKubeControllerManagerName is the name of the original configmap containing the cloud provider config (for compatibility reasons).
 	CloudProviderConfigKubeControllerManagerName = "cloud-provider-config-kube-controller-manager"
 	// CloudProviderConfigMapKey is the key storing the cloud provider config as value in the cloud provider configmap.
 	CloudProviderConfigMapKey = "cloudprovider.conf"

--- a/controllers/provider-openstack/pkg/openstack/types.go
+++ b/controllers/provider-openstack/pkg/openstack/types.go
@@ -49,6 +49,13 @@ const (
 	Password = "password"
 	// Region is a constant for the key in a backup secret that holds the Openstack region.
 	Region = "region"
+	// CloudYAML is a constant for the key in the backup or cloud provider secret that holds the access information for
+	// the etcd backup infrastructure.
+	CloudYAML = "cloudYAML"
+	// CloudYAMLKey is a constant for the credential key inside the CloudYAML.
+	CloudYAMLKey = "cloudYAMLKey"
+	// CloudYAMLDefaultKey is a constant for the default credentials key inside the CloudYAML.
+	CloudYAMLDefaultKey = "openstack"
 	// BucketName is a constant for the key in a backup secret that holds the bucket name.
 	// The bucket name is written to the backup secret by Gardener as a temporary solution.
 	// TODO In the future, the bucket name should come from a BackupBucket resource (see https://github.com/gardener/gardener/blob/master/docs/proposals/02-backupinfra.md)

--- a/controllers/provider-openstack/pkg/webhook/controlplanebackup/ensurer.go
+++ b/controllers/provider-openstack/pkg/webhook/controlplanebackup/ensurer.go
@@ -110,93 +110,21 @@ func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscont
 			provider = openstack.StorageProviderName
 			env = []corev1.EnvVar{
 				{
-					Name: "STORAGE_CONTAINER",
+					Name: "OS_CLIENT_CONFIG_FILE",
 					// The bucket name is written to the backup secret by Gardener as a temporary solution.
 					// TODO In the future, the bucket name should come from a BackupBucket resource (see https://github.com/gardener/gardener/blob/master/docs/proposals/02-backupinfra.md)
 					ValueFrom: &corev1.EnvVarSource{
 						SecretKeyRef: &corev1.SecretKeySelector{
-							Key:                  openstack.BucketName,
+							Key:                  openstack.CloudYAML,
 							LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
 						},
 					},
 				},
 				{
-					Name: "OS_AUTH_URL",
+					Name: "OS_CLOUD",
 					ValueFrom: &corev1.EnvVarSource{
 						SecretKeyRef: &corev1.SecretKeySelector{
-							Key:                  openstack.AuthURL,
-							LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
-						},
-					},
-				},
-				{
-					Name: "OS_DOMAIN_NAME",
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							Key:                  openstack.DomainName,
-							LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
-						},
-					},
-				},
-				{
-					Name: "OS_DOMAIN_ID",
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							Key:                  openstack.DomainID,
-							LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
-						},
-					},
-				},
-				{
-					Name: "OS_USERNAME",
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							Key:                  openstack.UserName,
-							LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
-						},
-					},
-				},
-				{
-					Name: "OS_PASSWORD",
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							Key:                  openstack.Password,
-							LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
-						},
-					},
-				},
-				{
-					Name: "OS_TENANT_NAME",
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							Key:                  openstack.TenantName,
-							LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
-						},
-					},
-				},
-				{
-					Name: "OS_TENANT_ID",
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							Key:                  openstack.TenantID,
-							LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
-						},
-					},
-				},
-				{
-					Name: "OS_USER_DOMAIN_NAME",
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							Key:                  openstack.UserDomainName,
-							LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
-						},
-					},
-				},
-				{
-					Name: "OS_USER_DOMAIN_ID",
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							Key:                  openstack.UserDomainID,
+							Key:                  openstack.CloudYAMLKey,
 							LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
 						},
 					},

--- a/controllers/provider-openstack/pkg/webhook/controlplanebackup/ensurer.go
+++ b/controllers/provider-openstack/pkg/webhook/controlplanebackup/ensurer.go
@@ -139,6 +139,15 @@ func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscont
 					},
 				},
 				{
+					Name: "OS_DOMAIN_ID",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							Key:                  openstack.DomainID,
+							LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
+						},
+					},
+				},
+				{
 					Name: "OS_USERNAME",
 					ValueFrom: &corev1.EnvVarSource{
 						SecretKeyRef: &corev1.SecretKeySelector{
@@ -161,6 +170,33 @@ func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscont
 					ValueFrom: &corev1.EnvVarSource{
 						SecretKeyRef: &corev1.SecretKeySelector{
 							Key:                  openstack.TenantName,
+							LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
+						},
+					},
+				},
+				{
+					Name: "OS_TENANT_ID",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							Key:                  openstack.TenantID,
+							LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
+						},
+					},
+				},
+				{
+					Name: "OS_USER_DOMAIN_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							Key:                  openstack.UserDomainName,
+							LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
+						},
+					},
+				},
+				{
+					Name: "OS_USER_DOMAIN_ID",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							Key:                  openstack.UserDomainID,
 							LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
 						},
 					},

--- a/controllers/provider-openstack/pkg/webhook/controlplanebackup/ensurer.go
+++ b/controllers/provider-openstack/pkg/webhook/controlplanebackup/ensurer.go
@@ -110,9 +110,18 @@ func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscont
 			provider = openstack.StorageProviderName
 			env = []corev1.EnvVar{
 				{
-					Name: "OS_CLIENT_CONFIG_FILE",
+					Name: "STORAGE_CONTAINER",
 					// The bucket name is written to the backup secret by Gardener as a temporary solution.
 					// TODO In the future, the bucket name should come from a BackupBucket resource (see https://github.com/gardener/gardener/blob/master/docs/proposals/02-backupinfra.md)
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							Key:                  openstack.BucketName,
+							LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
+						},
+					},
+				},
+				{
+					Name: "OS_CLIENT_CONFIG_FILE",
 					ValueFrom: &corev1.EnvVarSource{
 						SecretKeyRef: &corev1.SecretKeySelector{
 							Key:                  openstack.CloudYAML,

--- a/controllers/provider-openstack/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-openstack/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -229,91 +229,19 @@ func checkETCDMainStatefulSet(ss *appsv1.StatefulSet, annotations map[string]str
 	var (
 		env = []corev1.EnvVar{
 			{
-				Name: "STORAGE_CONTAINER",
+				Name: "OS_CLIENT_CONFIG_FILE",
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
-						Key:                  openstack.BucketName,
+						Key:                  openstack.CloudYAML,
 						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
 					},
 				},
 			},
 			{
-				Name: "OS_AUTH_URL",
+				Name: "OS_CLOUD",
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
-						Key:                  openstack.AuthURL,
-						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
-					},
-				},
-			},
-			{
-				Name: "OS_DOMAIN_NAME",
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						Key:                  openstack.DomainName,
-						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
-					},
-				},
-			},
-			{
-				Name: "OS_DOMAIN_ID",
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						Key:                  openstack.DomainID,
-						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
-					},
-				},
-			},
-			{
-				Name: "OS_USERNAME",
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						Key:                  openstack.UserName,
-						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
-					},
-				},
-			},
-			{
-				Name: "OS_PASSWORD",
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						Key:                  openstack.Password,
-						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
-					},
-				},
-			},
-			{
-				Name: "OS_TENANT_NAME",
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						Key:                  openstack.TenantName,
-						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
-					},
-				},
-			},
-			{
-				Name: "OS_TENANT_ID",
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						Key:                  openstack.TenantID,
-						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
-					},
-				},
-			},
-			{
-				Name: "OS_USER_DOMAIN_NAME",
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						Key:                  openstack.UserDomainName,
-						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
-					},
-				},
-			},
-			{
-				Name: "OS_USER_DOMAIN_ID",
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						Key:                  openstack.UserDomainID,
+						Key:                  openstack.CloudYAMLKey,
 						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
 					},
 				},

--- a/controllers/provider-openstack/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-openstack/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -256,6 +256,15 @@ func checkETCDMainStatefulSet(ss *appsv1.StatefulSet, annotations map[string]str
 				},
 			},
 			{
+				Name: "OS_DOMAIN_ID",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						Key:                  openstack.DomainID,
+						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
+					},
+				},
+			},
+			{
 				Name: "OS_USERNAME",
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
@@ -278,6 +287,33 @@ func checkETCDMainStatefulSet(ss *appsv1.StatefulSet, annotations map[string]str
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						Key:                  openstack.TenantName,
+						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
+					},
+				},
+			},
+			{
+				Name: "OS_TENANT_ID",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						Key:                  openstack.TenantID,
+						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
+					},
+				},
+			},
+			{
+				Name: "OS_USER_DOMAIN_NAME",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						Key:                  openstack.UserDomainName,
+						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
+					},
+				},
+			},
+			{
+				Name: "OS_USER_DOMAIN_ID",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						Key:                  openstack.UserDomainID,
 						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
 					},
 				},

--- a/controllers/provider-openstack/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-openstack/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -229,6 +229,15 @@ func checkETCDMainStatefulSet(ss *appsv1.StatefulSet, annotations map[string]str
 	var (
 		env = []corev1.EnvVar{
 			{
+				Name: "STORAGE_CONTAINER",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						Key:                  openstack.BucketName,
+						LocalObjectReference: corev1.LocalObjectReference{Name: openstack.BackupSecretName},
+					},
+				},
+			},
+			{
 				Name: "OS_CLIENT_CONFIG_FILE",
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -24,4 +24,8 @@ SKIP_TESTS=$(echo controllers/provider-{alicloud,aws,azure,gcp,openstack,packet}
 
 header_text "Test"
 
+if [ $# -gt 0 ]; then
+GO111MODULE=on ginkgo -mod=vendor --skipPackage="${SKIP_TESTS}" -r "${@}"
+else
 GO111MODULE=on ginkgo -mod=vendor --skipPackage="${SKIP_TESTS}" -r "${SOURCE_TREES[@]}"
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Added additional OpenStack Authentication Values 

**Which issue(s) this PR fixes**:
This PR is part of https://github.com/gardener/gardener-extensions/issues/154

**Release note**:
```noteworthyuser
Added support for additional OpenStack authentication values: `TenantID`, `DomainID`, `UserDomainName`, `UserDomainID`. Check out the example manifests.
```
