### PR TITLE
Add IPIP and IP Autodetection Method for calico controller

### DIFF
--- a/controllers/networking-calico/charts/internal/calico/templates/calico.yaml
+++ b/controllers/networking-calico/charts/internal/calico/templates/calico.yaml
@@ -184,17 +184,16 @@ spec:
             - name: CALICO_IPV4POOL_CIDR
               value: "{{ .Values.global.podCIDR }}"
             # Enable IPIP
-            {{- if ne .Values.config.backend "none"}}
-            # Enable IP-in-IP within Felix.
-            - name: FELIX_IPINIPENABLED
-              value: "true"
-            - name: CALICO_IPV4POOL_IPIP
-              value: "Always"
-            {{- else }}
+            {{- if eq .Values.config.backend "none"}}
             - name: FELIX_IPINIPENABLED
               value: "false"
             - name: CALICO_IPV4POOL_IPIP
               value: "Never"
+            {{- else }}
+            - name: FELIX_IPINIPENABLED
+              value: "true"
+            - name: CALICO_IPV4POOL_IPIP
+              value: "{{.Values.ipip}}"
             {{- end }}
             # Choose the backend to use.
             - name: CALICO_NETWORKING_BACKEND

--- a/controllers/networking-calico/charts/internal/calico/values.yaml
+++ b/controllers/networking-calico/charts/internal/calico/values.yaml
@@ -5,6 +5,8 @@ config:
   ipam:
     type: "host-local"
 #    subnet: "usePodCidr"
+#ipip: "Always"
+#ipAutodetectionMethod: "first-found"
 images:
   calico-node: "image-repository:image-tag"
   calico-cni: "image-repository:image-tag"

--- a/controllers/networking-calico/example/10-crd-managedresource.yaml
+++ b/controllers/networking-calico/example/10-crd-managedresource.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: managedresources.resources.gardener.cloud
+spec:
+  group: resources.gardener.cloud
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: managedresources
+    singular: managedresource
+    kind: ManagedResource
+    shortNames:
+    - mr
+  additionalPrinterColumns:
+  - name: Class
+    type: string
+    JSONPath: .spec.class
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}

--- a/controllers/networking-calico/example/20-network.yaml
+++ b/controllers/networking-calico/example/20-network.yaml
@@ -47,7 +47,8 @@ spec:
     apiVersion: calico.networking.extensions.gardener.cloud/v1alpha1
     kind: NetworkConfig
     backend: bird
-#   ipam:
-#     type: host-local
-#     cidr: usePodCIDR
-#   ipAutoDetectionMethod: first-found
+    ipam:
+      type: host-local
+      cidr: usePodCIDR
+#    ipAutodetectionMethod: interface=eth0
+#    ipip: CrossSubnet

--- a/controllers/networking-calico/hack/api-reference/calico.md
+++ b/controllers/networking-calico/hack/api-reference/calico.md
@@ -52,7 +52,7 @@ Backend
 </em>
 </td>
 <td>
-<p>Backend defines whether a backend should be used or not (e.g., bird or None)</p>
+<p>Backend defines whether a backend should be used or not (e.g., bird or none)</p>
 </td>
 </tr>
 <tr>
@@ -80,6 +80,20 @@ string
 <em>(Optional)</em>
 <p>IPAutoDetectionMethod is the method to use to autodetect the IPv4 address for this host. This is only used when the IPv4 address is being autodetected.
 <a href="https://docs.projectcalico.org/v2.2/reference/node/configuration#ip-autodetection-methods">https://docs.projectcalico.org/v2.2/reference/node/configuration#ip-autodetection-methods</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ipip</code></br>
+<em>
+<a href="#calico.networking.extensions.gardener.cloud/v1alpha1.IPIP">
+IPIP
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>IPIP is the IPIP Mode for the IPv4 Pool (e.g. Always, Never, CrossSubnet)</p>
 </td>
 </tr>
 </tbody>
@@ -144,6 +158,14 @@ CIDR
 </tr>
 </tbody>
 </table>
+<h3 id="calico.networking.extensions.gardener.cloud/v1alpha1.IPIP">IPIP
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#calico.networking.extensions.gardener.cloud/v1alpha1.NetworkConfig">NetworkConfig</a>)
+</p>
+<p>
+</p>
 <h3 id="calico.networking.extensions.gardener.cloud/v1alpha1.NetworkStatus">NetworkStatus
 </h3>
 <p>

--- a/controllers/networking-calico/pkg/apis/calico/types_network.go
+++ b/controllers/networking-calico/pkg/apis/calico/types_network.go
@@ -25,6 +25,15 @@ const (
 	None Backend = "none"
 )
 
+type IPIP string
+
+const (
+	Always      IPIP = "Always"
+	Never       IPIP = "Never"
+	CrossSubnet IPIP = "CrossSubnet"
+	Off         IPIP = "Off"
+)
+
 type CIDR string
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -32,7 +41,7 @@ type CIDR string
 // NetworkConfig configuration for the calico networking plugin
 type NetworkConfig struct {
 	metav1.TypeMeta
-	// Backend defines whether a backend should be used or not (e.g., bird or None)
+	// Backend defines whether a backend should be used or not (e.g., bird or none)
 	Backend Backend
 	// IPAM to use for the Calico Plugin (e.g., host-local or Calico)
 	// +optional
@@ -41,6 +50,9 @@ type NetworkConfig struct {
 	// https://docs.projectcalico.org/v2.2/reference/node/configuration#ip-autodetection-methods
 	// +optional
 	IPAutoDetectionMethod *string
+	// IPIP is the IPIP Mode for the IPv4 Pool (e.g. Always, Never, CrossSubnet)
+	// +optional
+	IPIP *IPIP
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/controllers/networking-calico/pkg/apis/calico/v1alpha1/types_network.go
+++ b/controllers/networking-calico/pkg/apis/calico/v1alpha1/types_network.go
@@ -25,6 +25,15 @@ const (
 	None Backend = "none"
 )
 
+type IPIP string
+
+const (
+	Always      IPIP = "Always"
+	Never       IPIP = "Never"
+	CrossSubnet IPIP = "CrossSubnet"
+	Off         IPIP = "Off"
+)
+
 type CIDR string
 
 // +genclient
@@ -34,7 +43,7 @@ type CIDR string
 type NetworkConfig struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// Backend defines whether a backend should be used or not (e.g., bird or None)
+	// Backend defines whether a backend should be used or not (e.g., bird or none)
 	Backend Backend `json:"backend"`
 	// IPAM to use for the Calico Plugin (e.g., host-local or Calico)
 	// +optional
@@ -43,6 +52,9 @@ type NetworkConfig struct {
 	// https://docs.projectcalico.org/v2.2/reference/node/configuration#ip-autodetection-methods
 	// +optional
 	IPAutoDetectionMethod *string `json:"ipAutodetectionMethod,omitempty"`
+	// IPIP is the IPIP Mode for the IPv4 Pool (e.g. Always, Never, CrossSubnet)
+	// +optional
+	IPIP *IPIP `json:"ipip,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/controllers/networking-calico/pkg/apis/calico/v1alpha1/zz_generated.conversion.go
+++ b/controllers/networking-calico/pkg/apis/calico/v1alpha1/zz_generated.conversion.go
@@ -94,6 +94,7 @@ func autoConvert_v1alpha1_NetworkConfig_To_calico_NetworkConfig(in *NetworkConfi
 	out.Backend = calico.Backend(in.Backend)
 	out.IPAM = (*calico.IPAM)(unsafe.Pointer(in.IPAM))
 	out.IPAutoDetectionMethod = (*string)(unsafe.Pointer(in.IPAutoDetectionMethod))
+	out.IPIP = (*calico.IPIP)(unsafe.Pointer(in.IPIP))
 	return nil
 }
 
@@ -106,6 +107,7 @@ func autoConvert_calico_NetworkConfig_To_v1alpha1_NetworkConfig(in *calico.Netwo
 	out.Backend = Backend(in.Backend)
 	out.IPAM = (*IPAM)(unsafe.Pointer(in.IPAM))
 	out.IPAutoDetectionMethod = (*string)(unsafe.Pointer(in.IPAutoDetectionMethod))
+	out.IPIP = (*IPIP)(unsafe.Pointer(in.IPIP))
 	return nil
 }
 

--- a/controllers/networking-calico/pkg/apis/calico/v1alpha1/zz_generated.deepcopy.go
+++ b/controllers/networking-calico/pkg/apis/calico/v1alpha1/zz_generated.deepcopy.go
@@ -59,6 +59,11 @@ func (in *NetworkConfig) DeepCopyInto(out *NetworkConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.IPIP != nil {
+		in, out := &in.IPIP, &out.IPIP
+		*out = new(IPIP)
+		**out = **in
+	}
 	return
 }
 

--- a/controllers/networking-calico/pkg/apis/calico/zz_generated.deepcopy.go
+++ b/controllers/networking-calico/pkg/apis/calico/zz_generated.deepcopy.go
@@ -59,6 +59,11 @@ func (in *NetworkConfig) DeepCopyInto(out *NetworkConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.IPIP != nil {
+		in, out := &in.IPIP, &out.IPIP
+		*out = new(IPIP)
+		**out = **in
+	}
 	return
 }
 

--- a/controllers/networking-calico/pkg/charts/utils.go
+++ b/controllers/networking-calico/pkg/charts/utils.go
@@ -43,6 +43,7 @@ func ComputeCalicoChartValues(network *extensionsv1alpha1.Network, config *calic
 			"global": map[string]string{
 				"podCIDR": network.Spec.PodCIDR,
 			},
+			"ipip": calicov1alpha1.Always,
 		}
 		calicoConfigValues = map[string]interface{}{
 			"backend": calicov1alpha1.Bird,
@@ -54,7 +55,10 @@ func ComputeCalicoChartValues(network *extensionsv1alpha1.Network, config *calic
 	)
 
 	if config != nil {
-		calicoConfigValues["backend"] = config.Backend
+		switch config.Backend {
+		case calicov1alpha1.Bird, calicov1alpha1.None:
+			calicoConfigValues["backend"] = config.Backend
+		}
 
 		if config.IPAM != nil {
 			if len(config.IPAM.Type) > 0 {
@@ -62,6 +66,16 @@ func ComputeCalicoChartValues(network *extensionsv1alpha1.Network, config *calic
 			}
 			if config.IPAM.Type == hostLocal && config.IPAM.CIDR != nil {
 				ipamConfig["subnet"] = *config.IPAM.CIDR
+			}
+		}
+
+		if config.IPAutoDetectionMethod != nil {
+			calicoChartValues["ipAutodetectionMethod"] = *config.IPAutoDetectionMethod
+		}
+		if config.IPIP != nil {
+			switch *config.IPIP {
+			case calicov1alpha1.Always, calicov1alpha1.Never, calicov1alpha1.Off, calicov1alpha1.CrossSubnet:
+				calicoChartValues["ipip"] = *config.IPIP
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes sure IP_AUTODETECTION_METHOD env var for calico/node can be used. Makes CALICO_IPV4POOL_IPIP env var configurable for calico/node. Removes redundant FELIX_IPINIPENABLED env var from calico/node.

**Special notes for your reviewer**:

Includes unit tests

**Release note**:

```noteworthy user
The configuration for the `networking-calico` controller now allows to explicitly set `.spec.ipip`. It will be defaulted to `Always`.
```
