### PR TITLE
[fix] Ignore us-east-1 location constraint in backup bucket creation

### DIFF
--- a/controllers/provider-aws/pkg/aws/client/client.go
+++ b/controllers/provider-aws/pkg/aws/client/client.go
@@ -233,6 +233,10 @@ func (c *Client) CreateBucketIfNotExists(ctx context.Context, bucket, region str
 		},
 	}
 
+	if region == "us-east-1" {
+		createBucketInput.CreateBucketConfiguration = nil
+	}
+
 	if _, err := c.S3.CreateBucketWithContext(ctx, createBucketInput); err != nil {
 		if aerr, ok := err.(awserr.Error); ok && (aerr.Code() == s3.ErrCodeBucketAlreadyExists || aerr.Code() == s3.ErrCodeBucketAlreadyOwnedByYou) {
 			return nil


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
