### PR TITLE
[ci:component:github.com/gardener/cert-management:0.2.2->0.2.3]

### DIFF
--- a/controllers/extension-shoot-cert-service/charts/images.yaml
+++ b/controllers/extension-shoot-cert-service/charts/images.yaml
@@ -2,4 +2,4 @@ images:
 - name: cert-management
   sourceRepository: github.com/gardener/cert-management
   repository: eu.gcr.io/gardener-project/cert-controller-manager
-  tag: "0.2.2"
+  tag: "0.2.3"


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/cert-management $51247dd5f8631382ba69a878cdf4b25155c3cf02
restrict watching issuer and secrets on default cluster to issuer namespace
```

``` improvement operator github.com/gardener/cert-management $51247dd5f8631382ba69a878cdf4b25155c3cf02
metrics on ACME obtains and DNS challenges
```

``` improvement operator github.com/gardener/cert-management $51247dd5f8631382ba69a878cdf4b25155c3cf02
email is not stored in issuer secret anymore
```