### PR TITLE
Adapt extensions to be able to work with `core.gardener.cloud/v1alpha1` resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,8 @@ start-os-coreos:
 		--ignore-operation-annotation=$(IGNORE_OPERATION_ANNOTATION) \
 		--leader-election=$(LEADER_ELECTION)
 
-.PHONY: start-os-jeos
-start-os-jeos:
+.PHONY: start-os-suse-jeos
+start-os-suse-jeos:
 	@LEADER_ELECTION_NAMESPACE=garden GO111MODULE=on go run \
 		-mod=vendor \
 		-ldflags $(LD_FLAGS) \

--- a/controllers/extension-certificate-service/example/30-cluster.yaml
+++ b/controllers/extension-certificate-service/example/30-cluster.yaml
@@ -5,13 +5,13 @@ metadata:
   name: shoot--foo--bar
 spec:
   cloudProfile:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: CloudProfile
   seed:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Seed
   shoot:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Shoot
     metadata:
       generation: 1

--- a/controllers/extension-shoot-dns-service/example/30-cluster.yaml
+++ b/controllers/extension-shoot-dns-service/example/30-cluster.yaml
@@ -5,13 +5,13 @@ metadata:
   name: shoot--foo--bar
 spec:
   cloudProfile:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: CloudProfile
   seed:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Seed
   shoot:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Shoot
     metadata:
       generation: 1

--- a/controllers/networking-calico/example/20-network.yaml
+++ b/controllers/networking-calico/example/20-network.yaml
@@ -13,13 +13,13 @@ metadata:
   name: shoot--foo--bar
 spec:
   cloudProfile:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: CloudProfile
   seed:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Seed
   shoot:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Shoot
     metadata:
       generation: 1

--- a/controllers/networking-calico/pkg/controller/actuator_delete.go
+++ b/controllers/networking-calico/pkg/controller/actuator_delete.go
@@ -26,12 +26,14 @@ import (
 
 // Delete implements Network.Actuator.
 func (a *actuator) Delete(ctx context.Context, network *extensionsv1alpha1.Network, cluster *extensionscontroller.Cluster) error {
-	if err := resourcemanager.NewSecret(a.client).
+	if err := resourcemanager.
+		NewSecret(a.client).
 		WithNamespacedName(network.Namespace, calicoConfigSecretName).
 		Delete(ctx); err != nil {
 		return err
 	}
-	if err := resourcemanager.NewManagedResource(a.client).
+	if err := resourcemanager.
+		NewManagedResource(a.client).
 		WithNamespacedName(network.Namespace, calicoConfigSecretName).
 		Delete(ctx); err != nil {
 		return err

--- a/controllers/networking-calico/pkg/controller/actuator_reconcile.go
+++ b/controllers/networking-calico/pkg/controller/actuator_reconcile.go
@@ -62,7 +62,7 @@ func (a *actuator) Reconcile(ctx context.Context, network *extensionsv1alpha1.Ne
 	}
 
 	// Create shoot chart renderer
-	chartRenderer, err := a.chartRendererFactory.NewChartRendererForShoot(cluster.Shoot.Spec.Kubernetes.Version)
+	chartRenderer, err := a.chartRendererFactory.NewChartRendererForShoot(extensionscontroller.GetKubernetesVersion(cluster))
 	if err != nil {
 		return errors.Wrapf(err, "could not create chart renderer for shoot '%s'", network.Namespace)
 	}
@@ -78,7 +78,8 @@ func (a *actuator) Reconcile(ctx context.Context, network *extensionsv1alpha1.Ne
 		return err
 	}
 
-	if err := manager.NewManagedResource(a.client).
+	if err := manager.
+		NewManagedResource(a.client).
 		WithNamespacedName(network.Namespace, calicoConfigSecretName).
 		WithSecretRefs(secretRefs).
 		WithInjectedLabels(map[string]string{common.ShootNoCleanup: "true"}).

--- a/controllers/provider-alicloud/example/30-controlplane.yaml
+++ b/controllers/provider-alicloud/example/30-controlplane.yaml
@@ -24,19 +24,17 @@ metadata:
   name: shoot--foobar--alicloud
 spec:
   cloudProfile:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: CloudProfile
   seed:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Seed
   shoot:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Shoot
     spec:
-      cloud:
-        alicloud:
-          networks:
-            pods: 10.250.0.0/19
+      networking:
+        pods: 10.250.0.0/19
       kubernetes:
         version: 1.14.0
       hibernation:

--- a/controllers/provider-alicloud/example/30-infrastructure.yaml
+++ b/controllers/provider-alicloud/example/30-infrastructure.yaml
@@ -20,22 +20,20 @@ metadata:
   name: shoot--foobar--alicloud
 spec:
   cloudProfile:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: CloudProfile
     spec:
       alicloud:
   seed:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Seed
   shoot:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Shoot
     spec:
-      cloud:
-        alicloud:
-          networks:
-            pods: 10.243.128.0/17
-            services: 10.243.0.0/17
+      networking:
+        pods: 10.243.128.0/17
+        services: 10.243.0.0/17
     status:
       lastOperation:
         state: Succeeded

--- a/controllers/provider-alicloud/example/30-worker.yaml
+++ b/controllers/provider-alicloud/example/30-worker.yaml
@@ -15,13 +15,13 @@ metadata:
   name: shoot--foobar--alicloud
 spec:
   cloudProfile:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: CloudProfile
   seed:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Seed
   shoot:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Shoot
     spec:
       kubernetes:

--- a/controllers/provider-alicloud/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-alicloud/pkg/controller/controlplane/valuesprovider.go
@@ -334,10 +334,10 @@ func getControlPlaneChartValues(
 ) (map[string]interface{}, error) {
 	values := map[string]interface{}{
 		"alicloud-cloud-controller-manager": map[string]interface{}{
-			"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster.Shoot, scaledDown, 1),
+			"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
 			"clusterName":       cp.Namespace,
-			"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
-			"podNetwork":        extensionscontroller.GetPodNetwork(cluster.Shoot),
+			"kubernetesVersion": extensionscontroller.GetKubernetesVersion(cluster),
+			"podNetwork":        extensionscontroller.GetPodNetwork(cluster),
 			"podAnnotations": map[string]interface{}{
 				"checksum/secret-cloud-controller-manager": checksums["cloud-controller-manager"],
 				"checksum/secret-cloudprovider":            checksums[v1alpha1constants.SecretNameCloudProvider],
@@ -345,8 +345,8 @@ func getControlPlaneChartValues(
 			},
 		},
 		"csi-alicloud": map[string]interface{}{
-			"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster.Shoot, scaledDown, 1),
-			"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
+			"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
+			"kubernetesVersion": extensionscontroller.GetKubernetesVersion(cluster),
 			"regionID":          cp.Spec.Region,
 			"podAnnotations": map[string]interface{}{
 				"checksum/secret-csi-attacher":    checksums["csi-attacher"],
@@ -375,7 +375,7 @@ func getControlPlaneShootChartValues(
 				"accessKeyID":     base64.StdEncoding.EncodeToString([]byte(credentials.AccessKeyID)),
 				"accessKeySecret": base64.StdEncoding.EncodeToString([]byte(credentials.AccessKeySecret)),
 			},
-			"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
+			"kubernetesVersion": extensionscontroller.GetKubernetesVersion(cluster),
 		},
 	}
 

--- a/controllers/provider-alicloud/pkg/controller/controlplane/valuesprovider_test.go
+++ b/controllers/provider-alicloud/pkg/controller/controlplane/valuesprovider_test.go
@@ -23,9 +23,9 @@ import (
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -89,18 +89,12 @@ var _ = Describe("ValuesProvider", func() {
 
 		cidr    = "10.250.0.0/19"
 		cluster = &extensionscontroller.Cluster{
-			Shoot: &gardenv1beta1.Shoot{
-				Spec: gardenv1beta1.ShootSpec{
-					Cloud: gardenv1beta1.Cloud{
-						Alicloud: &gardenv1beta1.Alicloud{
-							Networks: gardenv1beta1.AlicloudNetworks{
-								K8SNetworks: gardenv1beta1.K8SNetworks{
-									Pods: &cidr,
-								},
-							},
-						},
+			CoreShoot: &gardencorev1alpha1.Shoot{
+				Spec: gardencorev1alpha1.ShootSpec{
+					Networking: gardencorev1alpha1.Networking{
+						Pods: &cidr,
 					},
-					Kubernetes: gardenv1beta1.Kubernetes{
+					Kubernetes: gardencorev1alpha1.Kubernetes{
 						Version: "1.14.0",
 					},
 				},

--- a/controllers/provider-alicloud/pkg/controller/worker/machines.go
+++ b/controllers/provider-alicloud/pkg/controller/worker/machines.go
@@ -23,6 +23,7 @@ import (
 	alicloudapi "github.com/gardener/gardener-extensions/controllers/provider-alicloud/pkg/apis/alicloud"
 	apisalicloud "github.com/gardener/gardener-extensions/controllers/provider-alicloud/pkg/apis/alicloud"
 	alicloudapihelper "github.com/gardener/gardener-extensions/controllers/provider-alicloud/pkg/apis/alicloud/helper"
+	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	"github.com/gardener/gardener-extensions/pkg/controller/worker"
 	"github.com/gardener/gardener-extensions/pkg/util"
 
@@ -84,7 +85,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 		return err
 	}
 
-	shootVersionMajorMinor, err := util.VersionMajorMinor(w.cluster.Shoot.Spec.Kubernetes.Version)
+	shootVersionMajorMinor, err := util.VersionMajorMinor(extensionscontroller.GetKubernetesVersion(w.cluster))
 	if err != nil {
 		return err
 	}

--- a/controllers/provider-alicloud/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-alicloud/pkg/controller/worker/machines_test.go
@@ -30,8 +30,8 @@ import (
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	mockkubernetes "github.com/gardener/gardener-extensions/pkg/mock/gardener/client/kubernetes"
 
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -188,9 +188,9 @@ var _ = Describe("Machines", func() {
 				}
 
 				cluster = &extensionscontroller.Cluster{
-					Shoot: &gardenv1beta1.Shoot{
-						Spec: gardenv1beta1.ShootSpec{
-							Kubernetes: gardenv1beta1.Kubernetes{
+					CoreShoot: &gardencorev1alpha1.Shoot{
+						Spec: gardencorev1alpha1.ShootSpec{
+							Kubernetes: gardencorev1alpha1.Kubernetes{
 								Version: shootVersion,
 							},
 						},
@@ -437,7 +437,7 @@ var _ = Describe("Machines", func() {
 			It("should fail because the version is invalid", func() {
 				expectGetSecretCallToWork(c, alicloudAccessKeyID, alicloudAccessKeySecret)
 
-				cluster.Shoot.Spec.Kubernetes.Version = "invalid"
+				cluster.CoreShoot.Spec.Kubernetes.Version = "invalid"
 				workerDelegate = NewWorkerDelegate(c, scheme, decoder, machineImages, chartApplier, "", w, cluster)
 
 				result, err := workerDelegate.GenerateMachineDeployments(context.TODO())

--- a/controllers/provider-alicloud/pkg/webhook/controlplanebackup/ensurer.go
+++ b/controllers/provider-alicloud/pkg/webhook/controlplanebackup/ensurer.go
@@ -62,7 +62,7 @@ func (e *ensurer) EnsureETCDStatefulSet(ctx context.Context, ss *appsv1.Stateful
 	if err := e.ensureContainers(&ss.Spec.Template.Spec, ss.Name, cluster); err != nil {
 		return err
 	}
-	return e.ensureChecksumAnnotations(ctx, &ss.Spec.Template, ss.Namespace, ss.Name, cluster.Seed.Spec.Backup != nil)
+	return e.ensureChecksumAnnotations(ctx, &ss.Spec.Template, ss.Namespace, ss.Name, !extensionscontroller.IsSeedBackupNil(cluster))
 }
 
 func (e *ensurer) ensureContainers(ps *corev1.PodSpec, name string, cluster *extensionscontroller.Cluster) error {
@@ -84,7 +84,7 @@ func (e *ensurer) ensureChecksumAnnotations(ctx context.Context, template *corev
 func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscontroller.Cluster) (*corev1.Container, error) {
 	// Find etcd-backup-restore image
 	// TODO Get seed version from clientset when it's possible to inject it
-	image, err := e.imageVector.FindImage(alicloud.ETCDBackupRestoreImageName, imagevector.TargetVersion(cluster.Shoot.Spec.Kubernetes.Version))
+	image, err := e.imageVector.FindImage(alicloud.ETCDBackupRestoreImageName, imagevector.TargetVersion(extensionscontroller.GetKubernetesVersion(cluster)))
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not find image %s", alicloud.ETCDBackupRestoreImageName)
 	}
@@ -102,10 +102,10 @@ func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscont
 		volumeClaimTemplateName = name
 	)
 	if name == v1alpha1constants.StatefulSetNameETCDMain {
-		if cluster.Seed.Spec.Backup == nil {
-			e.logger.Info("Backup profile is not configured;  backup will not be taken for etcd-main")
+		if extensionscontroller.IsSeedBackupNil(cluster) {
+			e.logger.Info("Backup profile is not configured; backup will not be taken for etcd-main")
 		} else {
-			prefix = common.GenerateBackupEntryName(cluster.Shoot.Status.TechnicalID, cluster.Shoot.Status.UID)
+			prefix = common.GenerateBackupEntryName(extensionscontroller.GetTechnicalID(cluster), extensionscontroller.GetUID(cluster))
 			provider = alicloud.StorageProviderName
 			env = []corev1.EnvVar{
 				{

--- a/controllers/provider-alicloud/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-alicloud/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -26,8 +26,8 @@ import (
 	extensionswebhook "github.com/gardener/gardener-extensions/pkg/webhook"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
 
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -68,20 +68,20 @@ var _ = Describe("Ensurer", func() {
 			}
 
 			cluster = &extensionscontroller.Cluster{
-				Shoot: &gardenv1beta1.Shoot{
-					Spec: gardenv1beta1.ShootSpec{
-						Kubernetes: gardenv1beta1.Kubernetes{
+				CoreShoot: &gardencorev1alpha1.Shoot{
+					Spec: gardencorev1alpha1.ShootSpec{
+						Kubernetes: gardencorev1alpha1.Kubernetes{
 							Version: "1.13.4",
 						},
 					},
-					Status: gardenv1beta1.ShootStatus{
+					Status: gardencorev1alpha1.ShootStatus{
 						TechnicalID: "shoot--test--sample",
 						UID:         types.UID("test-uid"),
 					},
 				},
-				Seed: &gardenv1beta1.Seed{
-					Spec: gardenv1beta1.SeedSpec{
-						Backup: &gardenv1beta1.BackupProfile{},
+				CoreSeed: &gardencorev1alpha1.Seed{
+					Spec: gardencorev1alpha1.SeedSpec{
+						Backup: &gardencorev1alpha1.SeedBackup{},
 					},
 				},
 			}
@@ -164,7 +164,7 @@ var _ = Describe("Ensurer", func() {
 			ss := &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1alpha1constants.StatefulSetNameETCDMain},
 			}
-			cluster.Seed.Spec.Backup = nil
+			cluster.CoreSeed.Spec.Backup = nil
 
 			// Create mock client
 			client := mockclient.NewMockClient(ctrl)

--- a/controllers/provider-aws/example/30-controlplane.yaml
+++ b/controllers/provider-aws/example/30-controlplane.yaml
@@ -24,19 +24,17 @@ metadata:
   name: shoot--foobar--aws
 spec:
   cloudProfile:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: CloudProfile
   seed:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Seed
   shoot:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Shoot
     spec:
-      cloud:
-        aws:
-          networks:
-            pods: 10.250.0.0/19
+      networking:
+        pods: 10.250.0.0/19
       kubernetes:
         version: 1.13.4
       hibernation:

--- a/controllers/provider-aws/example/30-controlplaneexposure.yaml
+++ b/controllers/provider-aws/example/30-controlplaneexposure.yaml
@@ -5,19 +5,17 @@ metadata:
   name: shoot--foobar--aws
 spec:
   cloudProfile:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: CloudProfile
   seed:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Seed
   shoot:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Shoot
     spec:
-      cloud:
-        aws:
-          networks:
-            pods: 10.250.0.0/19
+      networking:
+        pods: 10.250.0.0/19
       kubernetes:
         version: 1.13.4
       hibernation:

--- a/controllers/provider-aws/example/30-infrastructure.yaml
+++ b/controllers/provider-aws/example/30-infrastructure.yaml
@@ -15,13 +15,13 @@ metadata:
   name: shoot--foobar--aws
 spec:
   cloudProfile:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: CloudProfile
   seed:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Seed
   shoot:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Shoot
     status:
       lastOperation:

--- a/controllers/provider-aws/example/30-worker.yaml
+++ b/controllers/provider-aws/example/30-worker.yaml
@@ -15,13 +15,13 @@ metadata:
   name: shoot--foobar--aws
 spec:
   cloudProfile:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: CloudProfile
   seed:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Seed
   shoot:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Shoot
     spec:
       kubernetes:

--- a/controllers/provider-aws/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-aws/pkg/controller/controlplane/valuesprovider.go
@@ -238,7 +238,7 @@ func (vp *valuesProvider) GetControlPlaneExposureChartValues(
 
 	return map[string]interface{}{
 		"domain":   address,
-		"replicas": extensionscontroller.GetReplicas(cluster.Shoot, 1),
+		"replicas": extensionscontroller.GetReplicas(cluster, 1),
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-aws-lb-readvertiser": checksums[awsLBReadvertiserDeploymentName],
 		},
@@ -274,10 +274,10 @@ func getCCMChartValues(
 	scaledDown bool,
 ) (map[string]interface{}, error) {
 	values := map[string]interface{}{
-		"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster.Shoot, scaledDown, 1),
+		"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
 		"clusterName":       cp.Namespace,
-		"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
-		"podNetwork":        extensionscontroller.GetPodNetwork(cluster.Shoot),
+		"kubernetesVersion": extensionscontroller.GetKubernetesVersion(cluster),
+		"podNetwork":        extensionscontroller.GetPodNetwork(cluster),
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-cloud-controller-manager":        checksums[cloudControllerManagerDeploymentName],
 			"checksum/secret-cloud-controller-manager-server": checksums[cloudControllerManagerServerName],

--- a/controllers/provider-aws/pkg/controller/controlplane/valuesprovider_test.go
+++ b/controllers/provider-aws/pkg/controller/controlplane/valuesprovider_test.go
@@ -23,9 +23,9 @@ import (
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -83,18 +83,12 @@ var _ = Describe("ValuesProvider", func() {
 
 		cidr    = "10.250.0.0/19"
 		cluster = &extensionscontroller.Cluster{
-			Shoot: &gardenv1beta1.Shoot{
-				Spec: gardenv1beta1.ShootSpec{
-					Cloud: gardenv1beta1.Cloud{
-						AWS: &gardenv1beta1.AWSCloud{
-							Networks: gardenv1beta1.AWSNetworks{
-								K8SNetworks: gardenv1beta1.K8SNetworks{
-									Pods: &cidr,
-								},
-							},
-						},
+			CoreShoot: &gardencorev1alpha1.Shoot{
+				Spec: gardencorev1alpha1.ShootSpec{
+					Networking: gardencorev1alpha1.Networking{
+						Pods: &cidr,
 					},
-					Kubernetes: gardenv1beta1.Kubernetes{
+					Kubernetes: gardencorev1alpha1.Kubernetes{
 						Version: "1.13.4",
 					},
 				},

--- a/controllers/provider-aws/pkg/controller/worker/machines.go
+++ b/controllers/provider-aws/pkg/controller/worker/machines.go
@@ -91,7 +91,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 		return err
 	}
 
-	shootVersionMajorMinor, err := util.VersionMajorMinor(w.cluster.Shoot.Spec.Kubernetes.Version)
+	shootVersionMajorMinor, err := util.VersionMajorMinor(extensionscontroller.GetKubernetesVersion(w.cluster))
 	if err != nil {
 		return err
 	}

--- a/controllers/provider-aws/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-aws/pkg/controller/worker/machines_test.go
@@ -31,8 +31,8 @@ import (
 	mockkubernetes "github.com/gardener/gardener-extensions/pkg/mock/gardener/client/kubernetes"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -181,9 +181,9 @@ var _ = Describe("Machines", func() {
 				}
 
 				cluster = &extensionscontroller.Cluster{
-					Shoot: &gardenv1beta1.Shoot{
-						Spec: gardenv1beta1.ShootSpec{
-							Kubernetes: gardenv1beta1.Kubernetes{
+					CoreShoot: &gardencorev1alpha1.Shoot{
+						Spec: gardencorev1alpha1.ShootSpec{
+							Kubernetes: gardencorev1alpha1.Kubernetes{
 								Version: shootVersion,
 							},
 						},
@@ -460,7 +460,7 @@ var _ = Describe("Machines", func() {
 			It("should fail because the version is invalid", func() {
 				expectGetSecretCallToWork(c, awsAccessKeyID, awsSecretAccessKey)
 
-				cluster.Shoot.Spec.Kubernetes.Version = "invalid"
+				cluster.CoreShoot.Spec.Kubernetes.Version = "invalid"
 				workerDelegate = NewWorkerDelegate(c, scheme, decoder, machineImageToAMIMapping, chartApplier, "", w, cluster)
 
 				result, err := workerDelegate.GenerateMachineDeployments(context.TODO())

--- a/controllers/provider-aws/pkg/webhook/controlplanebackup/ensurer.go
+++ b/controllers/provider-aws/pkg/webhook/controlplanebackup/ensurer.go
@@ -62,7 +62,7 @@ func (e *ensurer) EnsureETCDStatefulSet(ctx context.Context, ss *appsv1.Stateful
 	if err := e.ensureContainers(&ss.Spec.Template.Spec, ss.Name, cluster); err != nil {
 		return err
 	}
-	return e.ensureChecksumAnnotations(ctx, &ss.Spec.Template, ss.Namespace, ss.Name, cluster.Seed.Spec.Backup != nil)
+	return e.ensureChecksumAnnotations(ctx, &ss.Spec.Template, ss.Namespace, ss.Name, !extensionscontroller.IsSeedBackupNil(cluster))
 }
 
 func (e *ensurer) ensureContainers(ps *corev1.PodSpec, name string, cluster *extensionscontroller.Cluster) error {
@@ -84,7 +84,7 @@ func (e *ensurer) ensureChecksumAnnotations(ctx context.Context, template *corev
 func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscontroller.Cluster) (*corev1.Container, error) {
 	// Find etcd-backup-restore image
 	// TODO Get seed version from clientset when it's possible to inject it
-	image, err := e.imageVector.FindImage(aws.ETCDBackupRestoreImageName, imagevector.TargetVersion(cluster.Shoot.Spec.Kubernetes.Version))
+	image, err := e.imageVector.FindImage(aws.ETCDBackupRestoreImageName, imagevector.TargetVersion(extensionscontroller.GetKubernetesVersion(cluster)))
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not find image %s", aws.ETCDBackupRestoreImageName)
 	}
@@ -102,10 +102,10 @@ func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscont
 		volumeClaimTemplateName = name
 	)
 	if name == v1alpha1constants.StatefulSetNameETCDMain {
-		if cluster.Seed.Spec.Backup == nil {
+		if extensionscontroller.IsSeedBackupNil(cluster) {
 			e.logger.Info("Backup profile is not configured; backups will not be taken for etcd-main")
 		} else {
-			prefix = common.GenerateBackupEntryName(cluster.Shoot.Status.TechnicalID, cluster.Shoot.Status.UID)
+			prefix = common.GenerateBackupEntryName(extensionscontroller.GetTechnicalID(cluster), extensionscontroller.GetUID(cluster))
 			provider = aws.StorageProviderName
 			env = []corev1.EnvVar{
 				{

--- a/controllers/provider-aws/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-aws/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -26,8 +26,8 @@ import (
 	extensionswebhook "github.com/gardener/gardener-extensions/pkg/webhook"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
 
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -68,20 +68,20 @@ var _ = Describe("Ensurer", func() {
 			}
 
 			cluster = &extensionscontroller.Cluster{
-				Shoot: &gardenv1beta1.Shoot{
-					Spec: gardenv1beta1.ShootSpec{
-						Kubernetes: gardenv1beta1.Kubernetes{
+				CoreShoot: &gardencorev1alpha1.Shoot{
+					Spec: gardencorev1alpha1.ShootSpec{
+						Kubernetes: gardencorev1alpha1.Kubernetes{
 							Version: "1.13.4",
 						},
 					},
-					Status: gardenv1beta1.ShootStatus{
+					Status: gardencorev1alpha1.ShootStatus{
 						TechnicalID: "shoot--test--sample",
 						UID:         types.UID("test-uid"),
 					},
 				},
-				Seed: &gardenv1beta1.Seed{
-					Spec: gardenv1beta1.SeedSpec{
-						Backup: &gardenv1beta1.BackupProfile{},
+				CoreSeed: &gardencorev1alpha1.Seed{
+					Spec: gardencorev1alpha1.SeedSpec{
+						Backup: &gardencorev1alpha1.SeedBackup{},
 					},
 				},
 			}
@@ -164,7 +164,7 @@ var _ = Describe("Ensurer", func() {
 			ss := &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1alpha1constants.StatefulSetNameETCDMain},
 			}
-			cluster.Seed.Spec.Backup = nil
+			cluster.CoreSeed.Spec.Backup = nil
 
 			// Create mock client
 			client := mockclient.NewMockClient(ctrl)

--- a/controllers/provider-azure/example/30-controlplane.yaml
+++ b/controllers/provider-azure/example/30-controlplane.yaml
@@ -26,19 +26,17 @@ metadata:
   name: shoot--foobar--azure
 spec:
   cloudProfile:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: CloudProfile
   seed:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Seed
   shoot:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Shoot
     spec:
-      cloud:
-        azure:
-          networks:
-            pods: 10.250.0.0/19
+      networking:
+        pods: 10.250.0.0/19
       kubernetes:
         version: 1.13.4
       hibernation:

--- a/controllers/provider-azure/example/30-infrastructure.yaml
+++ b/controllers/provider-azure/example/30-infrastructure.yaml
@@ -22,28 +22,28 @@ metadata:
   name: shoot--foobar--azure
 spec:
   cloudProfile:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: CloudProfile
     spec:
-      azure:
+      providerConfig:
+        apiVersion: azure.provider.extensions.gardener.cloud/v1alpha1
+        kind: CloudProfileConfig
         countFaultDomains:
-        - count: 2
-          region: westeurope
+        - region: westeurope
+          count: 2
         countUpdateDomains:
-        - count: 5
-          region: westeurope
+        - region: westeurope
+          count: 5
   seed:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Seed
   shoot:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Shoot
     spec:
-      cloud:
-        azure:
-          networks:
-            pods: 10.243.128.0/17
-            services: 10.243.0.0/17
+      networking:
+        pods: 10.243.128.0/17
+        services: 10.243.0.0/17
     status:
       lastOperation:
         state: Succeeded

--- a/controllers/provider-azure/example/30-worker.yaml
+++ b/controllers/provider-azure/example/30-worker.yaml
@@ -17,13 +17,13 @@ metadata:
   name: shoot--foobar--azure
 spec:
   cloudProfile:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: CloudProfile
   seed:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Seed
   shoot:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Shoot
     spec:
       kubernetes:

--- a/controllers/provider-azure/pkg/apis/azure/v1alpha1/helper/helper.go
+++ b/controllers/provider-azure/pkg/apis/azure/v1alpha1/helper/helper.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper
+
+import (
+	"fmt"
+
+	azurev1alpha1 "github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/apis/azure/v1alpha1"
+)
+
+// FindDomainCountByRegion takes a region and the domain counts and finds the count for the given region.
+func FindDomainCountByRegion(domainCounts []azurev1alpha1.DomainCount, region string) (int, error) {
+	for _, domainCount := range domainCounts {
+		if domainCount.Region == region {
+			return domainCount.Count, nil
+		}
+	}
+	return 0, fmt.Errorf("could not find a domain count for region %s", region)
+}

--- a/controllers/provider-azure/pkg/apis/azure/v1alpha1/helper/helper_suite_test.go
+++ b/controllers/provider-azure/pkg/apis/azure/v1alpha1/helper/helper_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestHelper(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Azure API V1alpha1 Helper Suite")
+}

--- a/controllers/provider-azure/pkg/apis/azure/v1alpha1/helper/helper_test.go
+++ b/controllers/provider-azure/pkg/apis/azure/v1alpha1/helper/helper_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper_test
+
+import (
+	azurev1alpha1 "github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/apis/azure/v1alpha1"
+	. "github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/apis/azure/v1alpha1/helper"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Helper", func() {
+	DescribeTable("#FindDomainCountByRegion",
+		func(domainCounts []azurev1alpha1.DomainCount, region string, expectedCount int, expectErr bool) {
+			count, err := FindDomainCountByRegion(domainCounts, region)
+			expectResults(count, expectedCount, err, expectErr)
+		},
+
+		Entry("list is nil", nil, "foo", 0, true),
+		Entry("empty list", []azurev1alpha1.DomainCount{}, "foo", 0, true),
+		Entry("entry not found", []azurev1alpha1.DomainCount{{Region: "bar", Count: 1}}, "foo", 0, true),
+		Entry("entry exists", []azurev1alpha1.DomainCount{{Region: "bar", Count: 1}}, "bar", 1, false),
+	)
+})
+
+func expectResults(result, expected interface{}, err error, expectErr bool) {
+	if !expectErr {
+		Expect(result).To(Equal(expected))
+		Expect(err).NotTo(HaveOccurred())
+	} else {
+		Expect(result).To(BeZero())
+		Expect(err).To(HaveOccurred())
+	}
+}

--- a/controllers/provider-azure/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-azure/pkg/controller/controlplane/valuesprovider.go
@@ -223,7 +223,7 @@ func getConfigChartValues(
 
 	// Collect config chart values.
 	values := map[string]interface{}{
-		"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
+		"kubernetesVersion": extensionscontroller.GetKubernetesVersion(cluster),
 		"tenantId":          ca.TenantID,
 		"subscriptionId":    ca.SubscriptionID,
 		"aadClientId":       ca.ClientID,
@@ -258,10 +258,10 @@ func getCCMChartValues(
 	scaledDown bool,
 ) (map[string]interface{}, error) {
 	values := map[string]interface{}{
-		"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster.Shoot, scaledDown, 1),
+		"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
 		"clusterName":       cp.Namespace,
-		"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
-		"podNetwork":        extensionscontroller.GetPodNetwork(cluster.Shoot),
+		"kubernetesVersion": extensionscontroller.GetKubernetesVersion(cluster),
+		"podNetwork":        extensionscontroller.GetPodNetwork(cluster),
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-cloud-controller-manager":        checksums[cloudControllerManagerDeploymentName],
 			"checksum/secret-cloud-controller-manager-server": checksums[cloudControllerManagerServerName],

--- a/controllers/provider-azure/pkg/controller/controlplane/valuesprovider_test.go
+++ b/controllers/provider-azure/pkg/controller/controlplane/valuesprovider_test.go
@@ -23,9 +23,9 @@ import (
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -403,18 +403,12 @@ var _ = Describe("ValuesProvider", func() {
 
 		cidr    = "10.250.0.0/19"
 		cluster = &extensionscontroller.Cluster{
-			Shoot: &gardenv1beta1.Shoot{
-				Spec: gardenv1beta1.ShootSpec{
-					Cloud: gardenv1beta1.Cloud{
-						Azure: &gardenv1beta1.AzureCloud{
-							Networks: gardenv1beta1.AzureNetworks{
-								K8SNetworks: gardenv1beta1.K8SNetworks{
-									Pods: &cidr,
-								},
-							},
-						},
+			CoreShoot: &gardencorev1alpha1.Shoot{
+				Spec: gardencorev1alpha1.ShootSpec{
+					Networking: gardencorev1alpha1.Networking{
+						Pods: &cidr,
 					},
-					Kubernetes: gardenv1beta1.Kubernetes{
+					Kubernetes: gardencorev1alpha1.Kubernetes{
 						Version: "1.13.4",
 					},
 				},

--- a/controllers/provider-azure/pkg/controller/worker/machines.go
+++ b/controllers/provider-azure/pkg/controller/worker/machines.go
@@ -24,6 +24,7 @@ import (
 	azureapihelper "github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/apis/azure/helper"
 	"github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/azure"
 	"github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/internal"
+	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	"github.com/gardener/gardener-extensions/pkg/controller/worker"
 	"github.com/gardener/gardener-extensions/pkg/util"
 
@@ -94,7 +95,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 		return err
 	}
 
-	shootVersionMajorMinor, err := util.VersionMajorMinor(w.cluster.Shoot.Spec.Kubernetes.Version)
+	shootVersionMajorMinor, err := util.VersionMajorMinor(extensionscontroller.GetKubernetesVersion(w.cluster))
 	if err != nil {
 		return err
 	}

--- a/controllers/provider-azure/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-azure/pkg/controller/worker/machines_test.go
@@ -30,8 +30,8 @@ import (
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	mockkubernetes "github.com/gardener/gardener-extensions/pkg/mock/gardener/client/kubernetes"
 
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -176,9 +176,9 @@ var _ = Describe("Machines", func() {
 				}
 
 				cluster = &extensionscontroller.Cluster{
-					Shoot: &gardenv1beta1.Shoot{
-						Spec: gardenv1beta1.ShootSpec{
-							Kubernetes: gardenv1beta1.Kubernetes{
+					CoreShoot: &gardencorev1alpha1.Shoot{
+						Spec: gardencorev1alpha1.ShootSpec{
+							Kubernetes: gardencorev1alpha1.Kubernetes{
 								Version: shootVersion,
 							},
 						},
@@ -390,7 +390,7 @@ var _ = Describe("Machines", func() {
 			It("should fail because the version is invalid", func() {
 				expectGetSecretCallToWork(c, azureClientID, azureClientSecret, azureSubscriptionID, azureTenantID)
 
-				cluster.Shoot.Spec.Kubernetes.Version = "invalid"
+				cluster.CoreShoot.Spec.Kubernetes.Version = "invalid"
 				workerDelegate = NewWorkerDelegate(c, scheme, decoder, machineImages, chartApplier, "", w, cluster)
 
 				result, err := workerDelegate.GenerateMachineDeployments(context.TODO())

--- a/controllers/provider-azure/pkg/internal/scheme.go
+++ b/controllers/provider-azure/pkg/internal/scheme.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/apis/azure/install"
 	azurev1alpha1 "github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/apis/azure/v1alpha1"
+
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -51,4 +53,18 @@ func InfrastructureConfigFromInfrastructure(infra *extensionsv1alpha1.Infrastruc
 		return config, nil
 	}
 	return nil, fmt.Errorf("infrastructure config is not set on the infrastructure resource")
+}
+
+// CloudProfileConfigFromCloudProfile extracts the CloudProfileConfig from the
+// ProviderConfig section of the given CloudProfile.
+func CloudProfileConfigFromCloudProfile(cloudProfile *gardencorev1alpha1.CloudProfile) (*azurev1alpha1.CloudProfileConfig, error) {
+	config := &azurev1alpha1.CloudProfileConfig{}
+	if cloudProfile.Spec.ProviderConfig != nil && cloudProfile.Spec.ProviderConfig.Raw != nil {
+		if _, _, err := decoder.Decode(cloudProfile.Spec.ProviderConfig.Raw, nil, config); err != nil {
+			return nil, err
+		}
+
+		return config, nil
+	}
+	return nil, fmt.Errorf("cloud profile config is not set on the cloudprofile resource")
 }

--- a/controllers/provider-azure/pkg/webhook/controlplanebackup/ensurer.go
+++ b/controllers/provider-azure/pkg/webhook/controlplanebackup/ensurer.go
@@ -62,7 +62,7 @@ func (e *ensurer) EnsureETCDStatefulSet(ctx context.Context, ss *appsv1.Stateful
 	if err := e.ensureContainers(&ss.Spec.Template.Spec, ss.Name, cluster); err != nil {
 		return err
 	}
-	return e.ensureChecksumAnnotations(ctx, &ss.Spec.Template, ss.Namespace, ss.Name, cluster.Seed.Spec.Backup != nil)
+	return e.ensureChecksumAnnotations(ctx, &ss.Spec.Template, ss.Namespace, ss.Name, !extensionscontroller.IsSeedBackupNil(cluster))
 }
 
 func (e *ensurer) ensureContainers(ps *corev1.PodSpec, name string, cluster *extensionscontroller.Cluster) error {
@@ -84,7 +84,7 @@ func (e *ensurer) ensureChecksumAnnotations(ctx context.Context, template *corev
 func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscontroller.Cluster) (*corev1.Container, error) {
 	// Find etcd-backup-restore image
 	// TODO Get seed version from clientset when it's possible to inject it
-	image, err := e.imageVector.FindImage(azure.ETCDBackupRestoreImageName, imagevector.TargetVersion(cluster.Shoot.Spec.Kubernetes.Version))
+	image, err := e.imageVector.FindImage(azure.ETCDBackupRestoreImageName, imagevector.TargetVersion(extensionscontroller.GetKubernetesVersion(cluster)))
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not find image %s", azure.ETCDBackupRestoreImageName)
 	}
@@ -102,10 +102,10 @@ func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscont
 		volumeClaimTemplateName = name
 	)
 	if name == v1alpha1constants.StatefulSetNameETCDMain {
-		if cluster.Seed.Spec.Backup == nil {
-			e.logger.Info("Backup profile is not configured;  backup will not be taken for etcd-main")
+		if extensionscontroller.IsSeedBackupNil(cluster) {
+			e.logger.Info("Backup profile is not configured; backup will not be taken for etcd-main")
 		} else {
-			prefix = common.GenerateBackupEntryName(cluster.Shoot.Status.TechnicalID, cluster.Shoot.Status.UID)
+			prefix = common.GenerateBackupEntryName(extensionscontroller.GetTechnicalID(cluster), extensionscontroller.GetUID(cluster))
 
 			provider = azure.StorageProviderName
 			env = []corev1.EnvVar{

--- a/controllers/provider-azure/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-azure/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -26,8 +26,8 @@ import (
 	extensionswebhook "github.com/gardener/gardener-extensions/pkg/webhook"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
 
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -68,20 +68,20 @@ var _ = Describe("Ensurer", func() {
 			}
 
 			cluster = &extensionscontroller.Cluster{
-				Shoot: &gardenv1beta1.Shoot{
-					Spec: gardenv1beta1.ShootSpec{
-						Kubernetes: gardenv1beta1.Kubernetes{
+				CoreShoot: &gardencorev1alpha1.Shoot{
+					Spec: gardencorev1alpha1.ShootSpec{
+						Kubernetes: gardencorev1alpha1.Kubernetes{
 							Version: "1.13.4",
 						},
 					},
-					Status: gardenv1beta1.ShootStatus{
+					Status: gardencorev1alpha1.ShootStatus{
 						TechnicalID: "shoot--test--sample",
 						UID:         types.UID("test-uid"),
 					},
 				},
-				Seed: &gardenv1beta1.Seed{
-					Spec: gardenv1beta1.SeedSpec{
-						Backup: &gardenv1beta1.BackupProfile{},
+				CoreSeed: &gardencorev1alpha1.Seed{
+					Spec: gardencorev1alpha1.SeedSpec{
+						Backup: &gardencorev1alpha1.SeedBackup{},
 					},
 				},
 			}
@@ -164,7 +164,7 @@ var _ = Describe("Ensurer", func() {
 			ss := &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1alpha1constants.StatefulSetNameETCDMain},
 			}
-			cluster.Seed.Spec.Backup = nil
+			cluster.CoreSeed.Spec.Backup = nil
 
 			// Create mock client
 			client := mockclient.NewMockClient(ctrl)

--- a/controllers/provider-gcp/example/30-controlplane.yaml
+++ b/controllers/provider-gcp/example/30-controlplane.yaml
@@ -23,19 +23,17 @@ metadata:
   name: shoot--foobar--gcp
 spec:
   cloudProfile:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: CloudProfile
   seed:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Seed
   shoot:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Shoot
     spec:
-      cloud:
-        gcp:
-          networks:
-            pods: 10.250.0.0/19
+      networking:
+        pods: 10.250.0.0/19
       kubernetes:
         version: 1.13.4
       hibernation:

--- a/controllers/provider-gcp/example/30-infrastructure.yaml
+++ b/controllers/provider-gcp/example/30-infrastructure.yaml
@@ -19,20 +19,18 @@ metadata:
   name: shoot--foobar--gcp
 spec:
   cloudProfile:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: CloudProfile
   seed:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Seed
   shoot:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Shoot
     spec:
-      cloud:
-        gcp:
-          networks:
-            pods: 10.243.128.0/17
-            services: 10.243.0.0/17
+      networking:
+        pods: 10.243.128.0/17
+        services: 10.243.0.0/17
     status:
       lastOperation:
         state: Succeeded

--- a/controllers/provider-gcp/example/30-worker.yaml
+++ b/controllers/provider-gcp/example/30-worker.yaml
@@ -14,13 +14,13 @@ metadata:
   name: shoot--foobar--gcp
 spec:
   cloudProfile:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: CloudProfile
   seed:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Seed
   shoot:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Shoot
     spec:
       kubernetes:

--- a/controllers/provider-gcp/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-gcp/pkg/controller/controlplane/valuesprovider.go
@@ -222,10 +222,10 @@ func getCCMChartValues(
 	scaledDown bool,
 ) (map[string]interface{}, error) {
 	values := map[string]interface{}{
-		"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster.Shoot, scaledDown, 1),
+		"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
 		"clusterName":       cp.Namespace,
-		"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
-		"podNetwork":        extensionscontroller.GetPodNetwork(cluster.Shoot),
+		"kubernetesVersion": extensionscontroller.GetKubernetesVersion(cluster),
+		"podNetwork":        extensionscontroller.GetPodNetwork(cluster),
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-cloud-controller-manager":        checksums[cloudControllerManagerDeploymentName],
 			"checksum/secret-cloud-controller-manager-server": checksums[cloudControllerManagerServerName],

--- a/controllers/provider-gcp/pkg/controller/controlplane/valuesprovider_test.go
+++ b/controllers/provider-gcp/pkg/controller/controlplane/valuesprovider_test.go
@@ -24,9 +24,9 @@ import (
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -90,18 +90,12 @@ var _ = Describe("ValuesProvider", func() {
 
 		cidr    = "10.250.0.0/19"
 		cluster = &extensionscontroller.Cluster{
-			Shoot: &gardenv1beta1.Shoot{
-				Spec: gardenv1beta1.ShootSpec{
-					Cloud: gardenv1beta1.Cloud{
-						GCP: &gardenv1beta1.GCPCloud{
-							Networks: gardenv1beta1.GCPNetworks{
-								K8SNetworks: gardenv1beta1.K8SNetworks{
-									Pods: &cidr,
-								},
-							},
-						},
+			CoreShoot: &gardencorev1alpha1.Shoot{
+				Spec: gardencorev1alpha1.ShootSpec{
+					Networking: gardencorev1alpha1.Networking{
+						Pods: &cidr,
 					},
-					Kubernetes: gardenv1beta1.Kubernetes{
+					Kubernetes: gardencorev1alpha1.Kubernetes{
 						Version: "1.13.4",
 					},
 				},

--- a/controllers/provider-gcp/pkg/controller/worker/machines.go
+++ b/controllers/provider-gcp/pkg/controller/worker/machines.go
@@ -24,6 +24,7 @@ import (
 	gcpapihelper "github.com/gardener/gardener-extensions/controllers/provider-gcp/pkg/apis/gcp/helper"
 	"github.com/gardener/gardener-extensions/controllers/provider-gcp/pkg/gcp"
 	"github.com/gardener/gardener-extensions/controllers/provider-gcp/pkg/internal"
+	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	"github.com/gardener/gardener-extensions/pkg/controller/worker"
 	"github.com/gardener/gardener-extensions/pkg/util"
 
@@ -84,7 +85,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 		return err
 	}
 
-	shootVersionMajorMinor, err := util.VersionMajorMinor(w.cluster.Shoot.Spec.Kubernetes.Version)
+	shootVersionMajorMinor, err := util.VersionMajorMinor(extensionscontroller.GetKubernetesVersion(w.cluster))
 	if err != nil {
 		return err
 	}

--- a/controllers/provider-gcp/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-gcp/pkg/controller/worker/machines_test.go
@@ -30,8 +30,8 @@ import (
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	mockkubernetes "github.com/gardener/gardener-extensions/pkg/mock/gardener/client/kubernetes"
 
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -167,9 +167,9 @@ var _ = Describe("Machines", func() {
 				}
 
 				cluster = &extensionscontroller.Cluster{
-					Shoot: &gardenv1beta1.Shoot{
-						Spec: gardenv1beta1.ShootSpec{
-							Kubernetes: gardenv1beta1.Kubernetes{
+					CoreShoot: &gardencorev1alpha1.Shoot{
+						Spec: gardencorev1alpha1.ShootSpec{
+							Kubernetes: gardencorev1alpha1.Kubernetes{
 								Version: shootVersion,
 							},
 						},
@@ -430,7 +430,7 @@ var _ = Describe("Machines", func() {
 			It("should fail because the version is invalid", func() {
 				expectGetSecretCallToWork(c, serviceAccountJSON)
 
-				cluster.Shoot.Spec.Kubernetes.Version = "invalid"
+				cluster.CoreShoot.Spec.Kubernetes.Version = "invalid"
 				workerDelegate = NewWorkerDelegate(c, scheme, decoder, machineImages, chartApplier, "", w, cluster)
 
 				result, err := workerDelegate.GenerateMachineDeployments(context.TODO())

--- a/controllers/provider-gcp/pkg/internal/infrastructure/terraform_test.go
+++ b/controllers/provider-gcp/pkg/internal/infrastructure/terraform_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/gardener/gardener-extensions/controllers/provider-gcp/pkg/internal"
 	"github.com/gardener/gardener-extensions/pkg/controller"
 
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -38,6 +38,9 @@ var _ = Describe("Terraform", func() {
 		projectID          string
 		serviceAccountData []byte
 		serviceAccount     *internal.ServiceAccount
+
+		podsCIDR     = "11.0.0.0/16"
+		servicesCIDR = "12.0.0.0/16"
 	)
 
 	BeforeEach(func() {
@@ -71,20 +74,12 @@ var _ = Describe("Terraform", func() {
 			},
 		}
 
-		podsCIDR := "11.0.0.0/16"
-		servicesCIDR := "12.0.0.0/16"
 		cluster = &controller.Cluster{
-			Shoot: &gardenv1beta1.Shoot{
-				Spec: gardenv1beta1.ShootSpec{
-					Cloud: gardenv1beta1.Cloud{
-						GCP: &gardenv1beta1.GCPCloud{
-							Networks: gardenv1beta1.GCPNetworks{
-								K8SNetworks: gardenv1beta1.K8SNetworks{
-									Pods:     &podsCIDR,
-									Services: &servicesCIDR,
-								},
-							},
-						},
+			CoreShoot: &gardencorev1alpha1.Shoot{
+				Spec: gardencorev1alpha1.ShootSpec{
+					Networking: gardencorev1alpha1.Networking{
+						Pods:     &podsCIDR,
+						Services: &servicesCIDR,
 					},
 				},
 			},
@@ -112,8 +107,8 @@ var _ = Describe("Terraform", func() {
 				},
 				"clusterName": infra.Namespace,
 				"networks": map[string]interface{}{
-					"pods":     cluster.Shoot.Spec.Cloud.GCP.Networks.Pods,
-					"services": cluster.Shoot.Spec.Cloud.GCP.Networks.Services,
+					"pods":     podsCIDR,
+					"services": servicesCIDR,
 					"worker":   config.Networks.Worker,
 					"internal": config.Networks.Internal,
 				},
@@ -143,8 +138,8 @@ var _ = Describe("Terraform", func() {
 				},
 				"clusterName": infra.Namespace,
 				"networks": map[string]interface{}{
-					"pods":     cluster.Shoot.Spec.Cloud.GCP.Networks.Pods,
-					"services": cluster.Shoot.Spec.Cloud.GCP.Networks.Services,
+					"pods":     podsCIDR,
+					"services": servicesCIDR,
 					"worker":   config.Networks.Worker,
 					"internal": config.Networks.Internal,
 				},

--- a/controllers/provider-gcp/pkg/internal/terraform_test.go
+++ b/controllers/provider-gcp/pkg/internal/terraform_test.go
@@ -16,6 +16,7 @@ package internal
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/controllers/provider-gcp/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-gcp/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -27,8 +27,8 @@ import (
 	extensionswebhook "github.com/gardener/gardener-extensions/pkg/webhook"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
 
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -69,20 +69,20 @@ var _ = Describe("Ensurer", func() {
 			}
 
 			cluster = &extensionscontroller.Cluster{
-				Shoot: &gardenv1beta1.Shoot{
-					Spec: gardenv1beta1.ShootSpec{
-						Kubernetes: gardenv1beta1.Kubernetes{
+				CoreShoot: &gardencorev1alpha1.Shoot{
+					Spec: gardencorev1alpha1.ShootSpec{
+						Kubernetes: gardencorev1alpha1.Kubernetes{
 							Version: "1.13.4",
 						},
 					},
-					Status: gardenv1beta1.ShootStatus{
+					Status: gardencorev1alpha1.ShootStatus{
 						TechnicalID: "shoot--test--sample",
 						UID:         types.UID("test-uid"),
 					},
 				},
-				Seed: &gardenv1beta1.Seed{
-					Spec: gardenv1beta1.SeedSpec{
-						Backup: &gardenv1beta1.BackupProfile{},
+				CoreSeed: &gardencorev1alpha1.Seed{
+					Spec: gardencorev1alpha1.SeedSpec{
+						Backup: &gardencorev1alpha1.SeedBackup{},
 					},
 				},
 			}
@@ -165,7 +165,7 @@ var _ = Describe("Ensurer", func() {
 			ss := &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1alpha1constants.StatefulSetNameETCDMain},
 			}
-			cluster.Seed.Spec.Backup = nil
+			cluster.CoreSeed.Spec.Backup = nil
 
 			// Create mock client
 			client := mockclient.NewMockClient(ctrl)

--- a/controllers/provider-openstack/example/30-controlplane.yaml
+++ b/controllers/provider-openstack/example/30-controlplane.yaml
@@ -25,16 +25,18 @@ metadata:
   name: shoot--foobar--openstack
 spec:
   cloudProfile:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: CloudProfile
     spec:
-      openstack:
+      providerConfig:
+        apiVersion: openstack.provider.extensions.gardener.cloud/v1alpha1
+        kind: CloudProfileConfig
         keystoneURL: https://localhost
   seed:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Seed
   shoot:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Shoot
     spec:
       cloud:

--- a/controllers/provider-openstack/example/30-infrastructure.yaml
+++ b/controllers/provider-openstack/example/30-infrastructure.yaml
@@ -24,18 +24,20 @@ metadata:
   name: shoot--foobar--openstack
 spec:
   cloudProfile:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: CloudProfile
     spec:
-      openstack:
+      providerConfig:
+        apiVersion: openstack.provider.extensions.gardener.cloud/v1alpha1
+        kind: CloudProfileConfig
         keystoneURL: https://localhost
-        # dnsServers:
-        # - 1.1.1.1
+      # dnsServers:
+      # - 1.1.1.1
   seed:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Seed
   shoot:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Shoot
     status:
       lastOperation:

--- a/controllers/provider-openstack/example/30-worker.yaml
+++ b/controllers/provider-openstack/example/30-worker.yaml
@@ -17,16 +17,18 @@ metadata:
   name: shoot--foobar--openstack
 spec:
   cloudProfile:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: CloudProfile
     spec:
-      openstack:
+      providerConfig:
+        apiVersion: openstack.provider.extensions.gardener.cloud/v1alpha1
+        kind: CloudProfileConfig
         keystoneURL: https://localhost
   seed:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Seed
   shoot:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Shoot
     spec:
       kubernetes:

--- a/controllers/provider-openstack/pkg/apis/openstack/types_infrastructure.go
+++ b/controllers/provider-openstack/pkg/apis/openstack/types_infrastructure.go
@@ -84,6 +84,8 @@ type RouterStatus struct {
 type FloatingPoolStatus struct {
 	// ID is the floating pool id.
 	ID string
+	// Name is the floating pool name.
+	Name string
 }
 
 // Purpose is a purpose of resources.

--- a/controllers/provider-openstack/pkg/apis/openstack/v1alpha1/types_infrastructure.go
+++ b/controllers/provider-openstack/pkg/apis/openstack/v1alpha1/types_infrastructure.go
@@ -85,6 +85,8 @@ type RouterStatus struct {
 type FloatingPoolStatus struct {
 	// ID is the floating pool id.
 	ID string `json:"id"`
+	// Name is the floating pool name.
+	Name string `json:"name"`
 }
 
 // Purpose is a purpose of a resource.

--- a/controllers/provider-openstack/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
+++ b/controllers/provider-openstack/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
@@ -374,6 +374,7 @@ func Convert_openstack_FloatingPool_To_v1alpha1_FloatingPool(in *openstack.Float
 
 func autoConvert_v1alpha1_FloatingPoolStatus_To_openstack_FloatingPoolStatus(in *FloatingPoolStatus, out *openstack.FloatingPoolStatus, s conversion.Scope) error {
 	out.ID = in.ID
+	out.Name = in.Name
 	return nil
 }
 
@@ -384,6 +385,7 @@ func Convert_v1alpha1_FloatingPoolStatus_To_openstack_FloatingPoolStatus(in *Flo
 
 func autoConvert_openstack_FloatingPoolStatus_To_v1alpha1_FloatingPoolStatus(in *openstack.FloatingPoolStatus, out *FloatingPoolStatus, s conversion.Scope) error {
 	out.ID = in.ID
+	out.Name = in.Name
 	return nil
 }
 

--- a/controllers/provider-openstack/pkg/internal/scheme.go
+++ b/controllers/provider-openstack/pkg/internal/scheme.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/gardener/gardener-extensions/controllers/provider-openstack/pkg/apis/openstack/install"
 	openstackv1alpha1 "github.com/gardener/gardener-extensions/controllers/provider-openstack/pkg/apis/openstack/v1alpha1"
+
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -51,4 +53,18 @@ func InfrastructureConfigFromInfrastructure(infra *extensionsv1alpha1.Infrastruc
 		return config, nil
 	}
 	return nil, fmt.Errorf("infrastructure config is not set on the infrastructure resource")
+}
+
+// CloudProfileConfigFromCloudProfile extracts the CloudProfileConfig from the
+// ProviderConfig section of the given CloudProfile.
+func CloudProfileConfigFromCloudProfile(infra *gardencorev1alpha1.CloudProfile) (*openstackv1alpha1.CloudProfileConfig, error) {
+	config := &openstackv1alpha1.CloudProfileConfig{}
+	if infra.Spec.ProviderConfig != nil && infra.Spec.ProviderConfig.Raw != nil {
+		if _, _, err := decoder.Decode(infra.Spec.ProviderConfig.Raw, nil, config); err != nil {
+			return nil, err
+		}
+
+		return config, nil
+	}
+	return nil, fmt.Errorf("cloudprofile config is not set on the cloudprofile resource")
 }

--- a/controllers/provider-openstack/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-openstack/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -26,8 +26,8 @@ import (
 	extensionswebhook "github.com/gardener/gardener-extensions/pkg/webhook"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
 
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -68,20 +68,20 @@ var _ = Describe("Ensurer", func() {
 			}
 
 			cluster = &extensionscontroller.Cluster{
-				Shoot: &gardenv1beta1.Shoot{
-					Spec: gardenv1beta1.ShootSpec{
-						Kubernetes: gardenv1beta1.Kubernetes{
+				CoreShoot: &gardencorev1alpha1.Shoot{
+					Spec: gardencorev1alpha1.ShootSpec{
+						Kubernetes: gardencorev1alpha1.Kubernetes{
 							Version: "1.13.4",
 						},
 					},
-					Status: gardenv1beta1.ShootStatus{
+					Status: gardencorev1alpha1.ShootStatus{
 						TechnicalID: "shoot--test--sample",
 						UID:         types.UID("test-uid"),
 					},
 				},
-				Seed: &gardenv1beta1.Seed{
-					Spec: gardenv1beta1.SeedSpec{
-						Backup: &gardenv1beta1.BackupProfile{},
+				CoreSeed: &gardencorev1alpha1.Seed{
+					Spec: gardencorev1alpha1.SeedSpec{
+						Backup: &gardencorev1alpha1.SeedBackup{},
 					},
 				},
 			}
@@ -164,7 +164,7 @@ var _ = Describe("Ensurer", func() {
 			ss := &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1alpha1constants.StatefulSetNameETCDMain},
 			}
-			cluster.Seed.Spec.Backup = nil
+			cluster.CoreSeed.Spec.Backup = nil
 
 			// Create mock client
 			client := mockclient.NewMockClient(ctrl)

--- a/controllers/provider-packet/example/30-controlplane.yaml
+++ b/controllers/provider-packet/example/30-controlplane.yaml
@@ -24,19 +24,17 @@ metadata:
   name: shoot--foobar--packet
 spec:
   cloudProfile:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: CloudProfile
   seed:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Seed
   shoot:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Shoot
     spec:
-      cloud:
-        packet:
-          networks:
-            pods: 10.250.0.0/19
+      networking:
+        pods: 10.250.0.0/19
       kubernetes:
         version: 1.13.4
       hibernation:

--- a/controllers/provider-packet/example/30-infrastructure.yaml
+++ b/controllers/provider-packet/example/30-infrastructure.yaml
@@ -20,13 +20,13 @@ metadata:
   name: shoot--foobar--packet
 spec:
   cloudProfile:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: CloudProfile
   seed:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Seed
   shoot:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Shoot
     status:
       lastOperation:

--- a/controllers/provider-packet/example/30-worker.yaml
+++ b/controllers/provider-packet/example/30-worker.yaml
@@ -15,13 +15,13 @@ metadata:
   name: shoot--foobar--packet
 spec:
   cloudProfile:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: CloudProfile
   seed:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Seed
   shoot:
-    apiVersion: garden.sapcloud.io/v1beta1
+    apiVersion: core.gardener.cloud/v1alpha1
     kind: Shoot
     spec:
       kubernetes:

--- a/controllers/provider-packet/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-packet/pkg/controller/controlplane/valuesprovider.go
@@ -245,18 +245,18 @@ func getControlPlaneChartValues(
 ) (map[string]interface{}, error) {
 	values := map[string]interface{}{
 		"packet-cloud-controller-manager": map[string]interface{}{
-			"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster.Shoot, scaledDown, 1),
+			"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
 			"clusterName":       cp.Namespace,
-			"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
-			"podNetwork":        extensionscontroller.GetPodNetwork(cluster.Shoot),
+			"kubernetesVersion": extensionscontroller.GetKubernetesVersion(cluster),
+			"podNetwork":        extensionscontroller.GetPodNetwork(cluster),
 			"podAnnotations": map[string]interface{}{
 				"checksum/secret-cloud-controller-manager": checksums[packet.CloudControllerManagerImageName],
 				"checksum/secret-cloudprovider":            checksums[v1alpha1constants.SecretNameCloudProvider],
 			},
 		},
 		"csi-packet": map[string]interface{}{
-			"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster.Shoot, scaledDown, 1),
-			"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
+			"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
+			"kubernetesVersion": extensionscontroller.GetKubernetesVersion(cluster),
 			"regionID":          cp.Spec.Region,
 			"podAnnotations": map[string]interface{}{
 				"checksum/secret-csi-attacher":    checksums[packet.CSIAttacherImageName],
@@ -280,7 +280,7 @@ func getControlPlaneShootChartValues(
 				"apiToken":  base64.StdEncoding.EncodeToString([]byte(credentials.APIToken)),
 				"projectID": base64.StdEncoding.EncodeToString([]byte(credentials.ProjectID)),
 			},
-			"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
+			"kubernetesVersion": extensionscontroller.GetKubernetesVersion(cluster),
 		},
 	}
 

--- a/controllers/provider-packet/pkg/controller/controlplane/valuesprovider_test.go
+++ b/controllers/provider-packet/pkg/controller/controlplane/valuesprovider_test.go
@@ -23,9 +23,9 @@ import (
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -55,7 +55,7 @@ var _ = Describe("ValuesProvider", func() {
 				Namespace: namespace,
 			},
 			Spec: extensionsv1alpha1.ControlPlaneSpec{
-				Region: "WER1",
+				Region: "EWR1",
 				SecretRef: corev1.SecretReference{
 					Name:      v1alpha1constants.SecretNameCloudProvider,
 					Namespace: namespace,
@@ -71,18 +71,12 @@ var _ = Describe("ValuesProvider", func() {
 
 		cidr    = "10.250.0.0/19"
 		cluster = &extensionscontroller.Cluster{
-			Shoot: &gardenv1beta1.Shoot{
-				Spec: gardenv1beta1.ShootSpec{
-					Cloud: gardenv1beta1.Cloud{
-						Packet: &gardenv1beta1.PacketCloud{
-							Networks: gardenv1beta1.PacketNetworks{
-								K8SNetworks: gardenv1beta1.K8SNetworks{
-									Pods: &cidr,
-								},
-							},
-						},
+			CoreShoot: &gardencorev1alpha1.Shoot{
+				Spec: gardencorev1alpha1.ShootSpec{
+					Networking: gardencorev1alpha1.Networking{
+						Pods: &cidr,
 					},
-					Kubernetes: gardenv1beta1.Kubernetes{
+					Kubernetes: gardencorev1alpha1.Kubernetes{
 						Version: "1.13.4",
 					},
 				},
@@ -123,7 +117,7 @@ var _ = Describe("ValuesProvider", func() {
 			"csi-packet": map[string]interface{}{
 				"replicas":          1,
 				"kubernetesVersion": "1.13.4",
-				"regionID":          "WER1",
+				"regionID":          "EWR1",
 				"podAnnotations": map[string]interface{}{
 					"checksum/secret-csi-attacher":    "2da58ad61c401a2af779a909d22fb42eed93a1524cbfdab974ceedb413fcb914",
 					"checksum/secret-csi-provisioner": "f75b42d40ab501428c383dfb2336cb1fc892bbee1fc1d739675171e4acc4d911",

--- a/controllers/provider-packet/pkg/controller/infrastructure/actuator_delete.go
+++ b/controllers/provider-packet/pkg/controller/infrastructure/actuator_delete.go
@@ -23,7 +23,6 @@ import (
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/controllers/provider-packet/pkg/controller/worker/machines.go
+++ b/controllers/provider-packet/pkg/controller/worker/machines.go
@@ -89,7 +89,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 		return err
 	}
 
-	shootVersionMajorMinor, err := util.VersionMajorMinor(w.cluster.Shoot.Spec.Kubernetes.Version)
+	shootVersionMajorMinor, err := util.VersionMajorMinor(extensionscontroller.GetKubernetesVersion(w.cluster))
 	if err != nil {
 		return err
 	}

--- a/controllers/provider-packet/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-packet/pkg/controller/worker/machines_test.go
@@ -30,8 +30,8 @@ import (
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	mockkubernetes "github.com/gardener/gardener-extensions/pkg/mock/gardener/client/kubernetes"
 
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	extensionsv1alpha "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -159,9 +159,9 @@ var _ = Describe("Machines", func() {
 				}
 
 				cluster = &extensionscontroller.Cluster{
-					Shoot: &gardenv1beta1.Shoot{
-						Spec: gardenv1beta1.ShootSpec{
-							Kubernetes: gardenv1beta1.Kubernetes{
+					CoreShoot: &gardencorev1alpha1.Shoot{
+						Spec: gardencorev1alpha1.ShootSpec{
+							Kubernetes: gardencorev1alpha1.Kubernetes{
 								Version: shootVersion,
 							},
 						},
@@ -345,7 +345,7 @@ var _ = Describe("Machines", func() {
 			It("should fail because the version is invalid", func() {
 				expectGetSecretCallToWork(c, packetAPIToken, packetProjectID)
 
-				cluster.Shoot.Spec.Kubernetes.Version = "invalid"
+				cluster.CoreShoot.Spec.Kubernetes.Version = "invalid"
 				workerDelegate = NewWorkerDelegate(c, scheme, decoder, machineImages, chartApplier, "", w, cluster)
 
 				result, err := workerDelegate.GenerateMachineDeployments(context.TODO())

--- a/controllers/provider-packet/pkg/webhook/controlplanebackup/ensurer.go
+++ b/controllers/provider-packet/pkg/webhook/controlplanebackup/ensurer.go
@@ -62,7 +62,7 @@ func (e *ensurer) ensureContainers(ps *corev1.PodSpec, name string, cluster *ext
 func (e *ensurer) getBackupRestoreContainer(name string, cluster *extensionscontroller.Cluster) (*corev1.Container, error) {
 	// Find etcd-backup-restore image
 	// TODO Get seed version from clientset when it's possible to inject it
-	image, err := e.imageVector.FindImage(packet.ETCDBackupRestoreImageName, imagevector.TargetVersion(cluster.Shoot.Spec.Kubernetes.Version))
+	image, err := e.imageVector.FindImage(packet.ETCDBackupRestoreImageName, imagevector.TargetVersion(extensionscontroller.GetKubernetesVersion(cluster)))
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not find image %s", packet.ETCDBackupRestoreImageName)
 	}

--- a/controllers/provider-packet/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-packet/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -24,8 +24,8 @@ import (
 	extensionswebhook "github.com/gardener/gardener-extensions/pkg/webhook"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
 
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -58,9 +58,9 @@ var _ = Describe("Ensurer", func() {
 			}
 
 			cluster = &extensionscontroller.Cluster{
-				Shoot: &gardenv1beta1.Shoot{
-					Spec: gardenv1beta1.ShootSpec{
-						Kubernetes: gardenv1beta1.Kubernetes{
+				CoreShoot: &gardencorev1alpha1.Shoot{
+					Spec: gardencorev1alpha1.ShootSpec{
+						Kubernetes: gardencorev1alpha1.Kubernetes{
 							Version: "1.13.4",
 						},
 					},

--- a/go.sum
+++ b/go.sum
@@ -775,6 +775,7 @@ k8s.io/gengo v0.0.0-20190116091435-f8a0810f38af/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20190327210449-e17681d19d3a h1:QoHVuRquf80YZ+/bovwxoMO3Q/A3nt3yTgS0/0nejuk=
 k8s.io/gengo v0.0.0-20190327210449-e17681d19d3a/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20190826232639-a874a240740c h1:HH5z+xQGPLMQ2MlS+UVaOaSFgaEqGw1Zb007B9yjZEY=
 k8s.io/gengo v0.0.0-20190826232639-a874a240740c/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/helm v2.7.2+incompatible/go.mod h1:LZzlS4LQBHfciFOurYBFkCMTaZ0D1l+p0teMg7TSULI=
 k8s.io/helm v2.14.2+incompatible h1:kT4JDDvxvp/AR7sWTuTnv58SzVYP0KHIGFIXThSp7gc=

--- a/pkg/controller/controlplane/genericactuator/actuator_test.go
+++ b/pkg/controller/controlplane/genericactuator/actuator_test.go
@@ -30,9 +30,9 @@ import (
 
 	resourcemanagerv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -92,9 +92,9 @@ var _ = Describe("Actuator", func() {
 		}
 
 		cluster = &extensionscontroller.Cluster{
-			Shoot: &gardenv1beta1.Shoot{
-				Spec: gardenv1beta1.ShootSpec{
-					Kubernetes: gardenv1beta1.Kubernetes{
+			CoreShoot: &gardencorev1alpha1.Shoot{
+				Spec: gardencorev1alpha1.ShootSpec{
+					Kubernetes: gardencorev1alpha1.Kubernetes{
 						Version: shootVersion,
 					},
 				},

--- a/pkg/controller/controlplane/utils.go
+++ b/pkg/controller/controlplane/utils.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gardener/gardener-extensions/pkg/util"
 
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -29,7 +29,7 @@ func DNSNamesForService(name, namespace string) []string {
 		name,
 		fmt.Sprintf("%s.%s", name, namespace),
 		fmt.Sprintf("%s.%s.svc", name, namespace),
-		fmt.Sprintf("%s.%s.svc.%s", name, namespace, gardenv1beta1.DefaultDomain),
+		fmt.Sprintf("%s.%s.svc.%s", name, namespace, gardencorev1alpha1.DefaultDomain),
 	}
 }
 

--- a/pkg/controller/infrastructure/controller.go
+++ b/pkg/controller/infrastructure/controller.go
@@ -55,6 +55,7 @@ func DefaultPredicates(typeName string, ignoreOperationAnnotation bool) []predic
 		return []predicate.Predicate{
 			extensionspredicate.HasType(typeName),
 			extensionspredicate.GenerationChanged(),
+			extensionspredicate.ShootNotFailed(),
 		}
 	}
 

--- a/pkg/controller/seed.go
+++ b/pkg/controller/seed.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+// IsSeedBackupNil returns whether the seed backup is nil
+func IsSeedBackupNil(cluster *Cluster) bool {
+	if cluster.Seed != nil {
+		return cluster.Seed.Spec.Backup == nil
+	} else if cluster.CoreSeed != nil {
+		return cluster.CoreSeed.Spec.Backup == nil
+	}
+	return true
+}

--- a/pkg/controller/shoot.go
+++ b/pkg/controller/shoot.go
@@ -15,8 +15,8 @@
 package controller
 
 import (
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/chartrenderer"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -40,34 +40,100 @@ func (f ChartRendererFactoryFunc) NewChartRendererForShoot(version string) (char
 }
 
 // GetPodNetwork returns the pod network CIDR of the given Shoot.
-func GetPodNetwork(shoot *gardenv1beta1.Shoot) string {
-	cloud := shoot.Spec.Cloud
-	switch {
-	case cloud.AWS != nil:
-		return *cloud.AWS.Networks.K8SNetworks.Pods
-	case cloud.Azure != nil:
-		return *cloud.Azure.Networks.K8SNetworks.Pods
-	case cloud.GCP != nil:
-		return *cloud.GCP.Networks.K8SNetworks.Pods
-	case cloud.OpenStack != nil:
-		return *cloud.OpenStack.Networks.K8SNetworks.Pods
-	case cloud.Alicloud != nil:
-		return *cloud.Alicloud.Networks.K8SNetworks.Pods
-	case cloud.Packet != nil:
-		return *cloud.Packet.Networks.K8SNetworks.Pods
-	default:
-		return ""
+func GetPodNetwork(cluster *Cluster) string {
+	if cluster.Shoot != nil {
+		cloud := cluster.Shoot.Spec.Cloud
+		switch {
+		case cloud.AWS != nil:
+			return *cloud.AWS.Networks.K8SNetworks.Pods
+		case cloud.Azure != nil:
+			return *cloud.Azure.Networks.K8SNetworks.Pods
+		case cloud.GCP != nil:
+			return *cloud.GCP.Networks.K8SNetworks.Pods
+		case cloud.OpenStack != nil:
+			return *cloud.OpenStack.Networks.K8SNetworks.Pods
+		case cloud.Alicloud != nil:
+			return *cloud.Alicloud.Networks.K8SNetworks.Pods
+		case cloud.Packet != nil:
+			return *cloud.Packet.Networks.K8SNetworks.Pods
+		default:
+			return ""
+		}
+	} else if cluster.CoreShoot != nil && cluster.CoreShoot.Spec.Networking.Pods != nil {
+		return *cluster.CoreShoot.Spec.Networking.Pods
 	}
+	return ""
+}
+
+// GetServiceNetwork returns the service network CIDR of the given Shoot.
+func GetServiceNetwork(cluster *Cluster) string {
+	if cluster.Shoot != nil {
+		cloud := cluster.Shoot.Spec.Cloud
+		switch {
+		case cloud.AWS != nil:
+			return *cloud.AWS.Networks.K8SNetworks.Services
+		case cloud.Azure != nil:
+			return *cloud.Azure.Networks.K8SNetworks.Services
+		case cloud.GCP != nil:
+			return *cloud.GCP.Networks.K8SNetworks.Services
+		case cloud.OpenStack != nil:
+			return *cloud.OpenStack.Networks.K8SNetworks.Services
+		case cloud.Alicloud != nil:
+			return *cloud.Alicloud.Networks.K8SNetworks.Services
+		case cloud.Packet != nil:
+			return *cloud.Packet.Networks.K8SNetworks.Services
+		default:
+			return ""
+		}
+	} else if cluster.CoreShoot != nil && cluster.CoreShoot.Spec.Networking.Services != nil {
+		return *cluster.CoreShoot.Spec.Networking.Services
+	}
+	return ""
 }
 
 // IsHibernated returns true if the shoot is hibernated, or false otherwise.
-func IsHibernated(shoot *gardenv1beta1.Shoot) bool {
-	return shoot.Spec.Hibernation != nil && shoot.Spec.Hibernation.Enabled != nil && *shoot.Spec.Hibernation.Enabled
+func IsHibernated(cluster *Cluster) bool {
+	if cluster.Shoot != nil {
+		return cluster.Shoot.Spec.Hibernation != nil && cluster.Shoot.Spec.Hibernation.Enabled != nil && *cluster.Shoot.Spec.Hibernation.Enabled
+	} else if cluster.CoreShoot != nil {
+		return cluster.CoreShoot.Spec.Hibernation != nil && cluster.CoreShoot.Spec.Hibernation.Enabled != nil && *cluster.CoreShoot.Spec.Hibernation.Enabled
+	}
+	return false
+}
+
+// GetKubernetesVersion returns the kubernetes version.
+func GetKubernetesVersion(cluster *Cluster) string {
+	if cluster.Shoot != nil {
+		return cluster.Shoot.Spec.Kubernetes.Version
+	} else if cluster.CoreShoot != nil {
+		return cluster.CoreShoot.Spec.Kubernetes.Version
+	}
+	return ""
+}
+
+// GetTechnicalID returns the shoot technical id.
+func GetTechnicalID(cluster *Cluster) string {
+	if cluster.Shoot != nil {
+		return cluster.Shoot.Status.TechnicalID
+	} else if cluster.CoreShoot != nil {
+		return cluster.CoreShoot.Status.TechnicalID
+	}
+	return ""
+}
+
+// GetUID returns the shoot uid.
+func GetUID(cluster *Cluster) types.UID {
+	if cluster.Shoot != nil {
+		return cluster.Shoot.Status.UID
+	} else if cluster.CoreShoot != nil {
+		return cluster.CoreShoot.Status.UID
+	}
+	return ""
 }
 
 // GetReplicas returns the woken up replicas of the given Shoot.
-func GetReplicas(shoot *gardenv1beta1.Shoot, wokenUp int) int {
-	if IsHibernated(shoot) {
+func GetReplicas(cluster *Cluster, wokenUp int) int {
+	if IsHibernated(cluster) {
 		return 0
 	}
 	return wokenUp
@@ -75,8 +141,10 @@ func GetReplicas(shoot *gardenv1beta1.Shoot, wokenUp int) int {
 
 // GetControlPlaneReplicas returns the woken up replicas for controlplane components of the given Shoot
 // that should only be scaled down at the end of the flow.
-func GetControlPlaneReplicas(shoot *gardenv1beta1.Shoot, scaledDown bool, wokenUp int) int {
-	if shoot.DeletionTimestamp == nil && IsHibernated(shoot) && scaledDown {
+func GetControlPlaneReplicas(cluster *Cluster, scaledDown bool, wokenUp int) int {
+	if ((cluster.Shoot != nil && cluster.Shoot.DeletionTimestamp == nil) ||
+		(cluster.CoreShoot != nil && cluster.CoreShoot.DeletionTimestamp == nil)) &&
+		IsHibernated(cluster) && scaledDown {
 		return 0
 	}
 	return wokenUp

--- a/pkg/controller/shoot_test.go
+++ b/pkg/controller/shoot_test.go
@@ -15,6 +15,7 @@
 package controller
 
 import (
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 
 	. "github.com/onsi/ginkgo"
@@ -25,69 +26,120 @@ import (
 var _ = Describe("Shoot", func() {
 	trueVar := true
 	falseVar := false
+
 	cidr := "10.250.0.0/19"
 
 	DescribeTable("#GetPodNetwork",
-		func(cloud gardenv1beta1.Cloud, cidr string) {
-			shoot := &gardenv1beta1.Shoot{
-				Spec: gardenv1beta1.ShootSpec{
-					Cloud: cloud,
-				},
-			}
-
-			Expect(GetPodNetwork(shoot)).To(Equal(cidr))
+		func(cluster *Cluster, cidr string) {
+			Expect(GetPodNetwork(cluster)).To(Equal(cidr))
 		},
 
-		Entry("cloud is AWS", gardenv1beta1.Cloud{
-			AWS: &gardenv1beta1.AWSCloud{
-				Networks: gardenv1beta1.AWSNetworks{
-					K8SNetworks: gardenv1beta1.K8SNetworks{Pods: &cidr},
+		Entry("pod cidr is given", &Cluster{
+			CoreShoot: &gardencorev1alpha1.Shoot{
+				Spec: gardencorev1alpha1.ShootSpec{
+					Networking: gardencorev1alpha1.Networking{
+						Pods: &cidr,
+					},
 				},
 			},
 		}, cidr),
 
-		Entry("cloud is Azure", gardenv1beta1.Cloud{
-			Azure: &gardenv1beta1.AzureCloud{
-				Networks: gardenv1beta1.AzureNetworks{
-					K8SNetworks: gardenv1beta1.K8SNetworks{Pods: &cidr},
+		Entry("cloud is AWS", &Cluster{
+			Shoot: &gardenv1beta1.Shoot{
+				Spec: gardenv1beta1.ShootSpec{
+					Cloud: gardenv1beta1.Cloud{
+						AWS: &gardenv1beta1.AWSCloud{
+							Networks: gardenv1beta1.AWSNetworks{
+								K8SNetworks: gardenv1beta1.K8SNetworks{Pods: &cidr},
+							},
+						},
+					},
 				},
 			},
 		}, cidr),
 
-		Entry("cloud is GCP", gardenv1beta1.Cloud{
-			GCP: &gardenv1beta1.GCPCloud{
-				Networks: gardenv1beta1.GCPNetworks{
-					K8SNetworks: gardenv1beta1.K8SNetworks{Pods: &cidr},
+		Entry("cloud is Azure", &Cluster{
+			Shoot: &gardenv1beta1.Shoot{
+				Spec: gardenv1beta1.ShootSpec{
+					Cloud: gardenv1beta1.Cloud{
+						Azure: &gardenv1beta1.AzureCloud{
+							Networks: gardenv1beta1.AzureNetworks{
+								K8SNetworks: gardenv1beta1.K8SNetworks{Pods: &cidr},
+							},
+						},
+					},
 				},
 			},
 		}, cidr),
 
-		Entry("cloud is OpenStack", gardenv1beta1.Cloud{
-			OpenStack: &gardenv1beta1.OpenStackCloud{
-				Networks: gardenv1beta1.OpenStackNetworks{
-					K8SNetworks: gardenv1beta1.K8SNetworks{Pods: &cidr},
+		Entry("cloud is GCP", &Cluster{
+			Shoot: &gardenv1beta1.Shoot{
+				Spec: gardenv1beta1.ShootSpec{
+					Cloud: gardenv1beta1.Cloud{
+						GCP: &gardenv1beta1.GCPCloud{
+							Networks: gardenv1beta1.GCPNetworks{
+								K8SNetworks: gardenv1beta1.K8SNetworks{Pods: &cidr},
+							},
+						},
+					},
 				},
 			},
 		}, cidr),
 
-		Entry("cloud is Alicloud", gardenv1beta1.Cloud{
-			Alicloud: &gardenv1beta1.Alicloud{
-				Networks: gardenv1beta1.AlicloudNetworks{
-					K8SNetworks: gardenv1beta1.K8SNetworks{Pods: &cidr},
+		Entry("cloud is OpenStack", &Cluster{
+			Shoot: &gardenv1beta1.Shoot{
+				Spec: gardenv1beta1.ShootSpec{
+					Cloud: gardenv1beta1.Cloud{
+						OpenStack: &gardenv1beta1.OpenStackCloud{
+							Networks: gardenv1beta1.OpenStackNetworks{
+								K8SNetworks: gardenv1beta1.K8SNetworks{Pods: &cidr},
+							},
+						},
+					},
+				},
+			},
+		}, cidr),
+
+		Entry("cloud is Alicloud", &Cluster{
+			Shoot: &gardenv1beta1.Shoot{
+				Spec: gardenv1beta1.ShootSpec{
+					Cloud: gardenv1beta1.Cloud{
+						Alicloud: &gardenv1beta1.Alicloud{
+							Networks: gardenv1beta1.AlicloudNetworks{
+								K8SNetworks: gardenv1beta1.K8SNetworks{Pods: &cidr},
+							},
+						},
+					},
+				},
+			},
+		}, cidr),
+
+		Entry("cloud is Packet", &Cluster{
+			Shoot: &gardenv1beta1.Shoot{
+				Spec: gardenv1beta1.ShootSpec{
+					Cloud: gardenv1beta1.Cloud{
+						Packet: &gardenv1beta1.PacketCloud{
+							Networks: gardenv1beta1.PacketNetworks{
+								K8SNetworks: gardenv1beta1.K8SNetworks{Pods: &cidr},
+							},
+						},
+					},
 				},
 			},
 		}, cidr),
 	)
 
-	DescribeTable("#IsHibernated",
+	DescribeTable("#IsHibernated (gardenv1beta1.Shoot)",
 		func(hibernation *gardenv1beta1.Hibernation, expectation bool) {
-			shoot := &gardenv1beta1.Shoot{
-				Spec: gardenv1beta1.ShootSpec{
-					Hibernation: hibernation,
+			cluster := &Cluster{
+				Shoot: &gardenv1beta1.Shoot{
+					Spec: gardenv1beta1.ShootSpec{
+						Hibernation: hibernation,
+					},
 				},
 			}
 
-			Expect(IsHibernated(shoot)).To(Equal(expectation))
+			Expect(IsHibernated(cluster)).To(Equal(expectation))
 		},
 
 		Entry("hibernation is nil", nil, false),
@@ -95,18 +147,55 @@ var _ = Describe("Shoot", func() {
 		Entry("hibernation is enabled", &gardenv1beta1.Hibernation{Enabled: &trueVar}, true),
 	)
 
-	DescribeTable("#GetReplicas",
-		func(hibernation *gardenv1beta1.Hibernation, wokenUp, expectation int) {
-			shoot := &gardenv1beta1.Shoot{
-				Spec: gardenv1beta1.ShootSpec{
-					Hibernation: hibernation,
+	DescribeTable("#IsHibernated (gardencorev1alpha1.Shoot)",
+		func(hibernation *gardencorev1alpha1.Hibernation, expectation bool) {
+			cluster := &Cluster{
+				CoreShoot: &gardencorev1alpha1.Shoot{
+					Spec: gardencorev1alpha1.ShootSpec{
+						Hibernation: hibernation,
+					},
 				},
 			}
 
-			Expect(GetReplicas(shoot, wokenUp)).To(Equal(expectation))
+			Expect(IsHibernated(cluster)).To(Equal(expectation))
+		},
+
+		Entry("hibernation is nil", nil, false),
+		Entry("hibernation is not enabled", &gardencorev1alpha1.Hibernation{Enabled: &falseVar}, false),
+		Entry("hibernation is enabled", &gardencorev1alpha1.Hibernation{Enabled: &trueVar}, true),
+	)
+
+	DescribeTable("#GetReplicas (gardenv1beta1.Shoot)",
+		func(hibernation *gardenv1beta1.Hibernation, wokenUp, expectation int) {
+			cluster := &Cluster{
+				Shoot: &gardenv1beta1.Shoot{
+					Spec: gardenv1beta1.ShootSpec{
+						Hibernation: hibernation,
+					},
+				},
+			}
+
+			Expect(GetReplicas(cluster, wokenUp)).To(Equal(expectation))
 		},
 
 		Entry("hibernation is not enabled", nil, 3, 3),
 		Entry("hibernation is enabled", &gardenv1beta1.Hibernation{Enabled: &trueVar}, 1, 0),
+	)
+
+	DescribeTable("#GetReplicas (gardencorev1alpha1.Shoot)",
+		func(hibernation *gardencorev1alpha1.Hibernation, wokenUp, expectation int) {
+			cluster := &Cluster{
+				CoreShoot: &gardencorev1alpha1.Shoot{
+					Spec: gardencorev1alpha1.ShootSpec{
+						Hibernation: hibernation,
+					},
+				},
+			}
+
+			Expect(GetReplicas(cluster, wokenUp)).To(Equal(expectation))
+		},
+
+		Entry("hibernation is not enabled", nil, 3, 3),
+		Entry("hibernation is enabled", &gardencorev1alpha1.Hibernation{Enabled: &trueVar}, 1, 0),
 	)
 })

--- a/pkg/controller/worker/genericactuator/machine_controller_manager.go
+++ b/pkg/controller/worker/genericactuator/machine_controller_manager.go
@@ -56,7 +56,7 @@ func (a *genericActuator) deployMachineControllerManager(ctx context.Context, wo
 	mcmValues["replicas"] = replicaCount
 
 	if err := a.mcmSeedChart.Apply(ctx, a.chartApplier, workerObj.Namespace,
-		a.imageVector, a.gardenerClientset.Version(), cluster.Shoot.Spec.Kubernetes.Version, mcmValues); err != nil {
+		a.imageVector, a.gardenerClientset.Version(), extensionscontroller.GetKubernetesVersion(cluster), mcmValues); err != nil {
 		return errors.Wrapf(err, "could not apply MCM chart in seed for worker '%s'", util.ObjectName(workerObj))
 	}
 
@@ -89,7 +89,7 @@ func (a *genericActuator) deleteMachineControllerManager(ctx context.Context, wo
 
 func (a *genericActuator) applyMachineControllerManagerShootChart(ctx context.Context, workerDelegate WorkerDelegate, workerObj *extensionsv1alpha1.Worker, cluster *controller.Cluster) error {
 	// Create shoot chart renderer
-	chartRenderer, err := a.chartRendererFactory.NewChartRendererForShoot(cluster.Shoot.Spec.Kubernetes.Version)
+	chartRenderer, err := a.chartRendererFactory.NewChartRendererForShoot(extensionscontroller.GetKubernetesVersion(cluster))
 	if err != nil {
 		return errors.Wrapf(err, "could not create chart renderer for shoot '%s'", workerObj.Namespace)
 	}
@@ -100,7 +100,7 @@ func (a *genericActuator) applyMachineControllerManagerShootChart(ctx context.Co
 		return err
 	}
 
-	if err := extensionscontroller.RenderChartAndCreateManagedResource(ctx, workerObj.Namespace, mcmShootResourceName, a.client, chartRenderer, a.mcmShootChart, values, a.imageVector, metav1.NamespaceSystem, cluster.Shoot.Spec.Kubernetes.Version, true); err != nil {
+	if err := extensionscontroller.RenderChartAndCreateManagedResource(ctx, workerObj.Namespace, mcmShootResourceName, a.client, chartRenderer, a.mcmShootChart, values, a.imageVector, metav1.NamespaceSystem, extensionscontroller.GetKubernetesVersion(cluster), true); err != nil {
 		return errors.Wrapf(err, "could not apply control plane shoot chart for worker '%s'", util.ObjectName(workerObj))
 	}
 

--- a/pkg/util/shoot.go
+++ b/pkg/util/shoot.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 
 	"github.com/Masterminds/semver"
@@ -103,14 +102,6 @@ func GetOrCreateShootKubeconfig(ctx context.Context, c client.Client, certificat
 // e.g. kube-apiserver.shoot--project--prod.svc.cluster.local.
 func kubeAPIServerServiceDNS(namespace string) string {
 	return fmt.Sprintf("%s.%s", v1alpha1constants.DeploymentNameKubeAPIServer, namespace)
-}
-
-// GetReplicaCount returns the given replica count base on the hibernation status of the shoot.
-func GetReplicaCount(shoot *gardenv1beta1.Shoot, count int) int {
-	if shoot.Spec.Hibernation != nil && shoot.Spec.Hibernation.Enabled != nil && *shoot.Spec.Hibernation.Enabled {
-		return 0
-	}
-	return count
 }
 
 // VersionMajorMinor extracts and returns the major and the minor part of the given version (input must be a semantic version).

--- a/pkg/util/shoot_test.go
+++ b/pkg/util/shoot_test.go
@@ -21,22 +21,18 @@ import (
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener-extensions/pkg/util"
 	. "github.com/gardener/gardener-extensions/pkg/util"
-
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 
 	"github.com/golang/mock/gomock"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/version"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/webhook/controlplane/genericmutator/mutator_test.go
+++ b/pkg/webhook/controlplane/genericmutator/mutator_test.go
@@ -27,9 +27,9 @@ import (
 	extensionswebhook "github.com/gardener/gardener-extensions/pkg/webhook"
 
 	"github.com/coreos/go-systemd/unit"
+	gardencorevalpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -74,11 +74,25 @@ var _ = Describe("Mutator", func() {
 
 		clusterKey = client.ObjectKey{Name: namespace}
 		cluster    = &extensionscontroller.Cluster{
-			CloudProfile: &gardenv1beta1.CloudProfile{},
-			Seed:         &gardenv1beta1.Seed{},
-			Shoot: &gardenv1beta1.Shoot{
-				Spec: gardenv1beta1.ShootSpec{
-					Kubernetes: gardenv1beta1.Kubernetes{
+			CoreCloudProfile: &gardencorevalpha1.CloudProfile{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: gardencorevalpha1.SchemeGroupVersion.String(),
+					Kind:       "CloudProfile",
+				},
+			},
+			CoreSeed: &gardencorevalpha1.Seed{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: gardencorevalpha1.SchemeGroupVersion.String(),
+					Kind:       "Seed",
+				},
+			},
+			CoreShoot: &gardencorevalpha1.Shoot{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: gardencorevalpha1.SchemeGroupVersion.String(),
+					Kind:       "Shoot",
+				},
+				Spec: gardencorevalpha1.ShootSpec{
+					Kubernetes: gardencorevalpha1.Kubernetes{
 						Version: "1.13.4",
 					},
 				},
@@ -430,13 +444,13 @@ func clusterObject(cluster *extensionscontroller.Cluster) *extensionsv1alpha1.Cl
 	return &extensionsv1alpha1.Cluster{
 		Spec: extensionsv1alpha1.ClusterSpec{
 			CloudProfile: runtime.RawExtension{
-				Raw: encode(cluster.CloudProfile),
+				Raw: encode(cluster.CoreCloudProfile),
 			},
 			Seed: runtime.RawExtension{
-				Raw: encode(cluster.Seed),
+				Raw: encode(cluster.CoreSeed),
 			},
 			Shoot: runtime.RawExtension{
-				Raw: encode(cluster.Shoot),
+				Raw: encode(cluster.CoreShoot),
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR all the extension controllers are adapted to be able to work with both the `garden.sapcloud.io/v1beta1` and `core.gardener.cloud/v1alpha1` resources. This functionality will be cleaned up again in the next release and is only for the migration phase where the `gardener-controller-manager` will start working with `core.gardener.cloud/v1alpha1` but some `Cluster` resources still contain `garden.sapcloud.io/v1beta1` resources.

**Special notes for your reviewer**:
* Part of gardener/gardener#1376
* :warning: Depends on gardener/gardener#1430 which should be merged first (after that 89d4e6b2aeac2be92609c2798f748f79047b5e3a needs to be rebased again)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
All extension controllers are now able to work either with `garden.sapcloud.io/v1beta1` or with `core.gardener.cloud/v1alpha1` resources. This functionality is only temporary. In the next release the support for `garden.sapcloud.io/v1beta1` is dropped again as the API is deprecated.
```
