### PR TITLE
[ci:component:github.com/gardener/etcd-backup-restore:0.7.1->0.7.2]

### DIFF
--- a/controllers/provider-alicloud/charts/images.yaml
+++ b/controllers/provider-alicloud/charts/images.yaml
@@ -10,7 +10,7 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "0.7.1"
+  tag: "0.7.2"
 - name: alicloud-controller-manager
   sourceRepository: https://github.com/kubernetes/cloud-provider-alibaba-cloud
   repository: registry.eu-central-1.aliyuncs.com/gardener-de/alibaba-cloud-controller-manager

--- a/controllers/provider-aws/charts/images.yaml
+++ b/controllers/provider-aws/charts/images.yaml
@@ -13,7 +13,7 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "0.7.1"
+  tag: "0.7.2"
 - name: aws-lb-readvertiser
   sourceRepository: github.com/gardener/aws-lb-readvertiser
   repository: eu.gcr.io/gardener-project/gardener/aws-lb-readvertiser

--- a/controllers/provider-azure/charts/images.yaml
+++ b/controllers/provider-azure/charts/images.yaml
@@ -13,4 +13,4 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "0.7.1"
+  tag: "0.7.2"

--- a/controllers/provider-gcp/charts/images.yaml
+++ b/controllers/provider-gcp/charts/images.yaml
@@ -13,4 +13,4 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "0.7.1"
+  tag: "0.7.2"

--- a/controllers/provider-openstack/charts/images.yaml
+++ b/controllers/provider-openstack/charts/images.yaml
@@ -10,7 +10,7 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "0.7.1"
+  tag: "0.7.2"
 - name: openstack-cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager

--- a/controllers/provider-packet/charts/images.yaml
+++ b/controllers/provider-packet/charts/images.yaml
@@ -48,7 +48,7 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "0.7.1"
+  tag: "0.7.2"
 - name: metabot
   sourceRepository: https://github.com/packethost/metabot
   repository: packethost/metabot


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/etcd-backup-restore #198 @swapnilgm
Fix the object listing for OSS snapstore.
```