### PR TITLE
Bump Gardener version to fix vendor issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/aliyun/aliyun-oss-go-sdk v2.0.1+incompatible
 	github.com/aws/aws-sdk-go v1.21.10
 	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
-	github.com/gardener/gardener v0.0.0-20191025063857-c27ebd04a82b
+	github.com/gardener/gardener v0.0.0-20191028054636-32cb0027c126
 	github.com/gardener/gardener-resource-manager v0.0.0-20191025075317-09173887c1a7
 	github.com/gardener/machine-controller-manager v0.0.0-20190606071036-119056ee3fdd
 	github.com/go-logr/logr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -168,9 +168,8 @@ github.com/gardener/gardener v0.0.0-20190812144748-dec8f3c7f288/go.mod h1:ioI69P
 github.com/gardener/gardener v0.0.0-20190830053951-194cf8abb797/go.mod h1:UjyQiGrjIRJQ82t2PTqtdMXzJxqH/ftQ36jbpFxAWXw=
 github.com/gardener/gardener v0.0.0-20190913144920-5b4adb9f114d/go.mod h1:8LOLWzproKzfww5LdDo0/7FyVQR7gR1QA5LQc5buDzQ=
 github.com/gardener/gardener v0.0.0-20191004085047-5707d498b40c/go.mod h1:zvajWsteDY43oECil7ADr4NNp88CMltFEutUp1jX+zA=
-github.com/gardener/gardener v0.0.0-20191025063857-c27ebd04a82b h1:bkVdRJTQftPSy38uSjz+LnRVACdNTSXCoqfMjmi5Hig=
-github.com/gardener/gardener v0.0.0-20191025063857-c27ebd04a82b/go.mod h1:/quV7aGxbIjc9+XNTsJi9R5nvLhFOrvgrKDdHjJCMVI=
-github.com/gardener/gardener v0.0.0-20191025080333-9dd60d49eaed h1:FdB5WQJpcuunAFksuRv2d+oxz1tfOD05+GpTTNzCbbE=
+github.com/gardener/gardener v0.0.0-20191028054636-32cb0027c126 h1:brwVrGihGciQKSZC/TbylOKFv+LX70i4lR+rGwRlZxs=
+github.com/gardener/gardener v0.0.0-20191028054636-32cb0027c126/go.mod h1:Ow7vOXQYgQeHTRFn2HdbEIptelrSB5NLmVFIt2rgNeY=
 github.com/gardener/gardener-extensions v0.0.0-20190725050243-a80ef643c64b/go.mod h1:uXjtl3KeVdQXuGIP26+84wJY1Kwru67l0FXm7A5DiME=
 github.com/gardener/gardener-extensions v0.0.0-20190820050625-a15de8a82f6b/go.mod h1:q69+1cUGSfQ8gSMWzU7GFz/R8K8MpOLQBT2wJJcCjEA=
 github.com/gardener/gardener-extensions v0.0.0-20190906160200-5c329d46ae81/go.mod h1:OBUAbab8OMm8pvzr/1/cdwIQnQYuMoGDTNR2c+i9nYo=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -136,7 +136,7 @@ github.com/gardener/controller-manager-library/pkg/utils
 github.com/gardener/external-dns-management/pkg/apis/dns
 github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1
 github.com/gardener/external-dns-management/pkg/client/dns/clientset/versioned/scheme
-# github.com/gardener/gardener v0.0.0-20191025063857-c27ebd04a82b
+# github.com/gardener/gardener v0.0.0-20191028054636-32cb0027c126
 github.com/gardener/gardener/pkg/api/extensions
 github.com/gardener/gardener/pkg/apis/core
 github.com/gardener/gardener/pkg/apis/core/v1alpha1


### PR DESCRIPTION
The dependency Gardener in version `c27ebd04a82b` has an invalid dependency `github.com/gardener/external-dns-management v0.0.0-20190220100540-eb4bbb5832a03` (not existing commit hash -> `b4bbb5832a03`).

@ialidzhikov fixed this it in Gardener with commit `82369df93f78` (https://github.com/gardener/gardener/commit/82369df93f78e7b585efe98911a73b80046038a6). We need to use this commit or higher to use the extension repo as dependency in Gardener.

Vendoring the `gardener-extension` in Gardener failed with this issue:
```
go: github.com/gardener/gardener-extensions@v0.0.0-20191028054109-f37a873929da requires
	github.com/gardener/gardener@v0.0.0-20191025063857-c27ebd04a82b requires
	github.com/gardener/external-dns-management@v0.0.0-20190220100540-eb4bbb5832a03: invalid version: unknown revision eb4bbb5832a03
```
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```NONE

```
