### PR TITLE
Control plane generic actuator waits for managed resources to be deleted

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,7 @@ github.com/gardener/gardener-resource-manager v0.0.0-20190802153254-ea0dc5872b6a
 github.com/gardener/gardener-resource-manager v0.0.0-20190802153254-ea0dc5872b6a/go.mod h1:kIPm1DlE5jChb4moAseumj1qr+IITKXPJcqyIKJp14Y=
 github.com/gardener/gardener-resource-manager v0.0.0-20190828115855-7ceeb3021993 h1:HoOo1rfm4n/T23886/Yj2yCVC81cVuXMbzdMo6PzTOs=
 github.com/gardener/gardener-resource-manager v0.0.0-20190828115855-7ceeb3021993/go.mod h1:l18ykpXeMDrrrtiA99YTdvZPW2TOaHIR/LrtbVELIiU=
+github.com/gardener/gardener-resource-manager v0.0.0-20190912084358-b926d0903974 h1:CE0XLALKGUYdsbyUXkoyAi4qnn7MAq8N95k2MaDemiQ=
 github.com/gardener/machine-controller-manager v0.0.0-20190228095106-36a42c48af0a/go.mod h1:/ZDmMugbfkBfOO6/nrdnqV+OMSEuF75wrF9KFIuqndM=
 github.com/gardener/machine-controller-manager v0.0.0-20190606071036-119056ee3fdd h1:PrtJshi9rSN6V5w6FDFh9u1arfplk7ufxLKXFsasqzs=
 github.com/gardener/machine-controller-manager v0.0.0-20190606071036-119056ee3fdd/go.mod h1:/ZDmMugbfkBfOO6/nrdnqV+OMSEuF75wrF9KFIuqndM=

--- a/pkg/controller/controlplane/genericactuator/actuator_test.go
+++ b/pkg/controller/controlplane/genericactuator/actuator_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
@@ -378,6 +379,9 @@ var _ = Describe("Actuator", func() {
 			client.EXPECT().Delete(ctx, deleteMRForCPShootChart).Return(nil)
 			client.EXPECT().Delete(ctx, deletedMRSecretForCPShootChart).Return(nil)
 
+			client.EXPECT().Get(gomock.Any(), resourceKeyStorageClassesChart, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(errors.NewNotFound(schema.GroupResource{}, deleteMRForStorageClassesChart.Name))
+			client.EXPECT().Get(gomock.Any(), resourceKeyCPShootChart, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(errors.NewNotFound(schema.GroupResource{}, deleteMRForCPShootChart.Name))
+
 			// Create mock secrets and charts
 			secrets := mockutil.NewMockSecrets(ctrl)
 			secrets.EXPECT().Delete(gomock.Any(), namespace).Return(nil)
@@ -394,6 +398,7 @@ var _ = Describe("Actuator", func() {
 				client.EXPECT().Delete(ctx, deletedNetworkPolicyForShootWebhooks).Return(nil)
 				client.EXPECT().Delete(ctx, deletedMRForShootWebhooks).Return(nil)
 				client.EXPECT().Delete(ctx, deletedMRSecretForShootWebhooks).Return(nil)
+				client.EXPECT().Get(gomock.Any(), resourceKeyShootWebhooks, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(errors.NewNotFound(schema.GroupResource{}, deletedMRForShootWebhooks.Name))
 			}
 
 			// Create actuator
@@ -453,11 +458,11 @@ var _ = Describe("Actuator", func() {
 			exposureSecrets := mockutil.NewMockSecrets(ctrl)
 			exposureSecrets.EXPECT().Delete(gomock.Any(), namespace).Return(nil)
 
-			cpExplosureChart := mockutil.NewMockChart(ctrl)
-			cpExplosureChart.EXPECT().Delete(ctx, client, namespace).Return(nil)
+			cpExposureChart := mockutil.NewMockChart(ctrl)
+			cpExposureChart.EXPECT().Delete(ctx, client, namespace).Return(nil)
 
 			// Create actuator
-			a := NewActuator(providerName, nil, exposureSecrets, nil, nil, nil, nil, cpExplosureChart, nil, nil, nil, "", nil, 0, logger)
+			a := NewActuator(providerName, nil, exposureSecrets, nil, nil, nil, nil, cpExposureChart, nil, nil, nil, "", nil, 0, logger)
 			err := a.(inject.Client).InjectClient(client)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/controller/managedresources.go
+++ b/pkg/controller/managedresources.go
@@ -16,15 +16,17 @@ package controller
 
 import (
 	"context"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"time"
 
 	"github.com/gardener/gardener-extensions/pkg/util"
 
+	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener-resource-manager/pkg/manager"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -122,4 +124,15 @@ func DeleteManagedResource(ctx context.Context, client client.Client, namespace 
 	}
 
 	return nil
+}
+
+// WaitUntilManagedResourceDeleted waits until the given managed resource is deleted.
+func WaitUntilManagedResourceDeleted(ctx context.Context, client client.Client, namespace, name string) error {
+	mr := &resourcesv1alpha1.ManagedResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	return WaitUntilResourceDeleted(ctx, client, mr, 2*time.Second)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We have seen situations in which the shoot namespace in the seed was
hanging in "Terminating" state because the managed resources from the
control plane controller were still existing.
In the [shoot deletion flow](https://github.com/gardener/gardener/blob/master/pkg/controllermanager/controller/shoot/shoot_control_delete.go)
the `ControlPlane` resource is destroyed, and right after that the
kube-apiserver deployment is deleted. If the gardener-resource-manager
is not cleaning up the control plane MRs fast enough then the
kube-apiserver is deleted to fast which will block the
gardener-resource-manager from gracefully cleaning up the MRs.
Thus, now with the waiting mechanism we ensure that the `ControlPlane`
resource is only deleted after the MRs are gone, hence, the
kube-apiserver deployment will also only be deleted after that.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `ControlPlane` generic actuator now waits for its created `ManagedResource`s to be deleted during its deletion flow. This is so that it doesn't accidentally remove its finalizer although created artefacts still exist.
```
