### PR TITLE
Add missing owner reference to MCM cluster role

### DIFF
--- a/controllers/provider-alicloud/charts/internal/machine-controller-manager/seed/templates/clusterrole.yaml
+++ b/controllers/provider-alicloud/charts/internal/machine-controller-manager/seed/templates/clusterrole.yaml
@@ -3,6 +3,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: extensions.gardener.cloud:{{ .Values.providerName }}:{{ .Release.Namespace }}:machine-controller-manager
+  ownerReferences:
+  - apiVersion: v1
+    kind: Namespace
+    name: {{ .Release.Namespace }}
+    uid: {{ .Values.namespace.uid }}
+    controller: true
+    blockOwnerDeletion: true
 rules:
 - apiGroups:
   - machine.sapcloud.io

--- a/controllers/provider-alicloud/example/20-crd-managedresource.yaml
+++ b/controllers/provider-alicloud/example/20-crd-managedresource.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: managedresources.resources.gardener.cloud
+spec:
+  group: resources.gardener.cloud
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: managedresources
+    singular: managedresource
+    kind: ManagedResource
+    shortNames:
+    - mr
+  additionalPrinterColumns:
+  - name: Class
+    type: string
+    JSONPath: .spec.class
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}

--- a/controllers/provider-alicloud/example/20-crd-operatingsystemconfig.yaml
+++ b/controllers/provider-alicloud/example/20-crd-operatingsystemconfig.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: operatingsystemconfigs.extensions.gardener.cloud
+spec:
+  group: extensions.gardener.cloud
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: operatingsystemconfigs
+    singular: operatingsystemconfig
+    kind: OperatingSystemConfig
+    shortNames:
+    - osc
+  additionalPrinterColumns:
+  - name: Type
+    type: string
+    description: The type of the operating system configuration.
+    JSONPath: .spec.type
+  - name: State
+    type: string
+    JSONPath: .status.lastOperation.state
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}

--- a/controllers/provider-alicloud/example/20-crd-vpa.yaml
+++ b/controllers/provider-alicloud/example/20-crd-vpa.yaml
@@ -1,0 +1,60 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: verticalpodautoscalers.autoscaling.k8s.io
+spec:
+  group: autoscaling.k8s.io
+  scope: Namespaced
+  names:
+    plural: verticalpodautoscalers
+    singular: verticalpodautoscaler
+    kind: VerticalPodAutoscaler
+    shortNames:
+    - vpa
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1beta2
+    served: true
+    storage: true
+  validation:
+    # openAPIV3Schema is the schema for validating custom objects.
+    openAPIV3Schema:
+      properties:
+        spec:
+          required: []
+          properties:
+            targetRef:
+              type: object
+            updatePolicy:
+              properties:
+                updateMode:
+                  type: string
+            resourcePolicy:
+              properties:
+                containerPolicies:
+                  type: array
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: verticalpodautoscalercheckpoints.autoscaling.k8s.io
+spec:
+  group: autoscaling.k8s.io
+  scope: Namespaced
+  names:
+    plural: verticalpodautoscalercheckpoints
+    singular: verticalpodautoscalercheckpoint
+    kind: VerticalPodAutoscalerCheckpoint
+    shortNames:
+    - vpacheckpoint
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1beta2
+    served: true
+    storage: true

--- a/controllers/provider-aws/charts/internal/machine-controller-manager/seed/templates/clusterrole.yaml
+++ b/controllers/provider-aws/charts/internal/machine-controller-manager/seed/templates/clusterrole.yaml
@@ -3,6 +3,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: extensions.gardener.cloud:{{ .Values.providerName }}:{{ .Release.Namespace }}:machine-controller-manager
+  ownerReferences:
+  - apiVersion: v1
+    kind: Namespace
+    name: {{ .Release.Namespace }}
+    uid: {{ .Values.namespace.uid }}
+    controller: true
+    blockOwnerDeletion: true
 rules:
 - apiGroups:
   - machine.sapcloud.io

--- a/controllers/provider-aws/example/20-crd-managedresource.yaml
+++ b/controllers/provider-aws/example/20-crd-managedresource.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: managedresources.resources.gardener.cloud
+spec:
+  group: resources.gardener.cloud
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: managedresources
+    singular: managedresource
+    kind: ManagedResource
+    shortNames:
+    - mr
+  additionalPrinterColumns:
+  - name: Class
+    type: string
+    JSONPath: .spec.class
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}

--- a/controllers/provider-aws/example/20-crd-operatingsystemconfig.yaml
+++ b/controllers/provider-aws/example/20-crd-operatingsystemconfig.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: operatingsystemconfigs.extensions.gardener.cloud
+spec:
+  group: extensions.gardener.cloud
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: operatingsystemconfigs
+    singular: operatingsystemconfig
+    kind: OperatingSystemConfig
+    shortNames:
+    - osc
+  additionalPrinterColumns:
+  - name: Type
+    type: string
+    description: The type of the operating system configuration.
+    JSONPath: .spec.type
+  - name: State
+    type: string
+    JSONPath: .status.lastOperation.state
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}

--- a/controllers/provider-aws/example/20-crd-vpa.yaml
+++ b/controllers/provider-aws/example/20-crd-vpa.yaml
@@ -1,0 +1,60 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: verticalpodautoscalers.autoscaling.k8s.io
+spec:
+  group: autoscaling.k8s.io
+  scope: Namespaced
+  names:
+    plural: verticalpodautoscalers
+    singular: verticalpodautoscaler
+    kind: VerticalPodAutoscaler
+    shortNames:
+    - vpa
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1beta2
+    served: true
+    storage: true
+  validation:
+    # openAPIV3Schema is the schema for validating custom objects.
+    openAPIV3Schema:
+      properties:
+        spec:
+          required: []
+          properties:
+            targetRef:
+              type: object
+            updatePolicy:
+              properties:
+                updateMode:
+                  type: string
+            resourcePolicy:
+              properties:
+                containerPolicies:
+                  type: array
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: verticalpodautoscalercheckpoints.autoscaling.k8s.io
+spec:
+  group: autoscaling.k8s.io
+  scope: Namespaced
+  names:
+    plural: verticalpodautoscalercheckpoints
+    singular: verticalpodautoscalercheckpoint
+    kind: VerticalPodAutoscalerCheckpoint
+    shortNames:
+    - vpacheckpoint
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1beta2
+    served: true
+    storage: true

--- a/controllers/provider-azure/charts/internal/machine-controller-manager/seed/templates/clusterrole.yaml
+++ b/controllers/provider-azure/charts/internal/machine-controller-manager/seed/templates/clusterrole.yaml
@@ -3,6 +3,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: extensions.gardener.cloud:{{ .Values.providerName }}:{{ .Release.Namespace }}:machine-controller-manager
+  ownerReferences:
+  - apiVersion: v1
+    kind: Namespace
+    name: {{ .Release.Namespace }}
+    uid: {{ .Values.namespace.uid }}
+    controller: true
+    blockOwnerDeletion: true
 rules:
 - apiGroups:
   - machine.sapcloud.io

--- a/controllers/provider-azure/example/20-crd-managedresource.yaml
+++ b/controllers/provider-azure/example/20-crd-managedresource.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: managedresources.resources.gardener.cloud
+spec:
+  group: resources.gardener.cloud
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: managedresources
+    singular: managedresource
+    kind: ManagedResource
+    shortNames:
+    - mr
+  additionalPrinterColumns:
+  - name: Class
+    type: string
+    JSONPath: .spec.class
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}

--- a/controllers/provider-azure/example/20-crd-operatingsystemconfig.yaml
+++ b/controllers/provider-azure/example/20-crd-operatingsystemconfig.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: operatingsystemconfigs.extensions.gardener.cloud
+spec:
+  group: extensions.gardener.cloud
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: operatingsystemconfigs
+    singular: operatingsystemconfig
+    kind: OperatingSystemConfig
+    shortNames:
+    - osc
+  additionalPrinterColumns:
+  - name: Type
+    type: string
+    description: The type of the operating system configuration.
+    JSONPath: .spec.type
+  - name: State
+    type: string
+    JSONPath: .status.lastOperation.state
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}

--- a/controllers/provider-azure/example/20-crd-vpa.yaml
+++ b/controllers/provider-azure/example/20-crd-vpa.yaml
@@ -1,0 +1,60 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: verticalpodautoscalers.autoscaling.k8s.io
+spec:
+  group: autoscaling.k8s.io
+  scope: Namespaced
+  names:
+    plural: verticalpodautoscalers
+    singular: verticalpodautoscaler
+    kind: VerticalPodAutoscaler
+    shortNames:
+    - vpa
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1beta2
+    served: true
+    storage: true
+  validation:
+    # openAPIV3Schema is the schema for validating custom objects.
+    openAPIV3Schema:
+      properties:
+        spec:
+          required: []
+          properties:
+            targetRef:
+              type: object
+            updatePolicy:
+              properties:
+                updateMode:
+                  type: string
+            resourcePolicy:
+              properties:
+                containerPolicies:
+                  type: array
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: verticalpodautoscalercheckpoints.autoscaling.k8s.io
+spec:
+  group: autoscaling.k8s.io
+  scope: Namespaced
+  names:
+    plural: verticalpodautoscalercheckpoints
+    singular: verticalpodautoscalercheckpoint
+    kind: VerticalPodAutoscalerCheckpoint
+    shortNames:
+    - vpacheckpoint
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1beta2
+    served: true
+    storage: true

--- a/controllers/provider-gcp/charts/internal/machine-controller-manager/seed/templates/clusterrole.yaml
+++ b/controllers/provider-gcp/charts/internal/machine-controller-manager/seed/templates/clusterrole.yaml
@@ -3,6 +3,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: extensions.gardener.cloud:{{ .Values.providerName }}:{{ .Release.Namespace }}:machine-controller-manager
+  ownerReferences:
+  - apiVersion: v1
+    kind: Namespace
+    name: {{ .Release.Namespace }}
+    uid: {{ .Values.namespace.uid }}
+    controller: true
+    blockOwnerDeletion: true
 rules:
 - apiGroups:
   - machine.sapcloud.io

--- a/controllers/provider-gcp/example/20-crd-managedresource.yaml
+++ b/controllers/provider-gcp/example/20-crd-managedresource.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: managedresources.resources.gardener.cloud
+spec:
+  group: resources.gardener.cloud
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: managedresources
+    singular: managedresource
+    kind: ManagedResource
+    shortNames:
+    - mr
+  additionalPrinterColumns:
+  - name: Class
+    type: string
+    JSONPath: .spec.class
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}

--- a/controllers/provider-gcp/example/20-crd-operatingsystemconfig.yaml
+++ b/controllers/provider-gcp/example/20-crd-operatingsystemconfig.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: operatingsystemconfigs.extensions.gardener.cloud
+spec:
+  group: extensions.gardener.cloud
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: operatingsystemconfigs
+    singular: operatingsystemconfig
+    kind: OperatingSystemConfig
+    shortNames:
+    - osc
+  additionalPrinterColumns:
+  - name: Type
+    type: string
+    description: The type of the operating system configuration.
+    JSONPath: .spec.type
+  - name: State
+    type: string
+    JSONPath: .status.lastOperation.state
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}

--- a/controllers/provider-gcp/example/20-crd-vpa.yaml
+++ b/controllers/provider-gcp/example/20-crd-vpa.yaml
@@ -1,0 +1,60 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: verticalpodautoscalers.autoscaling.k8s.io
+spec:
+  group: autoscaling.k8s.io
+  scope: Namespaced
+  names:
+    plural: verticalpodautoscalers
+    singular: verticalpodautoscaler
+    kind: VerticalPodAutoscaler
+    shortNames:
+    - vpa
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1beta2
+    served: true
+    storage: true
+  validation:
+    # openAPIV3Schema is the schema for validating custom objects.
+    openAPIV3Schema:
+      properties:
+        spec:
+          required: []
+          properties:
+            targetRef:
+              type: object
+            updatePolicy:
+              properties:
+                updateMode:
+                  type: string
+            resourcePolicy:
+              properties:
+                containerPolicies:
+                  type: array
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: verticalpodautoscalercheckpoints.autoscaling.k8s.io
+spec:
+  group: autoscaling.k8s.io
+  scope: Namespaced
+  names:
+    plural: verticalpodautoscalercheckpoints
+    singular: verticalpodautoscalercheckpoint
+    kind: VerticalPodAutoscalerCheckpoint
+    shortNames:
+    - vpacheckpoint
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1beta2
+    served: true
+    storage: true

--- a/controllers/provider-openstack/charts/internal/machine-controller-manager/seed/templates/clusterrole.yaml
+++ b/controllers/provider-openstack/charts/internal/machine-controller-manager/seed/templates/clusterrole.yaml
@@ -3,6 +3,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: extensions.gardener.cloud:{{ .Values.providerName }}:{{ .Release.Namespace }}:machine-controller-manager
+  ownerReferences:
+  - apiVersion: v1
+    kind: Namespace
+    name: {{ .Release.Namespace }}
+    uid: {{ .Values.namespace.uid }}
+    controller: true
+    blockOwnerDeletion: true
 rules:
 - apiGroups:
   - machine.sapcloud.io

--- a/controllers/provider-openstack/example/20-crd-managedresource.yaml
+++ b/controllers/provider-openstack/example/20-crd-managedresource.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: managedresources.resources.gardener.cloud
+spec:
+  group: resources.gardener.cloud
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: managedresources
+    singular: managedresource
+    kind: ManagedResource
+    shortNames:
+    - mr
+  additionalPrinterColumns:
+  - name: Class
+    type: string
+    JSONPath: .spec.class
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}

--- a/controllers/provider-openstack/example/20-crd-operatingsystemconfig.yaml
+++ b/controllers/provider-openstack/example/20-crd-operatingsystemconfig.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: operatingsystemconfigs.extensions.gardener.cloud
+spec:
+  group: extensions.gardener.cloud
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: operatingsystemconfigs
+    singular: operatingsystemconfig
+    kind: OperatingSystemConfig
+    shortNames:
+    - osc
+  additionalPrinterColumns:
+  - name: Type
+    type: string
+    description: The type of the operating system configuration.
+    JSONPath: .spec.type
+  - name: State
+    type: string
+    JSONPath: .status.lastOperation.state
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}

--- a/controllers/provider-openstack/example/20-crd-vpa.yaml
+++ b/controllers/provider-openstack/example/20-crd-vpa.yaml
@@ -1,0 +1,60 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: verticalpodautoscalers.autoscaling.k8s.io
+spec:
+  group: autoscaling.k8s.io
+  scope: Namespaced
+  names:
+    plural: verticalpodautoscalers
+    singular: verticalpodautoscaler
+    kind: VerticalPodAutoscaler
+    shortNames:
+    - vpa
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1beta2
+    served: true
+    storage: true
+  validation:
+    # openAPIV3Schema is the schema for validating custom objects.
+    openAPIV3Schema:
+      properties:
+        spec:
+          required: []
+          properties:
+            targetRef:
+              type: object
+            updatePolicy:
+              properties:
+                updateMode:
+                  type: string
+            resourcePolicy:
+              properties:
+                containerPolicies:
+                  type: array
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: verticalpodautoscalercheckpoints.autoscaling.k8s.io
+spec:
+  group: autoscaling.k8s.io
+  scope: Namespaced
+  names:
+    plural: verticalpodautoscalercheckpoints
+    singular: verticalpodautoscalercheckpoint
+    kind: VerticalPodAutoscalerCheckpoint
+    shortNames:
+    - vpacheckpoint
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1beta2
+    served: true
+    storage: true

--- a/controllers/provider-packet/charts/internal/machine-controller-manager/seed/templates/clusterrole.yaml
+++ b/controllers/provider-packet/charts/internal/machine-controller-manager/seed/templates/clusterrole.yaml
@@ -3,6 +3,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: extensions.gardener.cloud:{{ .Values.providerName }}:{{ .Release.Namespace }}:machine-controller-manager
+  ownerReferences:
+  - apiVersion: v1
+    kind: Namespace
+    name: {{ .Release.Namespace }}
+    uid: {{ .Values.namespace.uid }}
+    controller: true
+    blockOwnerDeletion: true
 rules:
 - apiGroups:
   - machine.sapcloud.io

--- a/controllers/provider-packet/example/20-crd-managedresource.yaml
+++ b/controllers/provider-packet/example/20-crd-managedresource.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: managedresources.resources.gardener.cloud
+spec:
+  group: resources.gardener.cloud
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: managedresources
+    singular: managedresource
+    kind: ManagedResource
+    shortNames:
+    - mr
+  additionalPrinterColumns:
+  - name: Class
+    type: string
+    JSONPath: .spec.class
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}

--- a/controllers/provider-packet/example/20-crd-operatingsystemconfig.yaml
+++ b/controllers/provider-packet/example/20-crd-operatingsystemconfig.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: operatingsystemconfigs.extensions.gardener.cloud
+spec:
+  group: extensions.gardener.cloud
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: operatingsystemconfigs
+    singular: operatingsystemconfig
+    kind: OperatingSystemConfig
+    shortNames:
+    - osc
+  additionalPrinterColumns:
+  - name: Type
+    type: string
+    description: The type of the operating system configuration.
+    JSONPath: .spec.type
+  - name: State
+    type: string
+    JSONPath: .status.lastOperation.state
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}

--- a/controllers/provider-packet/example/20-crd-vpa.yaml
+++ b/controllers/provider-packet/example/20-crd-vpa.yaml
@@ -1,0 +1,60 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: verticalpodautoscalers.autoscaling.k8s.io
+spec:
+  group: autoscaling.k8s.io
+  scope: Namespaced
+  names:
+    plural: verticalpodautoscalers
+    singular: verticalpodautoscaler
+    kind: VerticalPodAutoscaler
+    shortNames:
+    - vpa
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1beta2
+    served: true
+    storage: true
+  validation:
+    # openAPIV3Schema is the schema for validating custom objects.
+    openAPIV3Schema:
+      properties:
+        spec:
+          required: []
+          properties:
+            targetRef:
+              type: object
+            updatePolicy:
+              properties:
+                updateMode:
+                  type: string
+            resourcePolicy:
+              properties:
+                containerPolicies:
+                  type: array
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: verticalpodautoscalercheckpoints.autoscaling.k8s.io
+spec:
+  group: autoscaling.k8s.io
+  scope: Namespaced
+  names:
+    plural: verticalpodautoscalercheckpoints
+    singular: verticalpodautoscalercheckpoint
+    kind: VerticalPodAutoscalerCheckpoint
+    shortNames:
+    - vpacheckpoint
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1beta2
+    served: true
+    storage: true

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,7 @@ github.com/gardener/gardener v0.0.0-20190830053951-194cf8abb797/go.mod h1:UjyQiG
 github.com/gardener/gardener v0.0.0-20191004085047-5707d498b40c/go.mod h1:zvajWsteDY43oECil7ADr4NNp88CMltFEutUp1jX+zA=
 github.com/gardener/gardener v0.0.0-20191017105650-90c425422051 h1:7fZhgC6hYuX4ook05AbUGyYik1reZYmWFWiWYXdM0Vc=
 github.com/gardener/gardener v0.0.0-20191017105650-90c425422051/go.mod h1:EPowOY6iwWqit6mED3UOQv72bodT3YlYe/xnZHjvHWY=
+github.com/gardener/gardener v0.0.0-20191018053912-96b796da32f7 h1:AOsg4FBTtBbt/Y8+6/YMGJ9JgJ4wTJbDU04FKJkqKrw=
 github.com/gardener/gardener-extensions v0.0.0-20190725050243-a80ef643c64b/go.mod h1:uXjtl3KeVdQXuGIP26+84wJY1Kwru67l0FXm7A5DiME=
 github.com/gardener/gardener-extensions v0.0.0-20190820050625-a15de8a82f6b/go.mod h1:q69+1cUGSfQ8gSMWzU7GFz/R8K8MpOLQBT2wJJcCjEA=
 github.com/gardener/gardener-extensions v0.0.0-20190906160200-5c329d46ae81/go.mod h1:OBUAbab8OMm8pvzr/1/cdwIQnQYuMoGDTNR2c+i9nYo=


### PR DESCRIPTION
**What this PR does / why we need it**:
Today, the created cluster roles for MCM never get cleaned up. With this owner reference we ensure that, as soon as the shoot namespace in the seed is deleted, the garbage collector also deletes this cluster role.

**Special notes for your reviewer**:
Along the way I added a few missing example CRDs to the provider extensions example directories.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `Worker` controller of all provider extensions does now properly ensure clean-up of its created `ClusterRole`s for the machine-controller-manager after shoot deletion.
```
