### PR TITLE
Azure: Enable os disk configuration

### DIFF
--- a/controllers/provider-azure/charts/internal/machineclass/templates/machineclass.yaml
+++ b/controllers/provider-azure/charts/internal/machineclass/templates/machineclass.yaml
@@ -49,7 +49,11 @@ spec:
         urn: {{ $machineClass.image.urn }}
       osDisk:
         caching: None
-        diskSizeGB: {{ $machineClass.volumeSize }}
+        diskSizeGB: {{ $machineClass.osDisk.size }}
+        {{- if hasKey $machineClass.osDisk "type" }}
+        managedDisk:
+          storageAccountType: {{ $machineClass.osDisk.type }}
+        {{- end }}
         createOption: FromImage
   resourceGroup: {{ $machineClass.resourceGroup }}
   secretRef:

--- a/controllers/provider-azure/charts/internal/machineclass/values.yaml
+++ b/controllers/provider-azure/charts/internal/machineclass/values.yaml
@@ -22,7 +22,9 @@ machineClasses:
     sku: Stable # TODO: remove these deprecated field after couple of releases
     version: "1576.5.0" # TODO: remove these deprecated field after couple of releases
     urn: "CoreOS:CoreOS:Stable:1576.5.0"
-  volumeSize: 50
+  osDisk:
+    size: 50
+    #type: Standard_LRS
   sshPublicKey: ssh-rsa AAAAB3...
 - name: class-2-availability-set
   region: westeurope
@@ -47,5 +49,7 @@ machineClasses:
     sku: Stable # TODO: remove these deprecated field after couple of releases
     version: "1576.5.0" # TODO: remove these deprecated field after couple of releases
     urn: "CoreOS:CoreOS:Stable:1576.5.0"
-  volumeSize: 50
+  osDisk:
+    size: 50
+    type: Standard_LRS
   sshPublicKey: ssh-rsa AAAAB3...

--- a/controllers/provider-azure/docs/usage-as-end-user.md
+++ b/controllers/provider-azure/docs/usage-as-end-user.md
@@ -123,7 +123,7 @@ spec:
       maximum: 2
       volume:
         size: 50Gi
-        type: standard
+        type: Standard_LRS
   networking:
     nodes: 10.250.0.0/16
     type: calico
@@ -175,7 +175,7 @@ spec:
       maximum: 2
       volume:
         size: 50Gi
-        type: standard
+        type: Standard_LRS
       zones:
       - "1"
       - "2"

--- a/controllers/provider-azure/docs/usage-as-operator.md
+++ b/controllers/provider-azure/docs/usage-as-operator.md
@@ -29,6 +29,8 @@ machineImages:
 
 ## Example `CloudProfile` manifest
 
+The possible values for `.spec.volumeTypes[].name` on Azure are `Standard_LRS`, `StandardSSD_LRS` and `Premium_LRS`. There is another volume type called `UltraSSD_LRS` but this type is not supported to use as os disk. If an end user select a volume type whose name is not equal to one of the valid values then the machine will be created with the default volume type which belong to the selected machine type. Therefore it is recommended to configure only the valid values for the `.spec.volumeType[].name` in the `CloudProfile`.
+
 Please find below an example `CloudProfile` manifest:
 
 ```yaml
@@ -53,10 +55,13 @@ spec:
     gpu: "0"
     memory: 16Gi
   volumeTypes:
-  - name: standard
+  - name: Standard_LRS
     class: standard
     usable: true
-  - name: premium
+  - name: StandardSSD_LRS
+    class: premium
+    usable: false
+  - name: Premium_LRS
     class: premium
     usable: false
   regions:

--- a/controllers/provider-azure/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-azure/pkg/controller/worker/machines_test.go
@@ -292,7 +292,9 @@ var _ = Describe("Machines", func() {
 							"version":   machineImageVersion,
 							"urn":       machineImageURN,
 						},
-						"volumeSize":   volumeSize,
+						"osDisk": map[string]interface{}{
+							"size": volumeSize,
+						},
 						"sshPublicKey": sshKey,
 					}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the Azure provider extension does not pass the configured os volume type to the `AzureMachineClass` and the machine-controller-manager will in consequence create machines always with the default os disk belonging to the requested machine type.

This will now change. The Azure provider will write the volume type now to the `AzureMachineClass`, but only if the passed volume type is a valid Azure volume type. Otherwise the default volume type of the machine type will be used.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The os volume type configuration for worker machines of Azure Shoot cluster will be now passed correctly, but only if the selected volume type is a valid Azure volume type.

This will trigger a rolling update of all machines in the cluster during the maintenance window, if configured.
```
