### PR TITLE
Fix machineclass generation for cloudnat

### DIFF
--- a/controllers/provider-gcp/charts/internal/machineclass/templates/machineclass.yaml
+++ b/controllers/provider-gcp/charts/internal/machineclass/templates/machineclass.yaml
@@ -19,7 +19,6 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   canIpForward: {{ $machineClass.canIpForward }}
-  disableExternalIP: {{ $machineClass.disableExternalIP }}
   deletionProtection: {{ $machineClass.deletionProtection }}
   description: {{ $machineClass.description }}
   disks:

--- a/controllers/provider-gcp/charts/internal/machineclass/values.yaml
+++ b/controllers/provider-gcp/charts/internal/machineclass/values.yaml
@@ -3,7 +3,6 @@ machineClasses:
   region: europe-west1
   zone: europe-west1-b
   canIpForward: true
-  disableExternalIP: true
   deletionProtection: false
   description: An optional description for machines created by that class.
   disks:
@@ -19,6 +18,7 @@ machineClasses:
   machineType: n1-standard-4
   networkInterfaces:
   - subnetwork: my-subnet
+    disableExternalIP: true
   scheduling:
     automaticRestart: true
     onHostMaintenance: MIGRATE

--- a/controllers/provider-gcp/pkg/controller/worker/machines.go
+++ b/controllers/provider-gcp/pkg/controller/worker/machines.go
@@ -137,7 +137,6 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				"region":             w.worker.Spec.Region,
 				"zone":               zone,
 				"canIpForward":       true,
-				"disableExternalIP":  true,
 				"deletionProtection": false,
 				"description":        fmt.Sprintf("Machine of Shoot %s created by machine-controller-manager.", w.worker.Name),
 				"disks":              []map[string]interface{}{disk},
@@ -147,7 +146,8 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				"machineType": pool.MachineType,
 				"networkInterfaces": []map[string]interface{}{
 					{
-						"subnetwork": nodesSubnet.Name,
+						"disableExternalIP": true,
+						"subnetwork":        nodesSubnet.Name,
 					},
 				},
 				"scheduling": map[string]interface{}{

--- a/controllers/provider-gcp/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-gcp/pkg/controller/worker/machines_test.go
@@ -262,7 +262,6 @@ var _ = Describe("Machines", func() {
 				var (
 					defaultMachineClass = map[string]interface{}{
 						"region":             region,
-						"disableExternalIP":  true,
 						"canIpForward":       true,
 						"deletionProtection": false,
 						"description":        fmt.Sprintf("Machine of Shoot %s created by machine-controller-manager.", name),
@@ -284,7 +283,8 @@ var _ = Describe("Machines", func() {
 						"machineType": machineType,
 						"networkInterfaces": []map[string]interface{}{
 							{
-								"subnetwork": subnetName,
+								"subnetwork":        subnetName,
+								"disableExternalIP": true,
 							},
 						},
 						"scheduling": map[string]interface{}{


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix machine class generate for disabling public IPs. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
An issue that prevented GCP shoot worker nodes from getting external IP addresses has been fixed.
```
