### PR TITLE
Fix calico chart to work when privileged containers are not allowed

### DIFF
--- a/controllers/networking-calico/charts/internal/calico/templates/calico.yaml
+++ b/controllers/networking-calico/charts/internal/calico/templates/calico.yaml
@@ -423,6 +423,7 @@ spec:
       securityContext:
         supplementalGroups: [ 65534 ]
         fsGroup: 65534
+        runAsUser: 65534
       containers:
         - image: {{ index .Values.images "typha-cpa" }}
           name: autoscaler
@@ -461,6 +462,8 @@ spec:
         k8s-app: calico-typha-autoscaler
     spec:
       priorityClassName: system-cluster-critical
+      securityContext:
+        runAsUser: 65534
       containers:
         - image:  {{ index .Values.images "typha-cpva" }}
           name: autoscaler

--- a/controllers/networking-calico/charts/internal/calico/templates/psp/calico-psp.yaml
+++ b/controllers/networking-calico/charts/internal/calico/templates/psp/calico-psp.yaml
@@ -17,6 +17,7 @@ spec:
   - pathPrefix: /run/xtables.lock
   - pathPrefix: /var/run/nodeagent
   - pathPrefix: /usr/libexec
+  - pathPrefix: /var/lib/kubelet/volumeplugins/nodeagent~uds
   runAsUser:
     rule: RunAsAny
   seLinux:

--- a/controllers/networking-calico/charts/internal/calico/templates/psp/calico-typha-horizontal-autoscaler-psp.yaml
+++ b/controllers/networking-calico/charts/internal/calico/templates/psp/calico-typha-horizontal-autoscaler-psp.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   volumes:
   - secret
+  runAsUser:
+    rule: MustRunAsNonRoot
   seLinux:
     rule: RunAsAny
   supplementalGroups:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix calico chart to work when privileged containers are not allowed.

**Which issue(s) this PR fixes**:
Fixes #341

**Special notes for your reviewer**:
/cc @vpnachev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Allow nodes to join the Shoot when `.spec.kubernetes.allowPrivilegedContainers=false`.
```
