### PR TITLE
Revert "include controller dirname in logical image name"

### DIFF
--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -9,7 +9,6 @@ for images_yaml_path in "$dir/../controllers/"*"/charts/images.yaml"; do
   images="$(yaml2json < $images_yaml_path)"
 
   echo "enriching creating component descriptor from ${BASE_DEFINITION_PATH}"
-  controller_dir="$(basename "$(dirname "$(dirname "${images_yaml_path}")")")"
 
   eval "$(jq -r ".images |
     map(if (.name == \"hyperkube\" or .repository == \"k8s.gcr.io/hyperkube\") then
@@ -17,7 +16,7 @@ for images_yaml_path in "$dir/../controllers/"*"/charts/images.yaml"; do
     elif (.repository | startswith(\"eu.gcr.io/gardener-project\")) then
       \"--component-dependencies '{\\\"name\\\": \\\"\" + .sourceRepository + \"\\\", \\\"version\\\": \\\"\" + .tag + \"\\\"}'\"
     else
-      \"--container-image-dependencies '{\\\"name\\\": \\\"${controller_dir}-\" + .name + \"\\\", \\\"image_reference\\\": \\\"\" + .repository + \":\" + .tag + \"\\\", \\\"version\\\": \\\"\" + .tag + \"\\\"}'\"
+      \"--container-image-dependencies '{\\\"name\\\": \\\"\" + .name + \"\\\", \\\"image_reference\\\": \\\"\" + .repository + \":\" + .tag + \"\\\", \\\"version\\\": \\\"\" + .tag + \"\\\"}'\"
     end) |
     \"${ADD_DEPENDENCIES_CMD} \\\\\n\" +
     join(\" \\\\\n\")" <<< "$images")"


### PR DESCRIPTION
We now can handle the same container image with the same name and different version, so this workaround is
not neede anymore.

This reverts commit b6e58bd577608459c8b3a812a788687f524e6a8c.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
