### PR TITLE
JeOS: ensure required packages are installed

### DIFF
--- a/controllers/os-suse-jeos/pkg/generator/templates/cloud-init-suse-jeos.template
+++ b/controllers/os-suse-jeos/pkg/generator/templates/cloud-init-suse-jeos.template
@@ -26,6 +26,7 @@ write_files:
 {{- end -}}
 {{- end }}
 runcmd:
+- "until zypper -q install -y docker wget socat jq nfs-client; [ $? -ne 7 ]; do sleep 1; done"
 - systemctl daemon-reload
 {{ if .Bootstrap -}}
 - ln -s /usr/bin/docker /bin/docker

--- a/controllers/os-suse-jeos/pkg/generator/testfiles/cloud-init
+++ b/controllers/os-suse-jeos/pkg/generator/testfiles/cloud-init
@@ -14,6 +14,7 @@ write_files:
   content: |
     b3ZlcnJpZGU=
 runcmd:
+- "until zypper -q install -y docker wget socat jq nfs-client; [ $? -ne 7 ]; do sleep 1; done"
 - systemctl daemon-reload
 - ln -s /usr/bin/docker /bin/docker
 - systemctl start docker


### PR DESCRIPTION
**What this PR does / why we need it**:

The PR adds the code, which ensures that required packages are installed in SUSE OS.

**Which issue(s) this PR fixes**:
Fixes #399

**Special notes for your reviewer**:

I put the package installation into the loop, because zypper lock file can be in place during the boot. Default cloud-init `packages:` can fail because of this and packages can be missing during the boot.

7 return code means that the zypper is locked: [ZYPPER_EXIT_ZYPP_LOCKED](https://en.opensuse.org/SDB:Zypper_manual_(plain))

Even if the `zypper install` fails, the further commands in the `runcmd:` list will be executed. If the packages are already installed and there are no repos configured, zypper will just return 0.

**Release note**:

```improvement operator
Ensure required packages are installed in JeOS
```

/cc @vpnachev 