### PR TITLE
[ci:component:github.com/gardener/external-dns-management:0.7.0->0.7.1]

### DIFF
--- a/controllers/extension-shoot-dns-service/charts/images.yaml
+++ b/controllers/extension-shoot-dns-service/charts/images.yaml
@@ -2,4 +2,4 @@ images:
 - name: dns-controller-manager
   sourceRepository: github.com/gardener/external-dns-management
   repository: eu.gcr.io/gardener-project/dns-controller-manager
-  tag: "0.7.0"
+  tag: "0.7.1"


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/external-dns-management #42 @MartinWeindel
dealing with owner conflict caused by stale cache from external changes, e.g. for DNSEntries moved between two dns-controller-managers working on the same hosted zone.
```

``` improvement operator github.com/gardener/external-dns-management #38 @afritzler
Added addional OpenStack credential flags (domainID, tenantID, userDomainName, userDomainID)
```

``` improvement operator github.com/gardener/external-dns-management $634b5af8a253db05dd553466afb97c6defb7b49e
Added additional OpenStack credential flags. It now support the following properties:
  userDomanName, OS_USER_DOMAIN_NAME
  userDomainID, OS_USER_DOMAIN_ID
  tenantID, OS_PROJECT_ID
  domainID, OS_DOMAIN_ID
```