### PR TITLE
Revert GCP CloudNat

### DIFF
--- a/controllers/provider-gcp/charts/internal/gcp-infra/templates/main.tf
+++ b/controllers/provider-gcp/charts/internal/gcp-infra/templates/main.tf
@@ -31,29 +31,6 @@ resource "google_compute_subnetwork" "subnetwork-nodes" {
   region        = "{{ required "google.region is required" .Values.google.region }}"
 }
 
-resource "google_compute_router" "router"{
-  name    = "{{ required "clusterName is required" .Values.clusterName }}-cloud-router"
-  region  = "{{ required "google.region is required" .Values.google.region }}"
-  network = "{{ required "vpc.name is required" .Values.vpc.name }}"
-
-  bgp {
-    asn = 64514
-  }
-}
-
-resource "google_compute_router_nat" "nat" {
-  name                               = "{{ required "clusterName is required" .Values.clusterName }}-cloud-nat"
-  router                             = "${google_compute_router.router.name}"
-  region                             = "{{ required "google.region is required" .Values.google.region }}"
-  nat_ip_allocate_option             = "AUTO_ONLY"
-  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
-
-  log_config {
-    enable = true
-    filter = "ERRORS_ONLY"
-  }
-}
-
 {{ if .Values.networks.internal -}}
 resource "google_compute_subnetwork" "subnetwork-internal" {
   name          = "{{ required "clusterName is required" .Values.clusterName }}-internal"
@@ -62,8 +39,6 @@ resource "google_compute_subnetwork" "subnetwork-internal" {
   region        = "{{ required "google.region is required" .Values.google.region }}"
 }
 {{- end}}
-
-
 //=====================================================================
 //= Firewall
 //=====================================================================
@@ -144,14 +119,6 @@ resource "null_resource" "outputs" {
 
 output "{{ .Values.outputKeys.vpcName }}" {
   value = "{{ required "vpc.name is required" .Values.vpc.name }}"
-}
-
-output "{{ .Values.outputKeys.cloudRouter }}" {
-  value = "${google_compute_router.router.name}"
-}
-
-output "{{ .Values.outputKeys.cloudNAT }}" {
-  value = "${google_compute_router_nat.nat.name}"
 }
 
 output "{{ .Values.outputKeys.serviceAccountEmail }}" {

--- a/controllers/provider-gcp/charts/internal/gcp-infra/values.yaml
+++ b/controllers/provider-gcp/charts/internal/gcp-infra/values.yaml
@@ -18,8 +18,6 @@ networks:
 
 outputKeys:
   vpcName: vpc_name
-  cloudNAT: cloud_nat
-  cloudRouter: cloud_router
   subnetNodes: subnet_nodes
   serviceAccountEmail: service_account_email
   subnetInternal: subnet_internal

--- a/controllers/provider-gcp/charts/internal/machineclass/templates/machineclass.yaml
+++ b/controllers/provider-gcp/charts/internal/machineclass/templates/machineclass.yaml
@@ -19,7 +19,6 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   canIpForward: {{ $machineClass.canIpForward }}
-  disableExternalIP: {{ $machineClass.disableExternalIP }}
   deletionProtection: {{ $machineClass.deletionProtection }}
   description: {{ $machineClass.description }}
   disks:

--- a/controllers/provider-gcp/charts/internal/machineclass/templates/machineclass.yaml
+++ b/controllers/provider-gcp/charts/internal/machineclass/templates/machineclass.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   canIpForward: {{ $machineClass.canIpForward }}
+  disableExternalIP: {{ $machineClass.disableExternalIP }}
   deletionProtection: {{ $machineClass.deletionProtection }}
   description: {{ $machineClass.description }}
   disks:

--- a/controllers/provider-gcp/charts/internal/machineclass/values.yaml
+++ b/controllers/provider-gcp/charts/internal/machineclass/values.yaml
@@ -3,6 +3,7 @@ machineClasses:
   region: europe-west1
   zone: europe-west1-b
   canIpForward: true
+  disableExternalIP: true
   deletionProtection: false
   description: An optional description for machines created by that class.
   disks:
@@ -18,7 +19,6 @@ machineClasses:
   machineType: n1-standard-4
   networkInterfaces:
   - subnetwork: my-subnet
-    disableExternalIP: true
   scheduling:
     automaticRestart: true
     onHostMaintenance: MIGRATE

--- a/controllers/provider-gcp/charts/internal/machineclass/values.yaml
+++ b/controllers/provider-gcp/charts/internal/machineclass/values.yaml
@@ -3,7 +3,6 @@ machineClasses:
   region: europe-west1
   zone: europe-west1-b
   canIpForward: true
-  disableExternalIP: true
   deletionProtection: false
   description: An optional description for machines created by that class.
   disks:

--- a/controllers/provider-gcp/pkg/controller/worker/machines.go
+++ b/controllers/provider-gcp/pkg/controller/worker/machines.go
@@ -137,7 +137,6 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				"region":             w.worker.Spec.Region,
 				"zone":               zone,
 				"canIpForward":       true,
-				"disableExternalIP":  true,
 				"deletionProtection": false,
 				"description":        fmt.Sprintf("Machine of Shoot %s created by machine-controller-manager.", w.worker.Name),
 				"disks":              []map[string]interface{}{disk},

--- a/controllers/provider-gcp/pkg/controller/worker/machines.go
+++ b/controllers/provider-gcp/pkg/controller/worker/machines.go
@@ -137,6 +137,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				"region":             w.worker.Spec.Region,
 				"zone":               zone,
 				"canIpForward":       true,
+				"disableExternalIP":  true,
 				"deletionProtection": false,
 				"description":        fmt.Sprintf("Machine of Shoot %s created by machine-controller-manager.", w.worker.Name),
 				"disks":              []map[string]interface{}{disk},
@@ -146,8 +147,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				"machineType": pool.MachineType,
 				"networkInterfaces": []map[string]interface{}{
 					{
-						"disableExternalIP": true,
-						"subnetwork":        nodesSubnet.Name,
+						"subnetwork": nodesSubnet.Name,
 					},
 				},
 				"scheduling": map[string]interface{}{

--- a/controllers/provider-gcp/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-gcp/pkg/controller/worker/machines_test.go
@@ -262,6 +262,7 @@ var _ = Describe("Machines", func() {
 				var (
 					defaultMachineClass = map[string]interface{}{
 						"region":             region,
+						"disableExternalIP":  true,
 						"canIpForward":       true,
 						"deletionProtection": false,
 						"description":        fmt.Sprintf("Machine of Shoot %s created by machine-controller-manager.", name),
@@ -283,8 +284,7 @@ var _ = Describe("Machines", func() {
 						"machineType": machineType,
 						"networkInterfaces": []map[string]interface{}{
 							{
-								"subnetwork":        subnetName,
-								"disableExternalIP": true,
+								"subnetwork": subnetName,
 							},
 						},
 						"scheduling": map[string]interface{}{

--- a/controllers/provider-gcp/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-gcp/pkg/controller/worker/machines_test.go
@@ -262,7 +262,6 @@ var _ = Describe("Machines", func() {
 				var (
 					defaultMachineClass = map[string]interface{}{
 						"region":             region,
-						"disableExternalIP":  true,
 						"canIpForward":       true,
 						"deletionProtection": false,
 						"description":        fmt.Sprintf("Machine of Shoot %s created by machine-controller-manager.", name),

--- a/controllers/provider-gcp/pkg/internal/infrastructure/terraform.go
+++ b/controllers/provider-gcp/pkg/internal/infrastructure/terraform.go
@@ -37,10 +37,6 @@ const (
 
 	// TerraformerOutputKeyVPCName is the name of the vpc_name terraform output variable.
 	TerraformerOutputKeyVPCName = "vpc_name"
-	// TerraformOutputKeyCloudNAT is the name of the cloud_nat terraform output variable.
-	TerraformOutputKeyCloudNAT = "cloud_nat"
-	// TerraformOutputKeyCloudRouter is the name of the cloud_router terraform output variable.
-	TerraformOutputKeyCloudRouter = "cloud_router"
 	// TerraformerOutputKeyServiceAccountEmail is the name of the service_account_email terraform output variable.
 	TerraformerOutputKeyServiceAccountEmail = "service_account_email"
 	// TerraformerOutputKeySubnetNodes is the name of the subnet_nodes terraform output variable.
@@ -94,8 +90,6 @@ func ComputeTerraformerChartValues(
 		},
 		"outputKeys": map[string]interface{}{
 			"vpcName":             TerraformerOutputKeyVPCName,
-			"cloudNAT":            TerraformOutputKeyCloudNAT,
-			"cloudRouter":         TerraformOutputKeyCloudRouter,
 			"serviceAccountEmail": TerraformerOutputKeyServiceAccountEmail,
 			"subnetNodes":         TerraformerOutputKeySubnetNodes,
 			"subnetInternal":      TerraformerOutputKeySubnetInternal,

--- a/controllers/provider-gcp/pkg/internal/infrastructure/terraform_test.go
+++ b/controllers/provider-gcp/pkg/internal/infrastructure/terraform_test.go
@@ -114,8 +114,6 @@ var _ = Describe("Terraform", func() {
 				},
 				"outputKeys": map[string]interface{}{
 					"vpcName":             TerraformerOutputKeyVPCName,
-					"cloudNAT":            TerraformOutputKeyCloudNAT,
-					"cloudRouter":         TerraformOutputKeyCloudRouter,
 					"serviceAccountEmail": TerraformerOutputKeyServiceAccountEmail,
 					"subnetNodes":         TerraformerOutputKeySubnetNodes,
 					"subnetInternal":      TerraformerOutputKeySubnetInternal,
@@ -147,8 +145,6 @@ var _ = Describe("Terraform", func() {
 				},
 				"outputKeys": map[string]interface{}{
 					"vpcName":             TerraformerOutputKeyVPCName,
-					"cloudNAT":            TerraformOutputKeyCloudNAT,
-					"cloudRouter":         TerraformOutputKeyCloudRouter,
 					"serviceAccountEmail": TerraformerOutputKeyServiceAccountEmail,
 					"subnetNodes":         TerraformerOutputKeySubnetNodes,
 					"subnetInternal":      TerraformerOutputKeySubnetInternal,


### PR DESCRIPTION
**What this PR does / why we need it**:
Revert changes around GCP Cloud Nat
For ref see:
- https://github.com/gardener/gardener-extensions/commit/f046abf660cb3e62dcd1b71773a9cfdd214380a3 
- https://github.com/gardener/gardener-extensions/commit/d75603f0a0bd0dc7162e045ae77c10194873f047


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->

```improvement user
NONE
```