### PR TITLE
Enable Using POD CIDRs on calico node/typha

### DIFF
--- a/controllers/networking-calico/charts/internal/calico/templates/calico.yaml
+++ b/controllers/networking-calico/charts/internal/calico/templates/calico.yaml
@@ -133,6 +133,10 @@ spec:
         - name: calico-node
           image: {{ index .Values.images "calico-node" }}
           env:
+            {{- if eq .Values.config.ipam.type "host-local"}}
+            - name: USE_POD_CIDR
+              value: "true"
+            {{- end }}
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
               value: "kubernetes"
@@ -180,22 +184,24 @@ spec:
             - name: CALICO_IPV4POOL_CIDR
               value: "{{ .Values.global.podCIDR }}"
             # Enable IPIP
+            {{- if ne .Values.config.backend "none"}}
+            # Enable IP-in-IP within Felix.
+            - name: FELIX_IPINIPENABLED
+              value: "true"
             - name: CALICO_IPV4POOL_IPIP
               value: "Always"
+            {{- else }}
+            - name: FELIX_IPINIPENABLED
+              value: "false"
+            - name: CALICO_IPV4POOL_IPIP
+              value: "Never"
+            {{- end }}
             # Choose the backend to use.
             - name: CALICO_NETWORKING_BACKEND
               valueFrom:
                 configMapKeyRef:
                   name: calico-config
                   key: calico_backend
-            {{- if ne .Values.config.backend "none"}}
-            # Enable IP-in-IP within Felix.
-            - name: FELIX_IPINIPENABLED
-              value: "true"
-            {{- else }}
-            - name: FELIX_IPINIPENABLED
-              value: "false"
-            {{- end }}
             # Set based on the k8s node name.
             - name: NODENAME
               valueFrom:
@@ -371,6 +377,10 @@ spec:
           name: calico-typha
           protocol: TCP
         env:
+          {{- if eq .Values.config.ipam.type "host-local"}}
+          - name: USE_POD_CIDR
+            value: "true"
+          {{- end }}
           # Enable "info" logging by default.  Can be set to "debug" to increase verbosity.
           - name: TYPHA_LOGSEVERITYSCREEN
             value: "error"


### PR DESCRIPTION
**What this PR does / why we need it**:
Configure Calico to correctly use Host-local IPAM. 

**Special notes for your reviewer**:
In addition to the IPAM config, the `CALICO_IPV4POOL_IPIP` was set to `Never` instead of `Always` to avoid side-effects since anyways tunnels are not used for Azure (backends are set to none). 


```action operator
Its recommended to modify the `IPPool` resource in Azure shoots by setting the `spec.ipipMode` mode to `Never`. This is to ensure consistent configuration and to avoid side effects in the future. 
```