### PR TITLE
Switch on the bandwidth plugin for CNI config

### DIFF
--- a/controllers/networking-calico/charts/internal/calico/templates/config.yaml
+++ b/controllers/networking-calico/charts/internal/calico/templates/config.yaml
@@ -47,6 +47,10 @@ data:
           "type": "portmap",
           "snat": true,
           "capabilities": {"portMappings": true}
+        },
+        {
+          "type": "bandwidth",
+          "capabilities": {"bandwidth": true}
         }
       ]
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable bandwidth plugin on for CNI config**Which issue(s) this PR fixes**:

Fixes #358 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
It is now possible to shape pod traffic by using the  `kubernetes.io/ingress-bandwidth` and `kubernetes.io/egress-bandwidth` annotations. This is possible only for Calico versions >= 3.8. For lower versions of calico the annotations will have a no-op. 
```
