### PR TITLE
[ci:component:github.com/gardener/terraformer:0.13.0->0.14.0]

### DIFF
--- a/controllers/provider-alicloud/charts/images.yaml
+++ b/controllers/provider-alicloud/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "0.13.0"
+  tag: "0.14.0"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager

--- a/controllers/provider-aws/charts/images.yaml
+++ b/controllers/provider-aws/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "0.13.0"
+  tag: "0.14.0"
 - name: hyperkube
   sourceRepository: github.com/kubernetes/kubernetes
   repository: k8s.gcr.io/hyperkube

--- a/controllers/provider-azure/charts/images.yaml
+++ b/controllers/provider-azure/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "0.13.0"
+  tag: "0.14.0"
 - name: hyperkube
   sourceRepository: github.com/kubernetes/kubernetes
   repository: k8s.gcr.io/hyperkube

--- a/controllers/provider-gcp/charts/images.yaml
+++ b/controllers/provider-gcp/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "0.13.0"
+  tag: "0.14.0"
 - name: hyperkube
   sourceRepository: github.com/kubernetes/kubernetes
   repository: k8s.gcr.io/hyperkube

--- a/controllers/provider-openstack/charts/images.yaml
+++ b/controllers/provider-openstack/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "0.13.0"
+  tag: "0.14.0"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager

--- a/controllers/provider-packet/charts/images.yaml
+++ b/controllers/provider-packet/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "0.13.0"
+  tag: "0.14.0"
 - name: cloud-controller-manager
   sourceRepository: https://github.com/packethost/packet-ccm
   repository: docker.io/packethost/packet-ccm


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/terraformer #24 @ialidzhikov
`tzdata` package is now used instead of `assets/zoneinfo.zip` to make all timezones available.
```

``` noteworthy operator github.com/gardener/terraformer #23 @mvladev
Provider versions are upgraded:

- aws `1.60.0` -> `2.26.0`
- google `1.20.0` -> `2.14.0`
- azurerm `1.22.1` -> `1.33.1`
- openstack `1.16.0` -> `1.21.1`
- alicloud `1.31.0` -> `1.55.2`
- packet `1.7.2` -> `2.3.0`
```