### PR TITLE
BackupEntry generic actuator handles terminating namespaces

### DIFF
--- a/pkg/controller/backupentry/genericactuator/actuator.go
+++ b/pkg/controller/backupentry/genericactuator/actuator.go
@@ -72,6 +72,10 @@ func (a *actuator) deployEtcdBackupSecret(ctx context.Context, be *extensionsv1a
 		a.logger.Error(err, "failed to get seed namespace")
 		return err
 	}
+	if namespace.DeletionTimestamp != nil {
+		a.logger.Info("SeedNamespace for shoot is being terminated. Avoiding etcd backup secret deployment")
+		return nil
+	}
 
 	backupSecret, err := extensionscontroller.GetSecretByReference(ctx, a.client, &be.Spec.SecretRef)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevent error logs like
```
{"level":"error","ts":"2019-09-18T02:56:21.822Z","logger":"backupentry_controller","msg":"Error reconciling backupentry","backupentry":"shoot--it--tm-ev3zx--12619378-d916-11e9-ab72-06b1937d9d6b","error":"secrets \"etcd-backup\" is forbidden: unable to create new content in namespace shoot--it--tm-ev3zx because it is being terminated","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/go/src/github.com/gardener/gardener-extensions/vendor/github.com/go-logr/zapr/zapr.go:128\ngithub.com/gardener/gardener-extensions/pkg/controller/backupentry.(*reconciler).reconcile\n\t/go/src/github.com/gardener/gardener-extensions/pkg/controller/backupentry/reconciler.go:121\ngithub.com/gardener/gardener-extensions/pkg/controller/backupentry.(*reconciler).Reconcile\n\t/go/src/github.com/gardener/gardener-extensions/pkg/controller/backupentry/reconciler.go:93\ngithub.com/gardener/gardener-extensions/pkg/controller.(*operationAnnotationWrapper).Reconcile\n\t/go/src/github.com/gardener/gardener-extensions/pkg/controller/reconciler.go:85\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/gardener/gardener-extensions/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:216\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/gardener/gardener-extensions/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:192\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/go/src/github.com/gardener/gardener-extensions/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:171\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/go/src/github.com/gardener/gardener-extensions/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/src/github.com/gardener/gardener-extensions/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/go/src/github.com/gardener/gardener-extensions/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `BackupEntry` generic actuator no longer tries to create the etcd secret in case the namespace is already terminating.
```
