### PR TITLE
Azure: Allow to configure service endpoints

### DIFF
--- a/controllers/provider-azure/charts/internal/azure-infra/templates/main.tf
+++ b/controllers/provider-azure/charts/internal/azure-infra/templates/main.tf
@@ -30,6 +30,7 @@ resource "azurerm_subnet" "workers" {
   resource_group_name       = "{{ required "resourceGroup.name is required" .Values.resourceGroup.name }}"
   virtual_network_name      = "{{ required "resourceGroup.vnet.name is required" .Values.resourceGroup.vnet.name }}"
   address_prefix            = "{{ required "networks.worker is required" .Values.networks.worker }}"
+  service_endpoints         = [{{range $index, $serviceEndpoint := .Values.resourceGroup.subnet.serviceEndpoints}}{{if $index}},{{end}}"{{$serviceEndpoint}}"{{end}}]
 }
 
 resource "azurerm_route_table" "workers" {

--- a/controllers/provider-azure/charts/internal/azure-infra/values.yaml
+++ b/controllers/provider-azure/charts/internal/azure-infra/values.yaml
@@ -14,6 +14,8 @@ resourceGroup:
   vnet:
     name: my-vnet
     cidr: 10.10.10.10/6
+  subnet:
+    serviceEndpoints: []
 
 clusterName: test-namespace
 

--- a/controllers/provider-azure/pkg/apis/azure/types_infrastructure.go
+++ b/controllers/provider-azure/pkg/apis/azure/types_infrastructure.go
@@ -41,6 +41,8 @@ type NetworkConfig struct {
 	VNet VNet
 	// Workers is the worker subnet range to create (used for the VMs).
 	Workers string
+	// ServiceEndpoints is a list of Azure ServiceEndpoints which should be associated with the worker subnet.
+	ServiceEndpoints []string
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/controllers/provider-azure/pkg/apis/azure/v1alpha1/types_infrastructure.go
+++ b/controllers/provider-azure/pkg/apis/azure/v1alpha1/types_infrastructure.go
@@ -42,6 +42,9 @@ type NetworkConfig struct {
 	VNet VNet `json:"vnet"`
 	// Workers is the worker subnet range to create (used for the VMs).
 	Workers string `json:"workers"`
+	// ServiceEndpoints is a list of Azure ServiceEndpoints which should be associated with the worker subnet.
+	// +optional
+	ServiceEndpoints []string `json:"serviceEndpoints,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/controllers/provider-azure/pkg/apis/azure/v1alpha1/zz_generated.conversion.go
+++ b/controllers/provider-azure/pkg/apis/azure/v1alpha1/zz_generated.conversion.go
@@ -479,6 +479,7 @@ func autoConvert_v1alpha1_NetworkConfig_To_azure_NetworkConfig(in *NetworkConfig
 		return err
 	}
 	out.Workers = in.Workers
+	out.ServiceEndpoints = *(*[]string)(unsafe.Pointer(&in.ServiceEndpoints))
 	return nil
 }
 
@@ -492,6 +493,7 @@ func autoConvert_azure_NetworkConfig_To_v1alpha1_NetworkConfig(in *azure.Network
 		return err
 	}
 	out.Workers = in.Workers
+	out.ServiceEndpoints = *(*[]string)(unsafe.Pointer(&in.ServiceEndpoints))
 	return nil
 }
 

--- a/controllers/provider-azure/pkg/apis/azure/v1alpha1/zz_generated.deepcopy.go
+++ b/controllers/provider-azure/pkg/apis/azure/v1alpha1/zz_generated.deepcopy.go
@@ -286,6 +286,11 @@ func (in *MachineImages) DeepCopy() *MachineImages {
 func (in *NetworkConfig) DeepCopyInto(out *NetworkConfig) {
 	*out = *in
 	in.VNet.DeepCopyInto(&out.VNet)
+	if in.ServiceEndpoints != nil {
+		in, out := &in.ServiceEndpoints, &out.ServiceEndpoints
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/controllers/provider-azure/pkg/apis/azure/zz_generated.deepcopy.go
+++ b/controllers/provider-azure/pkg/apis/azure/zz_generated.deepcopy.go
@@ -286,6 +286,11 @@ func (in *MachineImages) DeepCopy() *MachineImages {
 func (in *NetworkConfig) DeepCopyInto(out *NetworkConfig) {
 	*out = *in
 	in.VNet.DeepCopyInto(&out.VNet)
+	if in.ServiceEndpoints != nil {
+		in, out := &in.ServiceEndpoints, &out.ServiceEndpoints
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/controllers/provider-azure/pkg/internal/infrastructure/terraform.go
+++ b/controllers/provider-azure/pkg/internal/infrastructure/terraform.go
@@ -131,6 +131,9 @@ func ComputeTerraformerChartValues(infra *extensionsv1alpha1.Infrastructure, cli
 				"name": vnetName,
 				"cidr": vnetCIDR,
 			},
+			"subnet": map[string]interface{}{
+				"serviceEndpoints": config.Networks.ServiceEndpoints,
+			},
 		},
 		"clusterName": infra.Namespace,
 		"networks": map[string]interface{}{

--- a/controllers/provider-azure/pkg/internal/infrastructure/terraform_test.go
+++ b/controllers/provider-azure/pkg/internal/infrastructure/terraform_test.go
@@ -70,6 +70,8 @@ var _ = Describe("Terraform", func() {
 		config     *azurev1alpha1.InfrastructureConfig
 		cluster    *controller.Cluster
 		clientAuth *internal.ClientAuth
+
+		testServiceEndpoint = "Microsoft.Test"
 	)
 
 	BeforeEach(func() {
@@ -84,7 +86,8 @@ var _ = Describe("Terraform", func() {
 					Name: &VNetName,
 					CIDR: &VNetCIDR,
 				},
-				Workers: TestCIDR,
+				Workers:          TestCIDR,
+				ServiceEndpoints: []string{testServiceEndpoint},
 			},
 		}
 
@@ -137,6 +140,9 @@ var _ = Describe("Terraform", func() {
 					"vnet": map[string]interface{}{
 						"name": *config.Networks.VNet.Name,
 						"cidr": config.Networks.Workers,
+					},
+					"subnet": map[string]interface{}{
+						"serviceEndpoints": []string{testServiceEndpoint},
 					},
 				},
 				"clusterName": infra.Namespace,


### PR DESCRIPTION
Allow to configure Azure service endpoints for Gardener managed subnets.
See the Azure documentation for service endpoints: https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-service-endpoints-overview

If an `Infrastructure` CR reference an invalid service endpoint then Terraform will return an `SubnetHasServiceEndpointWithInvalidServiceName` error code.

**What this PR does / why we need it**:
See #199

**Which issue(s) this PR fixes**:
Fixes #199 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The Gardener Azure provider extension support now subnets configured with Azure Service Endpoints.
```

cc @bergerx