### PR TITLE
[ci:component:github.com/gardener/terraformer:0.15.0->0.16.0]

### DIFF
--- a/controllers/provider-alicloud/charts/images.yaml
+++ b/controllers/provider-alicloud/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "0.15.0"
+  tag: "0.16.0"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager

--- a/controllers/provider-aws/charts/images.yaml
+++ b/controllers/provider-aws/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "0.15.0"
+  tag: "0.16.0"
 - name: hyperkube
   sourceRepository: github.com/kubernetes/kubernetes
   repository: k8s.gcr.io/hyperkube

--- a/controllers/provider-azure/charts/images.yaml
+++ b/controllers/provider-azure/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "0.15.0"
+  tag: "0.16.0"
 - name: hyperkube
   sourceRepository: github.com/kubernetes/kubernetes
   repository: k8s.gcr.io/hyperkube

--- a/controllers/provider-gcp/charts/images.yaml
+++ b/controllers/provider-gcp/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "0.15.0"
+  tag: "0.16.0"
 - name: hyperkube
   sourceRepository: github.com/kubernetes/kubernetes
   repository: k8s.gcr.io/hyperkube

--- a/controllers/provider-openstack/charts/images.yaml
+++ b/controllers/provider-openstack/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "0.15.0"
+  tag: "0.16.0"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager

--- a/controllers/provider-packet/charts/images.yaml
+++ b/controllers/provider-packet/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "0.15.0"
+  tag: "0.16.0"
 - name: cloud-controller-manager
   sourceRepository: https://github.com/packethost/packet-ccm
   repository: docker.io/packethost/packet-ccm


### PR DESCRIPTION
*Release Notes*:
``` noteworthy operator github.com/gardener/terraformer #27 @ialidzhikov
Terraform version has been upgraded to `0.12.9`.
```