### PR TITLE
Azure: Avoid parallel LoadBalancer operations

### DIFF
--- a/controllers/provider-azure/charts/internal/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/controllers/provider-azure/charts/internal/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -63,7 +63,7 @@ spec:
         - --cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf
         - --cluster-cidr={{ .Values.podNetwork }}
         - --cluster-name={{ .Values.clusterName }}
-        - --concurrent-service-syncs=10
+        - --concurrent-service-syncs=1
         - --configure-cloud-routes=true
         {{- include "cloud-controller-manager.featureGates" . | trimSuffix "," | indent 8 }}
         - --kubeconfig=/var/lib/cloud-controller-manager/kubeconfig


### PR DESCRIPTION
Set concurrent-service-syncs to 1 for Azure Cloud Controller Managers to avoid parallel operations on the Shoot LoadBalancer on Azure which cause inconsistencies in the LoadBalancer configuration.
This is a workaround (probably also the fix) for https://github.com/kubernetes/kubernetes/issues/84052

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue with parallel LoadBalancer updates on Azure which caused inconsistencies in the LoadBalancer configuration is now fixed by disabling concurrent LoadBalancer operation executed by the Azure Cloud Controller Manager. Latest k8s version can be consumed again.
```
