### PR TITLE
enable watch for autoscaler cluster roles

### DIFF
--- a/controllers/networking-calico/charts/internal/calico/templates/rbac.yaml
+++ b/controllers/networking-calico/charts/internal/calico/templates/rbac.yaml
@@ -218,7 +218,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["list"]
+    verbs: ["list", "watch"]
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
@@ -275,7 +275,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["list"]
+    verbs: ["list", "watch"]
   - apiGroups: ["apps", "extensions"]
     resources: ["deployments"]
     verbs: ["patch"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Add watch cluster-roles for typha autoscalers. 

```improvement operator
NONE
```
