### PR TITLE
enable watch for autoscaler cluster roles

### DIFF
--- a/controllers/networking-calico/charts/internal/calico/templates/rbac.yaml
+++ b/controllers/networking-calico/charts/internal/calico/templates/rbac.yaml
@@ -218,7 +218,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["list"]
+    verbs: ["list", "watch"]
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding


### PR DESCRIPTION
**What this PR does / why we need it**:
enable the horizontal typha autoscaler to watch nodes. 

```improvement operator
NONE
```
