### PR TITLE
Added support for OpenStack CCM 1.16

### DIFF
--- a/controllers/provider-openstack/charts/images.yaml
+++ b/controllers/provider-openstack/charts/images.yaml
@@ -14,7 +14,7 @@ images:
 - name: openstack-cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager
-  tag: "v1.15.0"
+  tag: "v1.16.0"
   targetVersion: ">= 1.15"
 - name: openstack-cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack


### PR DESCRIPTION
**What this PR does / why we need it**:
Added support for the 1.16 version of CCM for OpenStack. The 1.16 CCM version should be also used for the 1.15 clusters as it fixes a few LoadBalancer related issues (https://github.com/kubernetes/cloud-provider-openstack/pull/742) and introduces additional authentication fields (https://github.com/kubernetes/cloud-provider-openstack/pull/735 & https://github.com/kubernetes/cloud-provider-openstack/pull/733).

**Which issue(s) this PR fixes**:
Part of #154

**Release note**:
```improvement operator
Added support for the 1.16 version CCM for OpenStack
```
