### PR TITLE
Check for ProviderConfig in CP Actuator to prevent manual intervention when updating

### DIFF
--- a/controllers/provider-alicloud/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-alicloud/pkg/controller/controlplane/valuesprovider.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 
 	"github.com/gardener/gardener-extensions/controllers/provider-alicloud/pkg/alicloud"
@@ -218,6 +219,9 @@ func (vp *valuesProvider) GetConfigChartValues(
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 ) (map[string]interface{}, error) {
+	if cp.Spec.ProviderConfig == nil {
+		return nil, fmt.Errorf("cannot decode nil providerConfig of ControlePlane '%s'", util.ObjectName(cp))
+	}
 	// Decode providerConfig
 	cpConfig := &apisalicloud.ControlPlaneConfig{}
 	if _, _, err := vp.decoder.Decode(cp.Spec.ProviderConfig.Raw, nil, cpConfig); err != nil {
@@ -248,6 +252,9 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	checksums map[string]string,
 	scaledDown bool,
 ) (map[string]interface{}, error) {
+	if cp.Spec.ProviderConfig == nil {
+		return nil, fmt.Errorf("cannot decode nil providerConfig of ControlePlane '%s'", util.ObjectName(cp))
+	}
 	// Decode providerConfig
 	cpConfig := &apisalicloud.ControlPlaneConfig{}
 	if _, _, err := vp.decoder.Decode(cp.Spec.ProviderConfig.Raw, nil, cpConfig); err != nil {

--- a/controllers/provider-aws/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-aws/pkg/controller/controlplane/valuesprovider.go
@@ -16,6 +16,7 @@ package controlplane
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 
 	apisaws "github.com/gardener/gardener-extensions/controllers/provider-aws/pkg/apis/aws"
@@ -194,6 +195,9 @@ func (vp *valuesProvider) GetConfigChartValues(
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 ) (map[string]interface{}, error) {
+	if cp.Spec.ProviderConfig == nil {
+		return nil, fmt.Errorf("cannot decode nil providerConfig of ControlePlane '%s'", util.ObjectName(cp))
+	}
 	// Decode infrastructureProviderStatus
 	infraStatus := &apisaws.InfrastructureStatus{}
 	if _, _, err := vp.decoder.Decode(cp.Spec.InfrastructureProviderStatus.Raw, nil, infraStatus); err != nil {
@@ -212,6 +216,9 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	checksums map[string]string,
 	scaledDown bool,
 ) (map[string]interface{}, error) {
+	if cp.Spec.ProviderConfig == nil {
+		return nil, fmt.Errorf("cannot decode nil providerConfig of ControlePlane '%s'", util.ObjectName(cp))
+	}
 	// Decode providerConfig
 	cpConfig := &apisaws.ControlPlaneConfig{}
 	if _, _, err := vp.decoder.Decode(cp.Spec.ProviderConfig.Raw, nil, cpConfig); err != nil {

--- a/controllers/provider-azure/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-azure/pkg/controller/controlplane/valuesprovider.go
@@ -16,6 +16,7 @@ package controlplane
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -162,6 +163,9 @@ func (vp *valuesProvider) GetConfigChartValues(
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 ) (map[string]interface{}, error) {
+	if cp.Spec.ProviderConfig == nil {
+		return nil, fmt.Errorf("cannot decode nil providerConfig of ControlePlane '%s'", util.ObjectName(cp))
+	}
 	// Decode providerConfig
 	cpConfig := &apisazure.ControlPlaneConfig{}
 	if _, _, err := vp.decoder.Decode(cp.Spec.ProviderConfig.Raw, nil, cpConfig); err != nil {
@@ -198,6 +202,9 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	checksums map[string]string,
 	scaledDown bool,
 ) (map[string]interface{}, error) {
+	if cp.Spec.ProviderConfig == nil {
+		return nil, fmt.Errorf("cannot decode nil providerConfig of ControlePlane '%s'", util.ObjectName(cp))
+	}
 	// Decode providerConfig
 	cpConfig := &apisazure.ControlPlaneConfig{}
 	if _, _, err := vp.decoder.Decode(cp.Spec.ProviderConfig.Raw, nil, cpConfig); err != nil {

--- a/controllers/provider-gcp/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-gcp/pkg/controller/controlplane/valuesprovider.go
@@ -16,6 +16,7 @@ package controlplane
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 
 	apisgcp "github.com/gardener/gardener-extensions/controllers/provider-gcp/pkg/apis/gcp"
@@ -153,6 +154,10 @@ func (vp *valuesProvider) GetConfigChartValues(
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 ) (map[string]interface{}, error) {
+	if cp.Spec.ProviderConfig == nil {
+		return nil, fmt.Errorf("cannot decode nil providerConfig of ControlePlane '%s'", util.ObjectName(cp))
+	}
+
 	// Decode providerConfig
 	cpConfig := &apisgcp.ControlPlaneConfig{}
 	if _, _, err := vp.decoder.Decode(cp.Spec.ProviderConfig.Raw, nil, cpConfig); err != nil {
@@ -183,6 +188,9 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	checksums map[string]string,
 	scaledDown bool,
 ) (map[string]interface{}, error) {
+	if cp.Spec.ProviderConfig == nil {
+		return nil, fmt.Errorf("cannot decode nil providerConfig of ControlePlane '%s'", util.ObjectName(cp))
+	}
 	// Decode providerConfig
 	cpConfig := &apisgcp.ControlPlaneConfig{}
 	if _, _, err := vp.decoder.Decode(cp.Spec.ProviderConfig.Raw, nil, cpConfig); err != nil {

--- a/controllers/provider-openstack/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-openstack/pkg/controller/controlplane/valuesprovider.go
@@ -16,6 +16,7 @@ package controlplane
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 
 	apisopenstack "github.com/gardener/gardener-extensions/controllers/provider-openstack/pkg/apis/openstack"
@@ -153,6 +154,9 @@ func (vp *valuesProvider) GetConfigChartValues(
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 ) (map[string]interface{}, error) {
+	if cp.Spec.ProviderConfig == nil {
+		return nil, fmt.Errorf("cannot decode nil providerConfig of ControlePlane '%s'", util.ObjectName(cp))
+	}
 	// Decode providerConfig
 	cpConfig := &apisopenstack.ControlPlaneConfig{}
 	if _, _, err := vp.decoder.Decode(cp.Spec.ProviderConfig.Raw, nil, cpConfig); err != nil {
@@ -183,6 +187,9 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	checksums map[string]string,
 	scaledDown bool,
 ) (map[string]interface{}, error) {
+	if cp.Spec.ProviderConfig == nil {
+		return nil, fmt.Errorf("cannot decode nil providerConfig of ControlePlane '%s'", util.ObjectName(cp))
+	}
 	// Decode providerConfig
 	cpConfig := &apisopenstack.ControlPlaneConfig{}
 	if _, _, err := vp.decoder.Decode(cp.Spec.ProviderConfig.Raw, nil, cpConfig); err != nil {

--- a/controllers/provider-packet/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-packet/pkg/controller/controlplane/valuesprovider.go
@@ -17,6 +17,7 @@ package controlplane
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"path/filepath"
 
 	apispacket "github.com/gardener/gardener-extensions/controllers/provider-packet/pkg/apis/packet"
@@ -194,6 +195,9 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	checksums map[string]string,
 	scaledDown bool,
 ) (map[string]interface{}, error) {
+	if cp.Spec.ProviderConfig == nil {
+		return nil, fmt.Errorf("cannot decode nil providerConfig of ControlePlane '%s'", util.ObjectName(cp))
+	}
 	// Decode providerConfig
 	cpConfig := &apispacket.ControlPlaneConfig{}
 	if _, _, err := vp.decoder.Decode(cp.Spec.ProviderConfig.Raw, nil, cpConfig); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Updating Extensions & Gardener without manual intervention.

I recently updated my Gardener Setup using the newest GardenerAPi Server & ControllerManager & newest provider extension.
I already had a ControlPlane & ControlPlaneExposure resources for my shoot.

**Problem:**

- GardenerController Manager reconcile fails waiting for succesful reconcile of the ControlePlane resource
-  gcp provider - controlplane actuator ran into nil pointer exception reconciling the ControlePlane Exposure 

- Provider is in CrashLoop and never reconciles the actual ControlePlane -> Gardener reconcile fails before it can update the ControlePlaneExposure -> deadlock


**Cause:**
- the newest provider distinguishes between ControlePlane & ControlePlane Exposure via the Spec.Purpose field
- ControlePlane Exposure is not yet updated by GardnerControllerManager to include the Purpose field -> will be reconciled as normal ControlePlane -> nil pointer

**Solution**

Check for ProviderConfig in ControlePlane

Other workaround:
- delete the ControlePlaneExposure via & restart provider





**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
