### PR TITLE
Fix alicloud backupentry deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # [Gardener Extensions](https://gardener.cloud)
 
+[![CI Build status](https://concourse.ci.infra.gardener.cloud/api/v1/teams/gardener/pipelines/gardener-extensions-master/jobs/master-head-update-job/badge)](https://concourse.ci.infra.gardener.cloud/teams/gardener/pipelines/gardener-extensions-master/jobs/master-head-update-job)
+
 Project Gardener implements the automated management and operation of [Kubernetes](https://kubernetes.io/) clusters as a service. Its main principle is to leverage Kubernetes concepts for all of its tasks.
 
 Recently, most of the vendor specific logic has been developed [in-tree](https://github.com/gardener/gardener). However, the project has grown to a size where it is very hard to extend, maintain, and test. With [GEP-1](https://github.com/gardener/gardener/blob/master/docs/proposals/01-extensibility.md) we have proposed how the architecture can be changed in a way to support external controllers that contain their very own vendor specifics. This way, we can keep Gardener core clean and independent.

--- a/controllers/provider-alicloud/pkg/alicloud/client/client.go
+++ b/controllers/provider-alicloud/pkg/alicloud/client/client.go
@@ -79,7 +79,8 @@ func (c *storageClient) DeleteObjectsWithPrefix(ctx context.Context, bucketName,
 
 	marker := ""
 	for {
-		lsRes, err := bucket.ListObjects(oss.Marker(marker), oss.Prefix(prefix), expirationOption)
+		lsRes, err := bucket.ListObjects(oss.Marker(marker), oss.Prefix(prefix), oss.MaxKeys(1000), expirationOption)
+
 		if err != nil {
 			return err
 		}
@@ -89,8 +90,10 @@ func (c *storageClient) DeleteObjectsWithPrefix(ctx context.Context, bucketName,
 			objectKeys = append(objectKeys, object.Key)
 		}
 
-		if _, err := bucket.DeleteObjects(objectKeys, oss.DeleteObjectsQuiet(true), expirationOption); err != nil {
-			return err
+		if len(objectKeys) != 0 {
+			if _, err := bucket.DeleteObjects(objectKeys, oss.DeleteObjectsQuiet(true), expirationOption); err != nil {
+				return err
+			}
 		}
 
 		if lsRes.IsTruncated {


### PR DESCRIPTION
**What this PR does / why we need it**:
The backupEntry deletion returns following error: 
```
level=error msg="Failed to delete backup entry: flow \"Backup Entry deletion\" encountered task errors: [task \"Waiting until extension backup entry is deleted\" failed: Error while waiting for backupEntry object to be deleted: Error deleting backupentry: oss: service returned error: StatusCode=400, ErrorCode=MalformedXML, ErrorMessage=\"The XML you provided was not well-formed or did not validate against our published schema.\", 
RequestId=5D7103DC5B235DBCD1A26CFC]" 
```
This PR fixes the issue by correct handling of SDK API.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @minchaow 
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fix the backupEntry deletion logic for Alicloud implementation.
```
