### PR TITLE
Add gardener user for SSH

### DIFF
--- a/controllers/provider-alicloud/pkg/webhook/controlplane/ensurer.go
+++ b/controllers/provider-alicloud/pkg/webhook/controlplane/ensurer.go
@@ -113,3 +113,13 @@ func (e *ensurer) EnsureKubeletConfiguration(ctx context.Context, kubeletConfig 
 	kubeletConfig.FeatureGates["CSIDriverRegistry"] = true
 	return nil
 }
+
+// EnsureGardenerUserServiceUnitOptions ensures that the gardener-user.service unit options conform to the provider requirements.
+func (e *ensurer) EnsureGardenerUserServiceUnitOptions(ctx context.Context, opts []*unit.UnitOption) ([]*unit.UnitOption, error) {
+	opts = extensionswebhook.EnsureUnitOption(opts, &unit.UnitOption{
+		Section: "Service",
+		Name:    "ExecStartPre",
+		Value:   `/bin/sh -c 'wget http://100.100.100.200/latest/meta-data/public-keys/0/openssh-key -O /var/lib/gardener-user-ssh.key'`,
+	})
+	return opts, nil
+}

--- a/controllers/provider-aws/pkg/webhook/controlplane/ensurer.go
+++ b/controllers/provider-aws/pkg/webhook/controlplane/ensurer.go
@@ -211,6 +211,16 @@ func (e *ensurer) EnsureKubernetesGeneralConfiguration(ctx context.Context, data
 	return nil
 }
 
+// EnsureGardenerUserServiceUnitOptions ensures that the gardener-user.service unit options conform to the provider requirements.
+func (e *ensurer) EnsureGardenerUserServiceUnitOptions(ctx context.Context, opts []*unit.UnitOption) ([]*unit.UnitOption, error) {
+	opts = extensionswebhook.EnsureUnitOption(opts, &unit.UnitOption{
+		Section: "Service",
+		Name:    "ExecStartPre",
+		Value:   `/bin/sh -c 'wget http://169.254.169.254/latest/meta-data/public-keys/0/openssh-key -O /var/lib/gardener-user-ssh.key'`,
+	})
+	return opts, nil
+}
+
 // EnsureAdditionalUnits ensures that additional required system units are added.
 func (e *ensurer) EnsureAdditionalUnits(ctx context.Context, units *[]extensionsv1alpha1.Unit) error {
 	var (

--- a/controllers/provider-azure/pkg/webhook/controlplane/ensurer.go
+++ b/controllers/provider-azure/pkg/webhook/controlplane/ensurer.go
@@ -154,6 +154,16 @@ func (e *ensurer) EnsureKubeletConfiguration(ctx context.Context, kubeletConfig 
 	return nil
 }
 
+// EnsureGardenerUserServiceUnitOptions ensures that the gardener-user.service unit options conform to the provider requirements.
+func (e *ensurer) EnsureGardenerUserServiceUnitOptions(ctx context.Context, opts []*unit.UnitOption) ([]*unit.UnitOption, error) {
+	opts = extensionswebhook.EnsureUnitOption(opts, &unit.UnitOption{
+		Section: "Service",
+		Name:    "ExecStartPre",
+		Value:   `/bin/sh -c 'wget --header Metadata:true "http://169.254.169.254/metadata/instance/compute/publicKeys/0/keyData?api-version=2019-06-04&format=text" -O /var/lib/gardener-user-ssh.key'`,
+	})
+	return opts, nil
+}
+
 // ShouldProvisionKubeletCloudProviderConfig returns true if the cloud provider config file should be added to the kubelet configuration.
 func (e *ensurer) ShouldProvisionKubeletCloudProviderConfig() bool {
 	return true

--- a/controllers/provider-gcp/pkg/webhook/controlplane/ensurer.go
+++ b/controllers/provider-gcp/pkg/webhook/controlplane/ensurer.go
@@ -190,6 +190,16 @@ func (e *ensurer) EnsureKubeletConfiguration(ctx context.Context, kubeletConfig 
 	return nil
 }
 
+// EnsureGardenerUserServiceUnitOptions ensures that the gardener-user.service unit options conform to the provider requirements.
+func (e *ensurer) EnsureGardenerUserServiceUnitOptions(ctx context.Context, opts []*unit.UnitOption) ([]*unit.UnitOption, error) {
+	opts = extensionswebhook.EnsureUnitOption(opts, &unit.UnitOption{
+		Section: "Service",
+		Name:    "ExecStartPre",
+		Value:   `/bin/sh -c 'wget --header "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/project/attributes/ssh-keys -O /var/lib/gardener-user-ssh.key'`,
+	})
+	return opts, nil
+}
+
 var regexFindProperty = regexp.MustCompile("net.ipv4.ip_forward[[:space:]]*=[[:space:]]*([[:alnum:]]+)")
 
 // EnsureKubernetesGeneralConfiguration ensures that the kubernetes general configuration conforms to the provider requirements.

--- a/controllers/provider-openstack/pkg/webhook/controlplane/ensurer.go
+++ b/controllers/provider-openstack/pkg/webhook/controlplane/ensurer.go
@@ -160,6 +160,16 @@ func (e *ensurer) EnsureKubeletConfiguration(ctx context.Context, kubeletConfig 
 	return nil
 }
 
+// EnsureGardenerUserServiceUnitOptions ensures that the gardener-user.service unit options conform to the provider requirements.
+func (e *ensurer) EnsureGardenerUserServiceUnitOptions(ctx context.Context, opts []*unit.UnitOption) ([]*unit.UnitOption, error) {
+	opts = extensionswebhook.EnsureUnitOption(opts, &unit.UnitOption{
+		Section: "Service",
+		Name:    "ExecStartPre",
+		Value:   `/bin/sh -c 'wget http://169.254.169.254/latest/meta-data/public-keys/0/openssh-key -O /var/lib/gardener-user-ssh.key'`,
+	})
+	return opts, nil
+}
+
 // ShouldProvisionKubeletCloudProviderConfig returns true if the cloud provider config file should be added to the kubelet configuration.
 func (e *ensurer) ShouldProvisionKubeletCloudProviderConfig() bool {
 	return true

--- a/pkg/mock/gardener-extensions/webhook/controlplane/genericmutator/mocks.go
+++ b/pkg/mock/gardener-extensions/webhook/controlplane/genericmutator/mocks.go
@@ -81,6 +81,21 @@ func (mr *MockEnsurerMockRecorder) EnsureETCDStatefulSet(arg0, arg1, arg2 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureETCDStatefulSet", reflect.TypeOf((*MockEnsurer)(nil).EnsureETCDStatefulSet), arg0, arg1, arg2)
 }
 
+// EnsureGardenerUserServiceUnitOptions mocks base method
+func (m *MockEnsurer) EnsureGardenerUserServiceUnitOptions(arg0 context.Context, arg1 []*unit.UnitOption) ([]*unit.UnitOption, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureGardenerUserServiceUnitOptions", arg0, arg1)
+	ret0, _ := ret[0].([]*unit.UnitOption)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnsureGardenerUserServiceUnitOptions indicates an expected call of EnsureGardenerUserServiceUnitOptions
+func (mr *MockEnsurerMockRecorder) EnsureGardenerUserServiceUnitOptions(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureGardenerUserServiceUnitOptions", reflect.TypeOf((*MockEnsurer)(nil).EnsureGardenerUserServiceUnitOptions), arg0, arg1)
+}
+
 // EnsureKubeAPIServerDeployment mocks base method
 func (m *MockEnsurer) EnsureKubeAPIServerDeployment(arg0 context.Context, arg1 *v1.Deployment) error {
 	m.ctrl.T.Helper()

--- a/pkg/webhook/controlplane/genericmutator/noopensurer.go
+++ b/pkg/webhook/controlplane/genericmutator/noopensurer.go
@@ -64,6 +64,11 @@ func (e *NoopEnsurer) EnsureKubeletConfiguration(context.Context, *kubeletconfig
 	return nil
 }
 
+// EnsureGardenerUserServiceUnitOptions ensures that the gardener-user.service unit options conform to the provider requirements.
+func (e *NoopEnsurer) EnsureGardenerUserServiceUnitOptions(_ context.Context, opts []*unit.UnitOption) ([]*unit.UnitOption, error) {
+	return opts, nil
+}
+
 // EnsureKubernetesGeneralConfiguration ensures that the kubernetes general configuration conforms to the provider requirements.
 func (e *NoopEnsurer) EnsureKubernetesGeneralConfiguration(context.Context, *string) error {
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Inject SSH key for the gardener user

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@vpnachev 
https://github.com/gardener/gardener/pull/1513

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The AWS, GCP, Azure, Alicloud, and OpenStack extension providers do now automatically inject the SSH key for the `gardener` user to all shoot worker VMs.
```
