### PR TITLE
Change monitoring ConfigMaps' syntax of provider-specific components

### DIFF
--- a/controllers/provider-alicloud/charts/internal/machine-controller-manager/seed/templates/configmap-monitoring.yaml
+++ b/controllers/provider-alicloud/charts/internal/machine-controller-manager/seed/templates/configmap-monitoring.yaml
@@ -7,7 +7,6 @@ metadata:
     extensions.gardener.cloud/configuration: monitoring
 data:
   scrape_config: |
-    scrape_configs:
     - job_name: machine-controller-manager
       honor_labels: false
       kubernetes_sd_configs:
@@ -48,4 +47,5 @@ data:
             summary: Machine controller manager is down.
 
   dashboard_operators: |
-{{ .Files.Get "mcm-monitoring-dashboard.json" | indent 4 }}
+    machine-controller-manager-dashboard.json: |-
+{{ .Files.Get "mcm-monitoring-dashboard.json" | indent 6 }}

--- a/controllers/provider-alicloud/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/templates/configmap-monitoring.yaml
+++ b/controllers/provider-alicloud/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/templates/configmap-monitoring.yaml
@@ -7,7 +7,6 @@ metadata:
     extensions.gardener.cloud/configuration: monitoring
 data:
   scrape_config: |
-    scrape_configs:
     - job_name: cloud-controller-manager
       honor_labels: false
       kubernetes_sd_configs:
@@ -47,5 +46,10 @@ data:
             description: All infrastruture specific operations cannot be completed (e.g. creating loadbalancers or persistent volumes).
             summary: Cloud controller manager is down.
 
+  dashboard_operators: |
+    cloud-controller-manager-dashboard.json: |-
+{{- .Files.Get "ccm-monitoring-dashboard.json" | nindent 6 }}
+
   dashboard_users: |
-{{- .Files.Get "ccm-monitoring-dashboard.json" | nindent 4}}
+    cloud-controller-manager-dashboard.json: |-
+{{- .Files.Get "ccm-monitoring-dashboard.json" | nindent 6 }}

--- a/controllers/provider-aws/charts/internal/cloud-controller-manager/templates/configmap-monitoring.yaml
+++ b/controllers/provider-aws/charts/internal/cloud-controller-manager/templates/configmap-monitoring.yaml
@@ -23,7 +23,6 @@ data:
             description: All infrastruture specific operations cannot be completed (e.g. creating loadbalancers or persistent volumes).
             summary: Cloud controller manager is down.
   scrape_config: |
-    scrape_configs:
     - job_name: cloud-controller-manager
       {{- if semverCompare ">= 1.13" .Values.kubernetesVersion  }}
       scheme: https
@@ -53,5 +52,10 @@ data:
         regex: ^(rest_client_requests_total|process_max_fds|process_open_fds)$
         action: keep
 
+  dashboard_operators: |
+    cloud-controller-manager-dashboard.json: |-
+{{- .Files.Get "ccm-monitoring-dashboard.json" | nindent 6 }}
+
   dashboard_users: |
-{{- .Files.Get "ccm-monitoring-dashboard.json" | nindent 4}}
+    cloud-controller-manager-dashboard.json: |-
+ {{- .Files.Get "ccm-monitoring-dashboard.json" | nindent 6 }}

--- a/controllers/provider-aws/charts/internal/machine-controller-manager/seed/templates/configmap-monitoring.yaml
+++ b/controllers/provider-aws/charts/internal/machine-controller-manager/seed/templates/configmap-monitoring.yaml
@@ -7,24 +7,23 @@ metadata:
     extensions.gardener.cloud/configuration: monitoring
 data:
   alerting_rules: |
-  machine-controller-manager.rules.yaml: |
-    groups:
-    - name: machine-controller-manager.rules
-      rules:
-      - alert: MachineControllerManagerDown
-        expr: absent(up{job="machine-controller-manager"} == 1)
-        for: 15m
-        labels:
-          service: machine-controller-manager
-          severity: critical
-          type: seed
-          visibility: operator
-        annotations:
-          description: There are no running machine controller manager instances. No shoot nodes can be created/maintained.
-          summary: Machine controller manager is down.
+    machine-controller-manager.rules.yaml: |
+      groups:
+      - name: machine-controller-manager.rules
+        rules:
+        - alert: MachineControllerManagerDown
+          expr: absent(up{job="machine-controller-manager"} == 1)
+          for: 15m
+          labels:
+            service: machine-controller-manager
+            severity: critical
+            type: seed
+            visibility: operator
+          annotations:
+            description: There are no running machine controller manager instances. No shoot nodes can be created/maintained.
+            summary: Machine controller manager is down.
 
   scrape_config: |
-    scrape_configs:
     - job_name: machine-controller-manager
       honor_labels: false
       kubernetes_sd_configs:
@@ -44,10 +43,9 @@ data:
         target_label: pod
       metric_relabel_configs:
       - source_labels: [ __name__ ]
-    {{/*TODO: this regex is formed by template in Gardener. Should this be configurable in Gardener extensions? */}}
         regex: ^(mcm_cloud_api_requests_failed_total|mcm_cloud_api_requests_total|mcm_machine_controller_frozen|mcm_machine_current_status_phase|mcm_machine_deployment_failed_machines|mcm_machine_items_total|mcm_machine_set_failed_machines|mcm_machinedeployment_items_total|mcm_machineset_items_total|mcm_scrape_failure_total|machine_adds|machine_depth|machine_queue_latency|machine_retries|machine_work_duration|machinedeployment_adds|machinedeployment_depth|machinedeployment_queue_latency|machinedeployment_retries|machinedeployment_work_duration|machinesafetyapiserver_adds|machinesafetyapiserver_depth|machinesafetyapiserver_queue_latency|machinesafetyapiserver_retries|machinesafetyapiserver_work_duration|machinesafetyorphanvms_adds|machinesafetyorphanvms_depth|machinesafetyorphanvms_queue_latency|machinesafetyorphanvms_retries|machinesafetyorphanvms_work_duration|machinesafetyovershooting_adds|machinesafetyovershooting_depth|machinesafetyovershooting_latency|machinesafetyovershooting_retries|machinesafetyovershooting_work_duration|machineset_adds|machineset_depth|machineset_queue_latency|machineset_retries|machineset_work_duration|node_adds|node_depth|node_queue_latency|node_retries|node_work_duration|secret_adds|secret_depth|secret_queue_latency|secret_retries|secret_work_duration|process_max_fds|process_open_fds)$
         action: keep
 
-
   dashboard_operators: |
-{{ .Files.Get "mcm-monitoring-dashboard.json" | indent 4 }}
+    machine-controller-manager-dashboard.json: |-
+{{ .Files.Get "mcm-monitoring-dashboard.json" | indent 6 }}

--- a/controllers/provider-azure/charts/internal/cloud-controller-manager/templates/configmap-monitoring.yaml
+++ b/controllers/provider-azure/charts/internal/cloud-controller-manager/templates/configmap-monitoring.yaml
@@ -7,7 +7,6 @@ metadata:
     extensions.gardener.cloud/configuration: monitoring
 data:
   scrape_config: |
-    scrape_configs:
     - job_name: cloud-controller-manager
       {{- if semverCompare ">= 1.13" .Values.kubernetesVersion  }}
       scheme: https
@@ -54,5 +53,10 @@ data:
             description: All infrastruture specific operations cannot be completed (e.g. creating loadbalancers or persistent volumes).
             summary: Cloud controller manager is down.
 
+  dashboard_operators: |
+    cloud-controller-manager-dashboard.json: |-
+{{- .Files.Get "ccm-monitoring-dashboard.json" | nindent 6 }}
+
   dashboard_users: |
-{{- .Files.Get "ccm-monitoring-dashboard.json" | nindent 4}}
+    cloud-controller-manager-dashboard.json: |-
+{{- .Files.Get "ccm-monitoring-dashboard.json" | nindent 6 }}

--- a/controllers/provider-azure/charts/internal/machine-controller-manager/seed/templates/configmap-monitoring.yaml
+++ b/controllers/provider-azure/charts/internal/machine-controller-manager/seed/templates/configmap-monitoring.yaml
@@ -7,7 +7,6 @@ metadata:
     extensions.gardener.cloud/configuration: monitoring
 data:
   scrape_config: |
-    scrape_configs:
     - job_name: machine-controller-manager
       honor_labels: false
       kubernetes_sd_configs:
@@ -48,4 +47,5 @@ data:
             summary: Machine controller manager is down.
 
   dashboard_operators: |
-{{ .Files.Get "mcm-monitoring-dashboard.json" | indent 4 }}
+    machine-controller-manager-dashboard.json: |-
+{{ .Files.Get "mcm-monitoring-dashboard.json" | indent 6 }}

--- a/controllers/provider-gcp/charts/internal/cloud-controller-manager/templates/configmap-monitoring.yaml
+++ b/controllers/provider-gcp/charts/internal/cloud-controller-manager/templates/configmap-monitoring.yaml
@@ -7,7 +7,6 @@ metadata:
     extensions.gardener.cloud/configuration: monitoring
 data:
   scrape_config: |
-    scrape_configs:
     - job_name: cloud-controller-manager
       {{- if semverCompare ">= 1.13" .Values.kubernetesVersion  }}
       scheme: https
@@ -54,5 +53,10 @@ data:
             description: All infrastruture specific operations cannot be completed (e.g. creating loadbalancers or persistent volumes).
             summary: Cloud controller manager is down.
 
+  dashboard_operators: |
+    cloud-controller-manager-dashboard.json: |-
+{{- .Files.Get "ccm-monitoring-dashboard.json" | nindent 6 }}
+
   dashboard_users: |
-{{- .Files.Get "ccm-monitoring-dashboard.json" | nindent 4}}
+    cloud-controller-manager-dashboard.json: |-
+{{- .Files.Get "ccm-monitoring-dashboard.json" | nindent 6 }}

--- a/controllers/provider-gcp/charts/internal/machine-controller-manager/seed/templates/configmap-monitoring.yaml
+++ b/controllers/provider-gcp/charts/internal/machine-controller-manager/seed/templates/configmap-monitoring.yaml
@@ -8,7 +8,6 @@ metadata:
 data:
 
   scrape_config: |
-    scrape_configs:
     - job_name: machine-controller-manager
       honor_labels: false
       kubernetes_sd_configs:
@@ -49,4 +48,5 @@ data:
             summary: Machine controller manager is down.
 
   dashboard_operators: |
-{{ .Files.Get "mcm-monitoring-dashboard.json" | indent 4 }}
+    machine-controller-manager-dashboard.json: |-
+{{ .Files.Get "mcm-monitoring-dashboard.json" | indent 6 }}

--- a/controllers/provider-openstack/charts/internal/cloud-controller-manager/templates/configmap-monitoring.yaml
+++ b/controllers/provider-openstack/charts/internal/cloud-controller-manager/templates/configmap-monitoring.yaml
@@ -7,7 +7,6 @@ metadata:
     extensions.gardener.cloud/configuration: monitoring
 data:
   scrape_config: |
-    scrape_configs:
     - job_name: cloud-controller-manager
       {{- if semverCompare ">= 1.13" .Values.kubernetesVersion  }}
       scheme: https
@@ -54,5 +53,10 @@ data:
             description: All infrastruture specific operations cannot be completed (e.g. creating loadbalancers or persistent volumes).
             summary: Cloud controller manager is down.
 
+  dashboard_operators: |
+    cloud-controller-manager-dashboard.json: |-
+{{- .Files.Get "ccm-monitoring-dashboard.json" | nindent 6 }}
+
   dashboard_users: |
-{{- .Files.Get "ccm-monitoring-dashboard.json" | nindent 4}}
+    cloud-controller-manager-dashboard.json: |-
+{{- .Files.Get "ccm-monitoring-dashboard.json" | nindent 6 }}

--- a/controllers/provider-openstack/charts/internal/machine-controller-manager/seed/templates/configmap-monitoring.yaml
+++ b/controllers/provider-openstack/charts/internal/machine-controller-manager/seed/templates/configmap-monitoring.yaml
@@ -7,7 +7,6 @@ metadata:
     extensions.gardener.cloud/configuration: monitoring
 data:
   scrape_config: |
-    scrape_configs:
     - job_name: machine-controller-manager
       honor_labels: false
       kubernetes_sd_configs:
@@ -48,4 +47,5 @@ data:
             summary: Machine controller manager is down.
 
   dashboard_operators: |
-{{ .Files.Get "mcm-monitoring-dashboard.json" | indent 4 }}
+    machine-controller-manager-dashboard.json: |-
+{{ .Files.Get "mcm-monitoring-dashboard.json" | indent 6 }}

--- a/controllers/provider-packet/charts/internal/machine-controller-manager/seed/templates/configmap-monitoring.yaml
+++ b/controllers/provider-packet/charts/internal/machine-controller-manager/seed/templates/configmap-monitoring.yaml
@@ -7,7 +7,6 @@ metadata:
     extensions.gardener.cloud/configuration: monitoring
 data:
   scrape_config: |
-    scrape_configs:
     - job_name: machine-controller-manager
       honor_labels: false
       kubernetes_sd_configs:
@@ -48,4 +47,5 @@ data:
             summary: Machine controller manager is down.
 
   dashboard_operators: |
-{{ .Files.Get "mcm-monitoring-dashboard.json" | indent 4 }}
+    machine-controller-manager-dashboard.json: |-
+{{ .Files.Get "mcm-monitoring-dashboard.json" | indent 6 }}

--- a/controllers/provider-packet/charts/internal/seed-controlplane/charts/packet-cloud-controller-manager/templates/configmap-monitoring.yaml
+++ b/controllers/provider-packet/charts/internal/seed-controlplane/charts/packet-cloud-controller-manager/templates/configmap-monitoring.yaml
@@ -7,7 +7,6 @@ metadata:
     extensions.gardener.cloud/configuration: monitoring
 data:
   scrape_config: |
-    scrape_configs:
     - job_name: cloud-controller-manager
       {{- if semverCompare ">= 1.13" .Values.kubernetesVersion  }}
       scheme: https
@@ -54,5 +53,10 @@ data:
             description: All infrastruture specific operations cannot be completed (e.g. creating loadbalancers or persistent volumes).
             summary: Cloud controller manager is down.
 
+  dashboard_operators: |
+    cloud-controller-manager-dashboard.json: |-
+{{- .Files.Get "ccm-monitoring-dashboard.json" | nindent 6 }}
+
   dashboard_users: |
-{{- .Files.Get "ccm-monitoring-dashboard.json" | nindent 4}}
+    cloud-controller-manager-dashboard.json: |-
+{{- .Files.Get "ccm-monitoring-dashboard.json" | nindent 6 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Change monitoring ConfigMaps' syntax of provider-specific components to be easily integrated with Gardener's Prometheus' configurations and Grafana's dashboards.

**Which issue(s) this PR fixes**:
Fixes #https://github.com/gardener/gardener/issues/1351

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Change monitoring ConfigMaps' syntax of provider-specific components
```
