### PR TITLE
extension-shoot-cert-service: updated image tag for cert-management

### DIFF
--- a/controllers/extension-shoot-cert-service/charts/images.yaml
+++ b/controllers/extension-shoot-cert-service/charts/images.yaml
@@ -2,4 +2,4 @@ images:
 - name: cert-management
   sourceRepository: github.com/gardener/cert-management
   repository: eu.gcr.io/gardener-project/cert-controller-manager
-  tag: "0.2.2"
+  tag: "0.2.3"


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated cert-management image tag to 0.2.3.
With this new version, the watches on issuers and secrets on the default cluster 
are restricted to the issuer namespace. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
extension-shoot-cert-service: The cert-controller-manager only watches
issuers and secrets on the default cluster in the issuer namespace.
```
