### PR TITLE
[ci:component:github.com/gardener/machine-controller-manager:0.21.1->0.22.0]

### DIFF
--- a/controllers/provider-alicloud/charts/images.yaml
+++ b/controllers/provider-alicloud/charts/images.yaml
@@ -6,7 +6,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.21.1"
+  tag: "0.22.0"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl

--- a/controllers/provider-aws/charts/images.yaml
+++ b/controllers/provider-aws/charts/images.yaml
@@ -9,7 +9,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.21.1"
+  tag: "0.22.0"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl

--- a/controllers/provider-azure/charts/images.yaml
+++ b/controllers/provider-azure/charts/images.yaml
@@ -9,7 +9,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.21.1"
+  tag: "0.22.0"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl

--- a/controllers/provider-gcp/charts/images.yaml
+++ b/controllers/provider-gcp/charts/images.yaml
@@ -9,7 +9,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.21.1"
+  tag: "0.22.0"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl

--- a/controllers/provider-openstack/charts/images.yaml
+++ b/controllers/provider-openstack/charts/images.yaml
@@ -6,7 +6,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.21.1"
+  tag: "0.22.0"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl

--- a/controllers/provider-packet/charts/images.yaml
+++ b/controllers/provider-packet/charts/images.yaml
@@ -10,7 +10,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.21.1"
+  tag: "0.22.0"
 - name: csi-attacher
   sourceRepository: https://github.com/kubernetes-csi/external-attacher
   repository: quay.io/k8scsi/csi-attacher


### PR DESCRIPTION
*Release Notes*:
``` improvement user github.com/gardener/machine-controller-manager #335 @dkistner
MCM supports now Azure machines deployed into availability zones. You can either deploy a machine into a zone or an AvailabilitySet.
```

``` improvement operator github.com/gardener/machine-controller-manager #331 @ialidzhikov
`tzdata` package is now used instead of `assets/zoneinfo.zip` to make all timezones available.
```

``` improvement operator github.com/gardener/machine-controller-manager #331 @ialidzhikov
Base docker image is updated to `alpine:3.10`.
```

``` improvement operator github.com/gardener/machine-controller-manager #330 @prashanth26
On failure to GET machine object, machine creation continues to retry instead of returning failure
```

``` improvement operator github.com/gardener/machine-controller-manager #329 @vlvasilev
MCM differentiates between cloud-config and script as user-data
```

``` improvement operator github.com/gardener/machine-controller-manager #328 @afritzler
Added missing user_domain_id secret field for OpenStack driver
```

``` improvement operator github.com/gardener/machine-controller-manager #327 @hardikdr
Negative tests for taints, annotations and labels support
```

``` noteworthy operator github.com/gardener/machine-controller-manager #326 @vpnachev
:warning: The `AzureMachineClass` now has a field `Spec.Properties.StorageProfile.ImageReference.URN` that is used to define the OS image for the VMs. This field is replacing the fields `Spec.Properties.StorageProfile.ImageReference.[Publisher|Offer|Sku|Version]` - they are marked as `DEPRECATED` and will be removed soon.
```

``` improvement operator github.com/gardener/machine-controller-manager #324 @prashanth26
Bugfix: Delete node only if nodeName isn't empty
```