### PR TITLE
Use shootUID for randomization of backup schedule

### DIFF
--- a/controllers/provider-alicloud/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-alicloud/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -189,7 +189,6 @@ var _ = Describe("Ensurer", func() {
 
 			// Create mock client
 			client := mockclient.NewMockClient(ctrl)
-			//client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
 
 			// Create ensurer
 			ensurer := NewEnsurer(etcdBackup, imageVector, logger)
@@ -201,8 +200,17 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 			oldSS := ss.DeepCopy()
 
-			// Re-ensure
+			// Re-ensure on existing statefulset
 			err = ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(ss).Should(Equal(oldSS))
+
+			// Re-ensure on new statefulset request
+			newSS := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1alpha1constants.StatefulSetNameETCDEvents},
+			}
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), newSS, cluster)
 
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(ss).Should(Equal(oldSS))
@@ -249,6 +257,42 @@ var _ = Describe("Ensurer", func() {
 			err := ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
 			Expect(err).To(Not(HaveOccurred()))
 			checkETCDEventsStatefulSet(ss)
+		})
+
+		It("should not modify elements to same etcd-events statefulset", func() {
+			var (
+				ss = &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1alpha1constants.StatefulSetNameETCDEvents},
+				}
+			)
+
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+
+			// Create ensurer
+			ensurer := NewEnsurer(etcdBackup, imageVector, logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Call EnsureETCDStatefulSet method and check the result
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+			Expect(err).To(Not(HaveOccurred()))
+			oldSS := ss.DeepCopy()
+
+			// Re-ensure on existing statefulset
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(ss).Should(Equal(oldSS))
+
+			// Re-ensure on new statefulset request
+			newSS := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1alpha1constants.StatefulSetNameETCDEvents},
+			}
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), newSS, cluster)
+
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(ss).Should(Equal(oldSS))
 		})
 	})
 })

--- a/controllers/provider-aws/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-aws/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -189,7 +189,6 @@ var _ = Describe("Ensurer", func() {
 
 			// Create mock client
 			client := mockclient.NewMockClient(ctrl)
-			//client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
 
 			// Create ensurer
 			ensurer := NewEnsurer(etcdBackup, imageVector, logger)
@@ -201,8 +200,17 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 			oldSS := ss.DeepCopy()
 
-			// Re-ensure
+			// Re-ensure on existing statefulset
 			err = ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(ss).Should(Equal(oldSS))
+
+			// Re-ensure on new statefulset request
+			newSS := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1alpha1constants.StatefulSetNameETCDEvents},
+			}
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), newSS, cluster)
 
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(ss).Should(Equal(oldSS))
@@ -249,6 +257,42 @@ var _ = Describe("Ensurer", func() {
 			err := ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
 			Expect(err).To(Not(HaveOccurred()))
 			checkETCDEventsStatefulSet(ss)
+		})
+
+		It("should not modify elements to same etcd-events statefulset", func() {
+			var (
+				ss = &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1alpha1constants.StatefulSetNameETCDEvents},
+				}
+			)
+
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+
+			// Create ensurer
+			ensurer := NewEnsurer(etcdBackup, imageVector, logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Call EnsureETCDStatefulSet method and check the result
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+			Expect(err).To(Not(HaveOccurred()))
+			oldSS := ss.DeepCopy()
+
+			// Re-ensure on existing statefulset
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(ss).Should(Equal(oldSS))
+
+			// Re-ensure on new statefulset request
+			newSS := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1alpha1constants.StatefulSetNameETCDEvents},
+			}
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), newSS, cluster)
+
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(ss).Should(Equal(oldSS))
 		})
 	})
 })

--- a/controllers/provider-azure/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-azure/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -189,7 +189,6 @@ var _ = Describe("Ensurer", func() {
 
 			// Create mock client
 			client := mockclient.NewMockClient(ctrl)
-			//client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
 
 			// Create ensurer
 			ensurer := NewEnsurer(etcdBackup, imageVector, logger)
@@ -201,8 +200,17 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 			oldSS := ss.DeepCopy()
 
-			// Re-ensure
+			// Re-ensure on existing statefulset
 			err = ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(ss).Should(Equal(oldSS))
+
+			// Re-ensure on new statefulset request
+			newSS := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1alpha1constants.StatefulSetNameETCDEvents},
+			}
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), newSS, cluster)
 
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(ss).Should(Equal(oldSS))
@@ -249,6 +257,42 @@ var _ = Describe("Ensurer", func() {
 			err := ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
 			Expect(err).To(Not(HaveOccurred()))
 			checkETCDEventsStatefulSet(ss)
+		})
+
+		It("should not modify elements to same etcd-events statefulset", func() {
+			var (
+				ss = &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1alpha1constants.StatefulSetNameETCDEvents},
+				}
+			)
+
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+
+			// Create ensurer
+			ensurer := NewEnsurer(etcdBackup, imageVector, logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Call EnsureETCDStatefulSet method and check the result
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+			Expect(err).To(Not(HaveOccurred()))
+			oldSS := ss.DeepCopy()
+
+			// Re-ensure on existing statefulset
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(ss).Should(Equal(oldSS))
+
+			// Re-ensure on new statefulset request
+			newSS := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1alpha1constants.StatefulSetNameETCDEvents},
+			}
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), newSS, cluster)
+
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(ss).Should(Equal(oldSS))
 		})
 	})
 })

--- a/controllers/provider-openstack/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-openstack/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -189,7 +189,6 @@ var _ = Describe("Ensurer", func() {
 
 			// Create mock client
 			client := mockclient.NewMockClient(ctrl)
-			//client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
 
 			// Create ensurer
 			ensurer := NewEnsurer(etcdBackup, imageVector, logger)
@@ -201,8 +200,17 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 			oldSS := ss.DeepCopy()
 
-			// Re-ensure
+			// Re-ensure on existing statefulset
 			err = ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(ss).Should(Equal(oldSS))
+
+			// Re-ensure on new statefulset request
+			newSS := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1alpha1constants.StatefulSetNameETCDEvents},
+			}
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), newSS, cluster)
 
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(ss).Should(Equal(oldSS))
@@ -249,6 +257,42 @@ var _ = Describe("Ensurer", func() {
 			err := ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
 			Expect(err).To(Not(HaveOccurred()))
 			checkETCDEventsStatefulSet(ss)
+		})
+
+		It("should not modify elements to same etcd-events statefulset", func() {
+			var (
+				ss = &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1alpha1constants.StatefulSetNameETCDEvents},
+				}
+			)
+
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+
+			// Create ensurer
+			ensurer := NewEnsurer(etcdBackup, imageVector, logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Call EnsureETCDStatefulSet method and check the result
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+			Expect(err).To(Not(HaveOccurred()))
+			oldSS := ss.DeepCopy()
+
+			// Re-ensure on existing statefulset
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(ss).Should(Equal(oldSS))
+
+			// Re-ensure on new statefulset request
+			newSS := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1alpha1constants.StatefulSetNameETCDEvents},
+			}
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), newSS, cluster)
+
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(ss).Should(Equal(oldSS))
 		})
 	})
 })

--- a/controllers/provider-packet/pkg/webhook/controlplanebackup/ensurer_test.go
+++ b/controllers/provider-packet/pkg/webhook/controlplanebackup/ensurer_test.go
@@ -134,8 +134,18 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 			oldSS := ss.DeepCopy()
 
-			// Re-ensure
+			// Re-ensure on existing statefulset
 			err = ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(ss).Should(Equal(oldSS))
+
+			// Re-ensure on new statefulset request
+			newSS := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1alpha1constants.StatefulSetNameETCDEvents},
+			}
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), newSS, cluster)
+
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(ss).Should(Equal(oldSS))
 		})
@@ -181,6 +191,37 @@ var _ = Describe("Ensurer", func() {
 			err := ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
 			Expect(err).To(Not(HaveOccurred()))
 			checkETCDEventsStatefulSet(ss)
+		})
+
+		It("should not modify elements to same etcd-events statefulset", func() {
+			var (
+				ss = &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1alpha1constants.StatefulSetNameETCDEvents},
+				}
+			)
+
+			// Create ensurer
+			ensurer := NewEnsurer(imageVector, logger)
+
+			// Call EnsureETCDStatefulSet method and check the result
+			err := ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+			Expect(err).To(Not(HaveOccurred()))
+			oldSS := ss.DeepCopy()
+
+			// Re-ensure on existing statefulset
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), ss, cluster)
+
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(ss).Should(Equal(oldSS))
+
+			// Re-ensure on new statefulset request
+			newSS := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1alpha1constants.StatefulSetNameETCDEvents},
+			}
+			err = ensurer.EnsureETCDStatefulSet(context.TODO(), newSS, cluster)
+
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(ss).Should(Equal(oldSS))
 		})
 	})
 })


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:
This PR fixes https://github.com/gardener/gardener-extensions/pull/337#issuecomment-537857510. And use shootUID for randomiaztion of schedule
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
