### PR TITLE
remove replicase field to enable autoscaling

### DIFF
--- a/controllers/networking-calico/charts/internal/calico/templates/calico.yaml
+++ b/controllers/networking-calico/charts/internal/calico/templates/calico.yaml
@@ -330,7 +330,6 @@ spec:
   # We recommend using Typha if you have more than 50 nodes.  Above 100 nodes it is essential
   # (when using the Kubernetes datastore).  Use one replica for every 100-200 nodes.  In
   # production, we recommend running at least 3 replicas to reduce the impact of rolling upgrade.
-  replicas: 1
   revisionHistoryLimit: 0
   template:
     metadata:


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the replicase field from the typha deployment to enable the autoscalers to modify it without being reconciled. 


```improvement operator
None
```
