### PR TITLE
Fix: Azure lb issue in combination with avSet

### DIFF
--- a/controllers/provider-azure/charts/internal/cloud-provider-config/templates/cloud-provider-config.tpl
+++ b/controllers/provider-azure/charts/internal/cloud-provider-config/templates/cloud-provider-config.tpl
@@ -4,11 +4,13 @@ location: "{{ .Values.region }}"
 resourceGroup: "{{ .Values.resourceGroup }}"
 routeTableName: "{{ .Values.routeTableName }}"
 securityGroupName: "{{ .Values.securityGroupName }}"
-loadBalancerSku: "{{ .Values.loadBalancerSku }}"
 subnetName: "{{ .Values.subnetName }}"
 vnetName: "{{ .Values.vnetName }}"
 {{- if hasKey .Values "availabilitySetName" }}
 primaryAvailabilitySetName: "{{ .Values.availabilitySetName }}"
+loadBalancerSku: "basic"
+{{- else }}
+loadBalancerSku: "standard"
 {{- end }}
 cloudProviderBackoff: true
 cloudProviderBackoffRetries: 6

--- a/controllers/provider-azure/charts/internal/cloud-provider-config/values.yaml
+++ b/controllers/provider-azure/charts/internal/cloud-provider-config/values.yaml
@@ -8,5 +8,4 @@ vnetName: name
 subnetName: sname
 routeTableName: rtname
 securityGroupName: sgname
-loadBalancerSku: standard
 region: location

--- a/controllers/provider-azure/pkg/controller/controlplane/valuesprovider_test.go
+++ b/controllers/provider-azure/pkg/controller/controlplane/valuesprovider_test.go
@@ -429,16 +429,6 @@ var _ = Describe("ValuesProvider", func() {
 				"tenantID":       []byte(`TenantID`),
 			},
 		}
-		cloudProviderConfigKey = client.ObjectKey{Namespace: namespace, Name: cloudProviderConfigMapName}
-		cloudProviderConfigMap = &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      cloudProviderConfigMapName,
-				Namespace: namespace,
-			},
-			Data: map[string]string{
-				cloudProviderConfigMapKey: "loadBalancerSku: \"standard\"",
-			},
-		}
 
 		checksums = map[string]string{
 			v1alpha1constants.SecretNameCloudProvider: "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
@@ -455,7 +445,6 @@ var _ = Describe("ValuesProvider", func() {
 			"resourceGroup":       "rg-abcd1234",
 			"vnetName":            "vnet-abcd1234",
 			"subnetName":          "subnet-abcd1234-nodes",
-			"loadBalancerSku":     "standard",
 			"region":              "eu-west-1a",
 			"availabilitySetName": "availability-set-name",
 			"routeTableName":      "route-table-name",
@@ -471,7 +460,6 @@ var _ = Describe("ValuesProvider", func() {
 			"resourceGroup":     "rg-abcd1234",
 			"vnetName":          "vnet-abcd1234",
 			"subnetName":        "subnet-abcd1234-nodes",
-			"loadBalancerSku":   "standard",
 			"region":            "eu-west-1a",
 			"routeTableName":    "route-table-name",
 			"securityGroupName": "security-group-name-workers",
@@ -509,7 +497,6 @@ var _ = Describe("ValuesProvider", func() {
 		It("should return correct config chart values for non zoned cluster", func() {
 			// Create mock client
 			client := mockclient.NewMockClient(ctrl)
-			client.EXPECT().Get(context.TODO(), cloudProviderConfigKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cloudProviderConfigMap))
 			client.EXPECT().Get(context.TODO(), cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
 
 			// Create valuesProvider
@@ -530,7 +517,6 @@ var _ = Describe("ValuesProvider", func() {
 	It("should return correct config chart values for zoned cluster", func() {
 		// Create mock client
 		client := mockclient.NewMockClient(ctrl)
-		client.EXPECT().Get(context.TODO(), cloudProviderConfigKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cloudProviderConfigMap))
 		client.EXPECT().Get(context.TODO(), cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
 
 		// Create valuesProvider
@@ -551,7 +537,6 @@ var _ = Describe("ValuesProvider", func() {
 		It("should return error, missing subnet", func() {
 			// Create mock client
 			client := mockclient.NewMockClient(ctrl)
-			client.EXPECT().Get(context.TODO(), cloudProviderConfigKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cloudProviderConfigMap))
 			client.EXPECT().Get(context.TODO(), cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
 
 			// Create valuesProvider
@@ -572,7 +557,6 @@ var _ = Describe("ValuesProvider", func() {
 		It("should return error, missing availability set", func() {
 			// Create mock client
 			client := mockclient.NewMockClient(ctrl)
-			client.EXPECT().Get(context.TODO(), cloudProviderConfigKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cloudProviderConfigMap))
 			client.EXPECT().Get(context.TODO(), cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
 
 			// Create valuesProvider
@@ -593,7 +577,6 @@ var _ = Describe("ValuesProvider", func() {
 		It("should return error, missing route tables", func() {
 			// Create mock client
 			client := mockclient.NewMockClient(ctrl)
-			client.EXPECT().Get(context.TODO(), cloudProviderConfigKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cloudProviderConfigMap))
 			client.EXPECT().Get(context.TODO(), cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
 
 			// Create valuesProvider
@@ -614,7 +597,6 @@ var _ = Describe("ValuesProvider", func() {
 		It("should return error, missing security groups", func() {
 			// Create mock client
 			client := mockclient.NewMockClient(ctrl)
-			client.EXPECT().Get(context.TODO(), cloudProviderConfigKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cloudProviderConfigMap))
 			client.EXPECT().Get(context.TODO(), cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
 
 			// Create valuesProvider
@@ -642,76 +624,6 @@ var _ = Describe("ValuesProvider", func() {
 			values, err := vp.GetControlPlaneChartValues(context.TODO(), cp, cluster, checksums, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(ccmChartValues))
-		})
-	})
-
-	Describe("#determineLoadBalancerType", func() {
-		It("should use standard load balancer, as configured in cloud-provider-config", func() {
-			c := mockclient.NewMockClient(ctrl)
-			c.EXPECT().Get(context.TODO(), cloudProviderConfigKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cloudProviderConfigMap))
-
-			vc := client.Client(c)
-			lbType, err := determineLoadBalancerType(context.TODO(), vc, namespace)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(lbType).To(Equal("standard"))
-		})
-
-		It("should use standard load balancer, as cloud-provider-config is empty", func() {
-			var cm = &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      cloudProviderConfigMapName,
-					Namespace: namespace,
-				},
-				Data: map[string]string{},
-			}
-
-			c := mockclient.NewMockClient(ctrl)
-			c.EXPECT().Get(context.TODO(), cloudProviderConfigKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
-
-			vc := client.Client(c)
-			lbType, err := determineLoadBalancerType(context.TODO(), vc, namespace)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(lbType).To(Equal("standard"))
-		})
-
-		It("should use basic load balancer, as no lb config in cloud-provider-config", func() {
-			var cm = &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      cloudProviderConfigMapName,
-					Namespace: namespace,
-				},
-				Data: map[string]string{
-					cloudProviderConfigMapKey: "",
-				},
-			}
-
-			c := mockclient.NewMockClient(ctrl)
-			c.EXPECT().Get(context.TODO(), cloudProviderConfigKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
-
-			vc := client.Client(c)
-			lbType, err := determineLoadBalancerType(context.TODO(), vc, namespace)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(lbType).To(Equal("basic"))
-		})
-
-		It("should use basic load balancer, as configured in cloud-provider-config", func() {
-			var cm = &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      cloudProviderConfigMapName,
-					Namespace: namespace,
-				},
-				Data: map[string]string{
-					cloudProviderConfigMapKey: "loadBalancerSku: \"basic\"",
-				},
-			}
-
-			c := mockclient.NewMockClient(ctrl)
-			c.EXPECT().Get(context.TODO(), cloudProviderConfigKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
-
-			vc := client.Client(c)
-			lbType, err := determineLoadBalancerType(context.TODO(), vc, namespace)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(lbType).To(Equal("basic"))
 		})
 	})
 })


### PR DESCRIPTION
We will use again basic load balancers for cluster with availability sets and standard only for zoned clusters.

**Which issue(s) this PR fixes**:
Fixes #359

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Azure: Shoot clusters with AvailabilitySets need to use again basic sku load balancers due to routing/nat issues of this combination. Zoned clusters will still use the standard sku load balancers.
```

```action operator
Azure: Shoot clusters with AvailabilitySet and standard sku load balancers need to migrated to use basic sku load balancers again, due to routing/nat issues of this combination. This works as the migration from basic to standard. See here: https://github.com/gardener/gardener-extensions/blob/master/controllers/provider-azure/docs/migrate-loadbalancer.md
```
