### PR TITLE
Fix invalid check in control plane values provider for AWS

### DIFF
--- a/controllers/provider-aws/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-aws/pkg/controller/controlplane/valuesprovider.go
@@ -196,7 +196,7 @@ func (vp *valuesProvider) GetConfigChartValues(
 ) (map[string]interface{}, error) {
 	// Decode infrastructureProviderStatus
 	infraStatus := &apisaws.InfrastructureStatus{}
-	if cp.Spec.ProviderConfig != nil {
+	if cp.Spec.InfrastructureProviderStatus != nil {
 		if _, _, err := vp.decoder.Decode(cp.Spec.InfrastructureProviderStatus.Raw, nil, infraStatus); err != nil {
 			return nil, errors.Wrapf(err, "could not decode infrastructureProviderStatus of controlplane '%s'", util.ObjectName(cp))
 		}
@@ -254,7 +254,7 @@ func getConfigChartValues(
 	infraStatus *apisaws.InfrastructureStatus,
 	cp *extensionsv1alpha1.ControlPlane,
 ) (map[string]interface{}, error) {
-	// Get the first subnet with purpose "nodes"
+	// Get the first subnet with purpose "public"
 	subnet, err := helper.FindSubnetForPurpose(infraStatus.VPC.Subnets, apisaws.PurposePublic)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not determine subnet from infrastructureProviderStatus of controlplane '%s'", util.ObjectName(cp))


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix an invalid check in the control plane values provider for AWS.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
An issue that prevented the control plane deployment for AWS shoots that don't specify a `controlPlaneConfig` in the `Shoot` specification has been resolved.
```
