### PR TITLE
Add provider config generation for create shoot tests

### DIFF
--- a/.test-defs/provider-alicloud.yaml
+++ b/.test-defs/provider-alicloud.yaml
@@ -1,0 +1,17 @@
+kind: TestDefinition
+metadata:
+  name: gen-provider-alicloud
+spec:
+  owner: gardener-oq@listserv.sap.com
+  description: Generates the alicloud provider specific configurations
+  activeDeadlineSeconds: 3600
+
+  command: [bash, -c]
+  args:
+  - >-
+    go run -mod=vendor ./controllers/provider-alicloud/test/tm/generator.go
+    --infrastructure-provider-config-filepath=$INFRASTRUCTURE_PROVIDER_CONFIG_FILEPATH
+    --controlplane-provider-config-filepath=$CONTROLPLANE_PROVIDER_CONFIG_FILEPATH
+    --zone=$ZONE
+
+  image: golang:1.13.0

--- a/.test-defs/provider-aws.yaml
+++ b/.test-defs/provider-aws.yaml
@@ -1,0 +1,17 @@
+kind: TestDefinition
+metadata:
+  name: gen-provider-aws
+spec:
+  owner: gardener-oq@listserv.sap.com
+  description: Generates the aws provider specific configurations
+  activeDeadlineSeconds: 3600
+
+  command: [bash, -c]
+  args:
+  - >-
+    go run -mod=vendor ./controllers/provider-aws/test/tm/generator.go
+    --infrastructure-provider-config-filepath=$INFRASTRUCTURE_PROVIDER_CONFIG_FILEPATH
+    --controlplane-provider-config-filepath=$CONTROLPLANE_PROVIDER_CONFIG_FILEPATH
+    --zone=$ZONE
+
+  image: golang:1.13.0

--- a/.test-defs/provider-azure.yaml
+++ b/.test-defs/provider-azure.yaml
@@ -1,0 +1,16 @@
+kind: TestDefinition
+metadata:
+  name: gen-provider-azure
+spec:
+  owner: gardener-oq@listserv.sap.com
+  description: Generates the azure provider specific configurations
+  activeDeadlineSeconds: 3600
+
+  command: [bash, -c]
+  args:
+  - >-
+    go run -mod=vendor ./controllers/provider-azure/test/tm/generator.go
+    --infrastructure-provider-config-filepath=$INFRASTRUCTURE_PROVIDER_CONFIG_FILEPATH
+    --controlplane-provider-config-filepath=$CONTROLPLANE_PROVIDER_CONFIG_FILEPATH
+
+  image: golang:1.13.0

--- a/.test-defs/provider-gcp.yaml
+++ b/.test-defs/provider-gcp.yaml
@@ -1,0 +1,17 @@
+kind: TestDefinition
+metadata:
+  name: gen-provider-gcp
+spec:
+  owner: gardener-oq@listserv.sap.com
+  description: Generates the gcp provider specific configurations
+  activeDeadlineSeconds: 3600
+
+  command: [bash, -c]
+  args:
+  - >-
+    go run -mod=vendor ./controllers/provider-gcp/test/tm/generator.go
+    --infrastructure-provider-config-filepath=$INFRASTRUCTURE_PROVIDER_CONFIG_FILEPATH
+    --controlplane-provider-config-filepath=$CONTROLPLANE_PROVIDER_CONFIG_FILEPATH
+    --zone=$ZONE
+
+  image: golang:1.13.0

--- a/.test-defs/provider-openstack.yaml
+++ b/.test-defs/provider-openstack.yaml
@@ -1,0 +1,19 @@
+kind: TestDefinition
+metadata:
+  name: gen-provider-openstack
+spec:
+  owner: gardener-oq@listserv.sap.com
+  description: Generates the openstack provider specific configurations
+  activeDeadlineSeconds: 3600
+
+  command: [bash, -c]
+  args:
+  - >-
+    go run -mod=vendor ./controllers/provider-openstack/test/tm/generator.go
+    --infrastructure-provider-config-filepath=$INFRASTRUCTURE_PROVIDER_CONFIG_FILEPATH
+    --controlplane-provider-config-filepath=$CONTROLPLANE_PROVIDER_CONFIG_FILEPATH
+    --floating-pool-name=$FLOATING_POOL_NAME
+    --loadbalancer-provider=$LOADBALANCER_PROVIDER
+    --zone=$ZONE
+
+  image: golang:1.13.0

--- a/controllers/provider-alicloud/test/tm/generator.go
+++ b/controllers/provider-alicloud/test/tm/generator.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package contains the generators for provider specific shoot configuration
+package main
+
+import (
+	"flag"
+	"github.com/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+	"reflect"
+
+	"github.com/gardener/gardener-extensions/controllers/provider-alicloud/pkg/apis/alicloud/v1alpha1"
+	"github.com/gardener/gardener-extensions/test/tm/generator"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var (
+	infrastructureProviderConfigPath = flag.String("infrastructure-provider-config-filepath", "", "filepath to the provider specific infrastructure config")
+	controlplaneProviderConfigPath   = flag.String("controlplane-provider-config-filepath", "", "filepath to the provider specific controlplane config")
+
+	networkVPCCidr    = flag.String("network-vpc-cidr", "10.250.0.0/16", "vpc network cidr")
+	networkWorkerCidr = flag.String("network-worker-cidr", "10.250.0.0/19", "worker network cidr")
+
+	zone = flag.String("zone", "", "cloudprovider zone fo the shoot")
+)
+
+func main() {
+	log.SetLogger(zap.Logger(false))
+	logger := log.Log.WithName("alicloud-generator")
+	flag.Parse()
+	if err := validate(); err != nil {
+		logger.Error(err, "error validating input flags")
+		os.Exit(1)
+	}
+
+	infra := v1alpha1.InfrastructureConfig{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+			Kind:       reflect.TypeOf(v1alpha1.InfrastructureConfig{}).Name(),
+		},
+		Networks: v1alpha1.Networks{
+			VPC: v1alpha1.VPC{
+				CIDR: networkVPCCidr,
+			},
+			Zones: []v1alpha1.Zone{
+				{
+					Name:   *zone,
+					Worker: *networkWorkerCidr,
+				},
+			},
+		},
+	}
+
+	cp := v1alpha1.ControlPlaneConfig{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+			Kind:       reflect.TypeOf(v1alpha1.ControlPlaneConfig{}).Name(),
+		},
+		Zone: *zone,
+	}
+
+	if err := generator.MarshalAndWriteConfig(*infrastructureProviderConfigPath, infra); err != nil {
+		logger.Error(err, "unable to write infrastructure config")
+		os.Exit(1)
+	}
+	if err := generator.MarshalAndWriteConfig(*controlplaneProviderConfigPath, cp); err != nil {
+		logger.Error(err, "unable to write infrastructure config")
+		os.Exit(1)
+	}
+	logger.Info("successfully written alicloud provider configuration", "infra", *infrastructureProviderConfigPath, "controlplane", *controlplaneProviderConfigPath)
+}
+
+func validate() error {
+	if err := generator.ValidateString(infrastructureProviderConfigPath); err != nil {
+		return errors.Wrap(err, "error validating infrastructure provider config path")
+	}
+	if err := generator.ValidateString(controlplaneProviderConfigPath); err != nil {
+		return errors.Wrap(err, "error validating controlplane provider config path")
+	}
+	if err := generator.ValidateString(networkVPCCidr); err != nil {
+		return errors.Wrap(err, "error validating VPC CIDR")
+	}
+	if err := generator.ValidateString(networkWorkerCidr); err != nil {
+		return errors.Wrap(err, "error validating worker CIDR")
+	}
+	if err := generator.ValidateString(zone); err != nil {
+		return errors.Wrap(err, "error validating zone")
+	}
+	return nil
+}

--- a/controllers/provider-aws/test/tm/generator.go
+++ b/controllers/provider-aws/test/tm/generator.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package contains the generators for provider specific shoot configuration
+package main
+
+import (
+	"flag"
+	"github.com/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+	"reflect"
+
+	"github.com/gardener/gardener-extensions/controllers/provider-aws/pkg/apis/aws/v1alpha1"
+	"github.com/gardener/gardener-extensions/test/tm/generator"
+	log "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var (
+	infrastructureProviderConfigPath = flag.String("infrastructure-provider-config-filepath", "", "filepath to the provider specific infrastructure config")
+	controlplaneProviderConfigPath   = flag.String("controlplane-provider-config-filepath", "", "filepath to the provider specific controlplane config")
+
+	networkVPCCidr      = flag.String("network-vpc-cidr", "10.250.0.0/16", "vpc network cidr")
+	networkInternalCidr = flag.String("network-internal-cidr", "10.250.112.0/22", "internal network cidr")
+	networkPublicCidr   = flag.String("network-public-cidr", "10.250.96.0/22", "public network cidr")
+	networkWorkerCidr   = flag.String("network-worker-cidr", "10.250.0.0/19", "worker network cidr")
+
+	zone = flag.String("zone", "", "cloudprovider zone fo the shoot")
+)
+
+func main() {
+	log.SetLogger(zap.Logger(false))
+	logger := log.Log.WithName("gcp-generator")
+	flag.Parse()
+	if err := validate(); err != nil {
+		logger.Error(err, "error validating input flags")
+		os.Exit(1)
+	}
+
+	infra := v1alpha1.InfrastructureConfig{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+			Kind:       reflect.TypeOf(v1alpha1.InfrastructureConfig{}).Name(),
+		},
+		Networks: v1alpha1.Networks{
+			VPC: v1alpha1.VPC{
+				CIDR: networkVPCCidr,
+			},
+			Zones: []v1alpha1.Zone{
+				{
+					Name:     *zone,
+					Internal: *networkInternalCidr,
+					Public:   *networkPublicCidr,
+					Workers:  *networkWorkerCidr,
+				},
+			},
+		},
+	}
+
+	cp := v1alpha1.ControlPlaneConfig{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+			Kind:       reflect.TypeOf(v1alpha1.ControlPlaneConfig{}).Name(),
+		},
+	}
+
+	if err := generator.MarshalAndWriteConfig(*infrastructureProviderConfigPath, infra); err != nil {
+		logger.Error(err, "unable to write infrastructure config")
+		os.Exit(1)
+	}
+	if err := generator.MarshalAndWriteConfig(*controlplaneProviderConfigPath, cp); err != nil {
+		logger.Error(err, "unable to write infrastructure config")
+		os.Exit(1)
+	}
+	logger.Info("successfully written aws provider configuration", "infra", *infrastructureProviderConfigPath, "controlplane", *controlplaneProviderConfigPath)
+}
+
+func validate() error {
+	if err := generator.ValidateString(infrastructureProviderConfigPath); err != nil {
+		return errors.Wrap(err, "error validating infrastructure provider config path")
+	}
+	if err := generator.ValidateString(controlplaneProviderConfigPath); err != nil {
+		return errors.Wrap(err, "error validating controlplane provider config path")
+	}
+	if err := generator.ValidateString(networkVPCCidr); err != nil {
+		return errors.Wrap(err, "error validating vpc CIDR")
+	}
+	if err := generator.ValidateString(networkPublicCidr); err != nil {
+		return errors.Wrap(err, "error validating public CIDR")
+	}
+	if err := generator.ValidateString(networkInternalCidr); err != nil {
+		return errors.Wrap(err, "error validating internal CIDR")
+	}
+	if err := generator.ValidateString(networkWorkerCidr); err != nil {
+		return errors.Wrap(err, "error validating worker CIDR")
+	}
+	if err := generator.ValidateString(zone); err != nil {
+		return errors.Wrap(err, "error validating zone")
+	}
+	return nil
+}

--- a/controllers/provider-azure/test/tm/generator.go
+++ b/controllers/provider-azure/test/tm/generator.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package contains the generators for provider specific shoot configuration
+package main
+
+import (
+	"flag"
+	"github.com/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+	"reflect"
+
+	"github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/apis/azure/v1alpha1"
+	"github.com/gardener/gardener-extensions/test/tm/generator"
+	log "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var (
+	infrastructureProviderConfigPath = flag.String("infrastructure-provider-config-filepath", "", "filepath to the provider specific infrastructure config")
+	controlplaneProviderConfigPath   = flag.String("controlplane-provider-config-filepath", "", "filepath to the provider specific controlplane config")
+
+	networkVnetCidr   = flag.String("network-vnet-cidr", "10.250.0.0/16", "vnet network cidr")
+	networkWorkerCidr = flag.String("network-worker-cidr", "10.250.0.0/19", "worker network cidr")
+
+	zoned = flag.Bool("zoned", false, "shoot uses multiple zones")
+)
+
+func main() {
+	log.SetLogger(zap.Logger(false))
+	logger := log.Log.WithName("azure-generator")
+	flag.Parse()
+	if err := validate(); err != nil {
+		logger.Error(err, "error validating input flags")
+		os.Exit(1)
+	}
+
+	infra := v1alpha1.InfrastructureConfig{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+			Kind:       reflect.TypeOf(v1alpha1.InfrastructureConfig{}).Name(),
+		},
+		Networks: v1alpha1.NetworkConfig{
+			VNet: v1alpha1.VNet{
+				CIDR: networkVnetCidr,
+			},
+			Workers: *networkWorkerCidr,
+		},
+		Zoned: *zoned,
+	}
+
+	cp := v1alpha1.ControlPlaneConfig{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+			Kind:       reflect.TypeOf(v1alpha1.ControlPlaneConfig{}).Name(),
+		},
+	}
+
+	if err := generator.MarshalAndWriteConfig(*infrastructureProviderConfigPath, infra); err != nil {
+		logger.Error(err, "unable to write infrastructure config")
+		os.Exit(1)
+	}
+	if err := generator.MarshalAndWriteConfig(*controlplaneProviderConfigPath, cp); err != nil {
+		logger.Error(err, "unable to write infrastructure config")
+		os.Exit(1)
+	}
+	logger.Info("successfully written azure provider configuration", "infra", *infrastructureProviderConfigPath, "controlplane", *controlplaneProviderConfigPath)
+}
+
+func validate() error {
+	if err := generator.ValidateString(infrastructureProviderConfigPath); err != nil {
+		return errors.Wrap(err, "error validating infrastructure provider config path")
+	}
+	if err := generator.ValidateString(controlplaneProviderConfigPath); err != nil {
+		return errors.Wrap(err, "error validating controlplane provider config path")
+	}
+	if err := generator.ValidateString(networkVnetCidr); err != nil {
+		return errors.Wrap(err, "error validating vnet CIDR")
+	}
+	if err := generator.ValidateString(networkWorkerCidr); err != nil {
+		return errors.Wrap(err, "error validating worker CIDR")
+	}
+	return nil
+}

--- a/controllers/provider-gcp/test/tm/generator.go
+++ b/controllers/provider-gcp/test/tm/generator.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package contains the generators for provider specific shoot configuration
+package main
+
+import (
+	"flag"
+	"github.com/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+	"reflect"
+
+	"github.com/gardener/gardener-extensions/controllers/provider-gcp/pkg/apis/gcp/v1alpha1"
+	"github.com/gardener/gardener-extensions/test/tm/generator"
+	log "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var (
+	infrastructureProviderConfigPath = flag.String("infrastructure-provider-config-filepath", "", "filepath to the provider specific infrastructure config")
+	controlplaneProviderConfigPath   = flag.String("controlplane-provider-config-filepath", "", "filepath to the provider specific controlplane config")
+
+	networkWorkerCidr = flag.String("network-worker-cidr", "10.250.0.0/19", "worker network cidr")
+
+	zone = flag.String("zone", "", "cloudprovider zone fo the shoot")
+)
+
+func main() {
+	log.SetLogger(zap.Logger(false))
+	logger := log.Log.WithName("gcp-generator")
+	flag.Parse()
+	if err := validate(); err != nil {
+		logger.Error(err, "error validating input flags")
+		os.Exit(1)
+	}
+
+	infra := v1alpha1.InfrastructureConfig{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+			Kind:       reflect.TypeOf(v1alpha1.InfrastructureConfig{}).Name(),
+		},
+		Networks: v1alpha1.NetworkConfig{
+			Worker: *networkWorkerCidr,
+		},
+	}
+
+	cp := v1alpha1.ControlPlaneConfig{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+			Kind:       reflect.TypeOf(v1alpha1.ControlPlaneConfig{}).Name(),
+		},
+		Zone: *zone,
+	}
+
+	if err := generator.MarshalAndWriteConfig(*infrastructureProviderConfigPath, infra); err != nil {
+		logger.Error(err, "unable to write infrastructure config")
+		os.Exit(1)
+	}
+	if err := generator.MarshalAndWriteConfig(*controlplaneProviderConfigPath, cp); err != nil {
+		logger.Error(err, "unable to write infrastructure config")
+		os.Exit(1)
+	}
+	logger.Info("successfully written gcp provider configuration", "infra", *infrastructureProviderConfigPath, "controlplane", *controlplaneProviderConfigPath)
+}
+
+func validate() error {
+	if err := generator.ValidateString(infrastructureProviderConfigPath); err != nil {
+		return errors.Wrap(err, "error validating infrastructure provider config path")
+	}
+	if err := generator.ValidateString(controlplaneProviderConfigPath); err != nil {
+		return errors.Wrap(err, "error validating controlplane provider config path")
+	}
+	if err := generator.ValidateString(networkWorkerCidr); err != nil {
+		return errors.Wrap(err, "error validating worker CIDR")
+	}
+	if err := generator.ValidateString(zone); err != nil {
+		return errors.Wrap(err, "error validating zone")
+	}
+	return nil
+}

--- a/controllers/provider-openstack/test/tm/generator.go
+++ b/controllers/provider-openstack/test/tm/generator.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package contains the generators for provider specific shoot configuration
+package main
+
+import (
+	"flag"
+	"github.com/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+	"reflect"
+
+	"github.com/gardener/gardener-extensions/controllers/provider-openstack/pkg/apis/openstack/v1alpha1"
+	"github.com/gardener/gardener-extensions/test/tm/generator"
+	log "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var (
+	infrastructureProviderConfigPath = flag.String("infrastructure-provider-config-filepath", "", "filepath to the provider specific infrastructure config")
+	controlplaneProviderConfigPath   = flag.String("controlplane-provider-config-filepath", "", "filepath to the provider specific controlplane config")
+
+	floatingPoolName  = flag.String("floating-pool-name", "", "set the name of the floating pool")
+	networkWorkerCidr = flag.String("network-worker-cidr", "10.250.0.0/19", "worker network cidr")
+
+	loadBalancerProvider = flag.String("loadbalancer-provider", "", "loadbalancer provider for the shoot's loadbalancers")
+	zone                 = flag.String("zone", "", "cloudprovider zone fo the shoot")
+)
+
+func main() {
+	log.SetLogger(zap.Logger(false))
+	logger := log.Log.WithName("openstack-generator")
+	flag.Parse()
+	if err := validate(); err != nil {
+		logger.Error(err, "error validating input flags")
+		os.Exit(1)
+	}
+
+	infra := v1alpha1.InfrastructureConfig{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+			Kind:       reflect.TypeOf(v1alpha1.InfrastructureConfig{}).Name(),
+		},
+		FloatingPoolName: *floatingPoolName,
+		Networks: v1alpha1.Networks{
+			Worker: *networkWorkerCidr,
+		},
+	}
+
+	cp := v1alpha1.ControlPlaneConfig{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+			Kind:       reflect.TypeOf(v1alpha1.ControlPlaneConfig{}).Name(),
+		},
+		LoadBalancerProvider: *loadBalancerProvider,
+		Zone:                 *zone,
+	}
+
+	if err := generator.MarshalAndWriteConfig(*infrastructureProviderConfigPath, infra); err != nil {
+		logger.Error(err, "unable to write infrastructure config")
+		os.Exit(1)
+	}
+	if err := generator.MarshalAndWriteConfig(*controlplaneProviderConfigPath, cp); err != nil {
+		logger.Error(err, "unable to write infrastructure config")
+		os.Exit(1)
+	}
+	logger.Info("successfully written openstack provider configuration", "infra", *infrastructureProviderConfigPath, "controlplane", *controlplaneProviderConfigPath)
+}
+
+func validate() error {
+	if err := generator.ValidateString(infrastructureProviderConfigPath); err != nil {
+		return errors.Wrap(err, "error validating infrastructure provider config path")
+	}
+	if err := generator.ValidateString(controlplaneProviderConfigPath); err != nil {
+		return errors.Wrap(err, "error validating controlplane provider config path")
+	}
+	if err := generator.ValidateString(networkWorkerCidr); err != nil {
+		return errors.Wrap(err, "error validating worker CIDR")
+	}
+	if err := generator.ValidateString(floatingPoolName); err != nil {
+		return errors.Wrap(err, "error floating pool name")
+	}
+	if err := generator.ValidateString(loadBalancerProvider); err != nil {
+		return errors.Wrap(err, "error loadbalancer provider")
+	}
+	if err := generator.ValidateString(zone); err != nil {
+		return errors.Wrap(err, "error validating zone")
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	k8s.io/kube-aggregator v0.0.0-20190314000639-da8327669ac5
 	k8s.io/kubelet v0.0.0-20190314002251-f6da02f58325
 	sigs.k8s.io/controller-runtime v0.2.0-beta.4
+	sigs.k8s.io/yaml v1.1.0
 )
 
 replace (

--- a/test/tm/generator/helper.go
+++ b/test/tm/generator/helper.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package tm contains the generators for provider specific configuration
+
+package generator
+
+import (
+	"github.com/pkg/errors"
+	"io/ioutil"
+	"os"
+	"path"
+	"sigs.k8s.io/yaml"
+)
+
+// MarshalAndWriteConfig marshals the provided config and write is as a file to the provided path
+func MarshalAndWriteConfig(filepath string, config interface{}) error {
+	raw, err := yaml.Marshal(config)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse config")
+	}
+
+	if err := os.MkdirAll(path.Dir(filepath), os.ModePerm); err != nil {
+		return errors.Wrapf(err, "unable to create path %s", path.Dir(filepath))
+	}
+	if err := ioutil.WriteFile(filepath, raw, os.ModePerm); err != nil {
+		return errors.Wrapf(err, "unable to write config to %s", filepath)
+	}
+
+	return nil
+}
+
+// ValidateString validates if a string is defined
+func ValidateString(s *string) error {
+	if s == nil || *s == "" {
+		return errors.New("empty string")
+	}
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the generation of provider specific configuration that is then written as yaml to a specified path.
These configurations are intended to be used by `create shoot` in https://github.com/gardener/gardener/pull/1474 .

For now only the necessary provider specific configuration is implemented to get the same functionality as before the extension story.
Therefore, not all configuration is exposed (like CIDR's) and OS and network configurations are implemented as we need special configuration for tests.

**Special notes for your reviewer**:
Currently the kind of a configuration is received with `reflect.TypeOf(v1alpha1.InfrastructureConfig{}).Name()` as it is implemented by the apimachinery runtime in `AddKnownTypes`.
Is there are better of receiving this name dynamically or should I set the kind hardcoded

cc @danielfoehrKn 
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
