### PR TITLE
Replace deprecated field in alicloud provider

### DIFF
--- a/controllers/provider-alicloud/charts/internal/alicloud-infra/templates/main.tf
+++ b/controllers/provider-alicloud/charts/internal/alicloud-infra/templates/main.tf
@@ -17,7 +17,7 @@ resource "alicloud_vpc" "vpc" {
 }
 resource "alicloud_nat_gateway" "nat_gateway" {
   vpc_id = "{{ required "vpc.id is required" .Values.vpc.id }}"
-  spec   = "Small"
+  specification   = "Small"
   name   = "{{ required "clusterName is required" .Values.clusterName }}-natgw"
 }
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to replace deprecated argument `spec` in alicloud terraform provider with `specification`.

**Which issue(s) this PR fixes**:
Ref #320

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
