### PR TITLE
Reduce limits for control plane components for which VPA is deployed

### DIFF
--- a/controllers/provider-alicloud/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/controllers/provider-alicloud/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -74,8 +74,8 @@ spec:
             cpu: 50m
             memory: 64Mi
           limits:
-            cpu: "3"
-            memory: 3000Mi
+            cpu: 350m
+            memory: 256Mi
         volumeMounts:
         - mountPath: /var/lib/machine-controller-manager
           name: machine-controller-manager

--- a/controllers/provider-aws/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/controllers/provider-aws/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -74,8 +74,8 @@ spec:
             cpu: 50m
             memory: 64Mi
           limits:
-            cpu: "3"
-            memory: 3000Mi
+            cpu: 350m
+            memory: 256Mi
         volumeMounts:
         - mountPath: /var/lib/machine-controller-manager
           name: machine-controller-manager

--- a/controllers/provider-azure/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/controllers/provider-azure/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -74,8 +74,8 @@ spec:
             cpu: 50m
             memory: 64Mi
           limits:
-            cpu: "3"
-            memory: 3000Mi
+            cpu: 350m
+            memory: 256Mi
         volumeMounts:
         - mountPath: /var/lib/machine-controller-manager
           name: machine-controller-manager

--- a/controllers/provider-gcp/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/controllers/provider-gcp/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -74,8 +74,8 @@ spec:
             cpu: 50m
             memory: 64Mi
           limits:
-            cpu: "3"
-            memory: 3000Mi
+            cpu: 350m
+            memory: 256Mi
         volumeMounts:
         - mountPath: /var/lib/machine-controller-manager
           name: machine-controller-manager

--- a/controllers/provider-openstack/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/controllers/provider-openstack/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -74,8 +74,8 @@ spec:
             cpu: 50m
             memory: 64Mi
           limits:
-            cpu: "3"
-            memory: 3000Mi
+            cpu: 350m
+            memory: 256Mi
         volumeMounts:
         - mountPath: /var/lib/machine-controller-manager
           name: machine-controller-manager

--- a/controllers/provider-packet/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/controllers/provider-packet/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -74,8 +74,8 @@ spec:
             cpu: 50m
             memory: 64Mi
           limits:
-            cpu: "3"
-            memory: 3000Mi
+            cpu: 350m
+            memory: 256Mi
         volumeMounts:
         - mountPath: /var/lib/machine-controller-manager
           name: machine-controller-manager


### PR DESCRIPTION
**What this PR does / why we need it**:
Reduce limits for control plane components for which VPA is deployed. The `limits` are now controlled by VPA in its version 0.6+

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
