### PR TITLE
Enforce type information for actuators

### DIFF
--- a/controllers/extension-certificate-service/pkg/controller/certservice/add.go
+++ b/controllers/extension-certificate-service/pkg/controller/certservice/add.go
@@ -60,6 +60,7 @@ func AddToManagerWithOptions(mgr manager.Manager, opts controller.Options, confi
 		Name:              ControllerName,
 		FinalizerSuffix:   FinalizerSuffix,
 		Resync:            config.Spec.ServiceSync.Duration,
-		Predicates:        extension.DefaultPredicates(Type, DefaultAddOptions.IgnoreOperationAnnotation),
+		Predicates:        extension.DefaultPredicates(DefaultAddOptions.IgnoreOperationAnnotation),
+		Type:              Type,
 	})
 }

--- a/controllers/extension-shoot-cert-service/pkg/controller/add.go
+++ b/controllers/extension-shoot-cert-service/pkg/controller/add.go
@@ -61,6 +61,7 @@ func AddToManagerWithOptions(mgr manager.Manager, opts controller.Options, confi
 		Name:              ControllerName,
 		FinalizerSuffix:   FinalizerSuffix,
 		Resync:            0,
-		Predicates:        extension.DefaultPredicates(Type, DefaultAddOptions.IgnoreOperationAnnotation),
+		Predicates:        extension.DefaultPredicates(DefaultAddOptions.IgnoreOperationAnnotation),
+		Type:              Type,
 	})
 }

--- a/controllers/extension-shoot-dns-service/pkg/controller/add.go
+++ b/controllers/extension-shoot-dns-service/pkg/controller/add.go
@@ -39,6 +39,7 @@ func AddToManager(mgr manager.Manager) error {
 		Name:              Name,
 		FinalizerSuffix:   FinalizerSuffix,
 		Resync:            60 * time.Minute,
-		Predicates:        extension.DefaultPredicates(service.ExtensionType, config.ServiceConfig.IgnoreOperationAnnotation),
+		Predicates:        extension.DefaultPredicates(config.ServiceConfig.IgnoreOperationAnnotation),
+		Type:              service.ExtensionType,
 	})
 }

--- a/controllers/networking-calico/pkg/controller/add.go
+++ b/controllers/networking-calico/pkg/controller/add.go
@@ -48,7 +48,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return network.Add(mgr, network.AddArgs{
 		Actuator:          NewActuator(extensioncontroller.ChartRendererFactoryFunc(util.NewChartRendererForShoot)),
 		ControllerOptions: opts.Controller,
-		Predicates:        network.DefaultPredicates(calico.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        network.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              calico.Type,
 	})
 }
 

--- a/controllers/os-coreos-alicloud/pkg/coreos-alicloud/add.go
+++ b/controllers/os-coreos-alicloud/pkg/coreos-alicloud/add.go
@@ -43,7 +43,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return operatingsystemconfig.Add(mgr, operatingsystemconfig.AddArgs{
 		Actuator:          NewActuator(),
 		ControllerOptions: opts.Controller,
-		Predicates:        operatingsystemconfig.DefaultPredicates(Type, opts.IgnoreOperationAnnotation),
+		Predicates:        operatingsystemconfig.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              Type,
 	})
 }
 

--- a/controllers/os-coreos/pkg/coreos/add.go
+++ b/controllers/os-coreos/pkg/coreos/add.go
@@ -43,7 +43,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return operatingsystemconfig.Add(mgr, operatingsystemconfig.AddArgs{
 		Actuator:          NewActuator(),
 		ControllerOptions: opts.Controller,
-		Predicates:        operatingsystemconfig.DefaultPredicates(Type, opts.IgnoreOperationAnnotation),
+		Predicates:        operatingsystemconfig.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              Type,
 	})
 }
 

--- a/controllers/provider-alicloud/pkg/controller/backupbucket/add.go
+++ b/controllers/provider-alicloud/pkg/controller/backupbucket/add.go
@@ -41,7 +41,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return backupbucket.Add(mgr, backupbucket.AddArgs{
 		Actuator:          newActuator(),
 		ControllerOptions: opts.Controller,
-		Predicates:        backupbucket.DefaultPredicates(alicloud.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        backupbucket.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              alicloud.Type,
 	})
 }
 

--- a/controllers/provider-alicloud/pkg/controller/backupentry/add.go
+++ b/controllers/provider-alicloud/pkg/controller/backupentry/add.go
@@ -45,7 +45,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return backupentry.Add(mgr, backupentry.AddArgs{
 		Actuator:          genericactuator.NewActuator(newActuator(), logger),
 		ControllerOptions: opts.Controller,
-		Predicates:        backupentry.DefaultPredicates(alicloud.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        backupentry.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              alicloud.Type,
 	})
 }
 

--- a/controllers/provider-alicloud/pkg/controller/controlplane/add.go
+++ b/controllers/provider-alicloud/pkg/controller/controlplane/add.go
@@ -50,7 +50,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 			storageClassChart, nil, NewValuesProvider(logger), extensionscontroller.ChartRendererFactoryFunc(util.NewChartRendererForShoot),
 			imagevector.ImageVector(), alicloud.CloudProviderConfigName, nil, mgr.GetWebhookServer().Port, logger),
 		ControllerOptions: opts.Controller,
-		Predicates:        controlplane.DefaultPredicates(alicloud.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        controlplane.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              alicloud.Type,
 	})
 }
 

--- a/controllers/provider-alicloud/pkg/controller/infrastructure/add.go
+++ b/controllers/provider-alicloud/pkg/controller/infrastructure/add.go
@@ -40,7 +40,8 @@ func AddToManagerWithOptions(mgr manager.Manager, options AddOptions) error {
 	return infrastructure.Add(mgr, infrastructure.AddArgs{
 		Actuator:          NewActuator(),
 		ControllerOptions: options.Controller,
-		Predicates:        infrastructure.DefaultPredicates(alicloud.Type, options.IgnoreOperationAnnotation),
+		Predicates:        infrastructure.DefaultPredicates(options.IgnoreOperationAnnotation),
+		Type:              alicloud.Type,
 	})
 }
 

--- a/controllers/provider-alicloud/pkg/controller/worker/add.go
+++ b/controllers/provider-alicloud/pkg/controller/worker/add.go
@@ -53,7 +53,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return worker.Add(mgr, worker.AddArgs{
 		Actuator:          NewActuator(opts.MachineImages),
 		ControllerOptions: opts.Controller,
-		Predicates:        worker.DefaultPredicates(alicloud.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        worker.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              alicloud.Type,
 	})
 }
 

--- a/controllers/provider-aws/pkg/controller/backupbucket/add.go
+++ b/controllers/provider-aws/pkg/controller/backupbucket/add.go
@@ -41,7 +41,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return backupbucket.Add(mgr, backupbucket.AddArgs{
 		Actuator:          newActuator(),
 		ControllerOptions: opts.Controller,
-		Predicates:        backupbucket.DefaultPredicates(aws.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        backupbucket.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              aws.Type,
 	})
 }
 

--- a/controllers/provider-aws/pkg/controller/backupentry/add.go
+++ b/controllers/provider-aws/pkg/controller/backupentry/add.go
@@ -45,7 +45,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return backupentry.Add(mgr, backupentry.AddArgs{
 		Actuator:          genericactuator.NewActuator(newActuator(), logger),
 		ControllerOptions: opts.Controller,
-		Predicates:        backupentry.DefaultPredicates(aws.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        backupentry.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              aws.Type,
 	})
 }
 

--- a/controllers/provider-aws/pkg/controller/controlplane/add.go
+++ b/controllers/provider-aws/pkg/controller/controlplane/add.go
@@ -53,7 +53,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 			storageClassChart, cpExposureChart, NewValuesProvider(logger), extensionscontroller.ChartRendererFactoryFunc(util.NewChartRendererForShoot),
 			imagevector.ImageVector(), aws.CloudProviderConfigName, opts.ShootWebhooks, mgr.GetWebhookServer().Port, logger),
 		ControllerOptions: opts.Controller,
-		Predicates:        controlplane.DefaultPredicates(aws.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        controlplane.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              aws.Type,
 	})
 }
 

--- a/controllers/provider-aws/pkg/controller/infrastructure/add.go
+++ b/controllers/provider-aws/pkg/controller/infrastructure/add.go
@@ -40,7 +40,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return infrastructure.Add(mgr, infrastructure.AddArgs{
 		Actuator:          NewActuator(),
 		ControllerOptions: opts.Controller,
-		Predicates:        infrastructure.DefaultPredicates(aws.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        infrastructure.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              aws.Type,
 	})
 }
 

--- a/controllers/provider-aws/pkg/controller/worker/add.go
+++ b/controllers/provider-aws/pkg/controller/worker/add.go
@@ -53,7 +53,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return worker.Add(mgr, worker.AddArgs{
 		Actuator:          NewActuator(opts.MachineImagesToAMIMapping),
 		ControllerOptions: opts.Controller,
-		Predicates:        worker.DefaultPredicates(aws.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        worker.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              aws.Type,
 	})
 }
 

--- a/controllers/provider-azure/pkg/controller/backupbucket/add.go
+++ b/controllers/provider-azure/pkg/controller/backupbucket/add.go
@@ -41,7 +41,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return backupbucket.Add(mgr, backupbucket.AddArgs{
 		Actuator:          newActuator(),
 		ControllerOptions: opts.Controller,
-		Predicates:        backupbucket.DefaultPredicates(azure.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        backupbucket.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              azure.Type,
 	})
 }
 

--- a/controllers/provider-azure/pkg/controller/backupentry/add.go
+++ b/controllers/provider-azure/pkg/controller/backupentry/add.go
@@ -45,7 +45,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return backupentry.Add(mgr, backupentry.AddArgs{
 		Actuator:          genericactuator.NewActuator(newActuator(), logger),
 		ControllerOptions: opts.Controller,
-		Predicates:        backupentry.DefaultPredicates(azure.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        backupentry.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              azure.Type,
 	})
 }
 

--- a/controllers/provider-azure/pkg/controller/controlplane/add.go
+++ b/controllers/provider-azure/pkg/controller/controlplane/add.go
@@ -49,7 +49,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 			storageClassChart, nil, NewValuesProvider(logger), extensionscontroller.ChartRendererFactoryFunc(util.NewChartRendererForShoot),
 			imagevector.ImageVector(), azure.CloudProviderConfigName, nil, mgr.GetWebhookServer().Port, logger),
 		ControllerOptions: opts.Controller,
-		Predicates:        controlplane.DefaultPredicates(azure.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        controlplane.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              azure.Type,
 	})
 }
 

--- a/controllers/provider-azure/pkg/controller/infrastructure/add.go
+++ b/controllers/provider-azure/pkg/controller/infrastructure/add.go
@@ -40,7 +40,8 @@ func AddToManagerWithOptions(mgr manager.Manager, options AddOptions) error {
 	return infrastructure.Add(mgr, infrastructure.AddArgs{
 		Actuator:          NewActuator(),
 		ControllerOptions: options.Controller,
-		Predicates:        infrastructure.DefaultPredicates(azure.Type, options.IgnoreOperationAnnotation),
+		Predicates:        infrastructure.DefaultPredicates(options.IgnoreOperationAnnotation),
+		Type:              azure.Type,
 	})
 }
 

--- a/controllers/provider-azure/pkg/controller/worker/add.go
+++ b/controllers/provider-azure/pkg/controller/worker/add.go
@@ -53,7 +53,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return worker.Add(mgr, worker.AddArgs{
 		Actuator:          NewActuator(opts.MachineImages),
 		ControllerOptions: opts.Controller,
-		Predicates:        worker.DefaultPredicates(azure.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        worker.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              azure.Type,
 	})
 }
 

--- a/controllers/provider-gcp/pkg/controller/backupbucket/add.go
+++ b/controllers/provider-gcp/pkg/controller/backupbucket/add.go
@@ -41,7 +41,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return backupbucket.Add(mgr, backupbucket.AddArgs{
 		Actuator:          newActuator(),
 		ControllerOptions: opts.Controller,
-		Predicates:        backupbucket.DefaultPredicates(gcp.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        backupbucket.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              gcp.Type,
 	})
 }
 

--- a/controllers/provider-gcp/pkg/controller/backupentry/add.go
+++ b/controllers/provider-gcp/pkg/controller/backupentry/add.go
@@ -45,7 +45,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return backupentry.Add(mgr, backupentry.AddArgs{
 		Actuator:          genericactuator.NewActuator(newActuator(), logger),
 		ControllerOptions: opts.Controller,
-		Predicates:        backupentry.DefaultPredicates(gcp.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        backupentry.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              gcp.Type,
 	})
 }
 

--- a/controllers/provider-gcp/pkg/controller/controlplane/add.go
+++ b/controllers/provider-gcp/pkg/controller/controlplane/add.go
@@ -50,7 +50,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 			storageClassChart, nil, NewValuesProvider(logger), extensionscontroller.ChartRendererFactoryFunc(util.NewChartRendererForShoot),
 			imagevector.ImageVector(), internal.CloudProviderConfigName, nil, mgr.GetWebhookServer().Port, logger),
 		ControllerOptions: opts.Controller,
-		Predicates:        controlplane.DefaultPredicates(gcp.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        controlplane.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              gcp.Type,
 	})
 }
 

--- a/controllers/provider-gcp/pkg/controller/infrastructure/add.go
+++ b/controllers/provider-gcp/pkg/controller/infrastructure/add.go
@@ -40,7 +40,8 @@ func AddToManagerWithOptions(mgr manager.Manager, options AddOptions) error {
 	return infrastructure.Add(mgr, infrastructure.AddArgs{
 		Actuator:          NewActuator(),
 		ControllerOptions: options.Controller,
-		Predicates:        infrastructure.DefaultPredicates(gcp.Type, options.IgnoreOperationAnnotation),
+		Predicates:        infrastructure.DefaultPredicates(options.IgnoreOperationAnnotation),
+		Type:              gcp.Type,
 	})
 }
 

--- a/controllers/provider-gcp/pkg/controller/worker/add.go
+++ b/controllers/provider-gcp/pkg/controller/worker/add.go
@@ -53,7 +53,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return worker.Add(mgr, worker.AddArgs{
 		Actuator:          NewActuator(opts.MachineImages),
 		ControllerOptions: opts.Controller,
-		Predicates:        worker.DefaultPredicates(gcp.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        worker.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              gcp.Type,
 	})
 }
 

--- a/controllers/provider-openstack/pkg/controller/backupbucket/add.go
+++ b/controllers/provider-openstack/pkg/controller/backupbucket/add.go
@@ -41,7 +41,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return backupbucket.Add(mgr, backupbucket.AddArgs{
 		Actuator:          newActuator(),
 		ControllerOptions: opts.Controller,
-		Predicates:        backupbucket.DefaultPredicates(openstack.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        backupbucket.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              openstack.Type,
 	})
 }
 

--- a/controllers/provider-openstack/pkg/controller/backupentry/add.go
+++ b/controllers/provider-openstack/pkg/controller/backupentry/add.go
@@ -45,7 +45,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return backupentry.Add(mgr, backupentry.AddArgs{
 		Actuator:          genericactuator.NewActuator(newActuator(), logger),
 		ControllerOptions: opts.Controller,
-		Predicates:        backupentry.DefaultPredicates(openstack.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        backupentry.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              openstack.Type,
 	})
 }
 

--- a/controllers/provider-openstack/pkg/controller/controlplane/add.go
+++ b/controllers/provider-openstack/pkg/controller/controlplane/add.go
@@ -49,7 +49,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 			storageClassChart, nil, NewValuesProvider(logger), extensionscontroller.ChartRendererFactoryFunc(util.NewChartRendererForShoot),
 			imagevector.ImageVector(), openstack.CloudProviderConfigCloudControllerManagerName, nil, mgr.GetWebhookServer().Port, logger),
 		ControllerOptions: opts.Controller,
-		Predicates:        controlplane.DefaultPredicates(openstack.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        controlplane.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              openstack.Type,
 	})
 }
 

--- a/controllers/provider-openstack/pkg/controller/infrastructure/add.go
+++ b/controllers/provider-openstack/pkg/controller/infrastructure/add.go
@@ -40,7 +40,8 @@ func AddToManagerWithOptions(mgr manager.Manager, options AddOptions) error {
 	return infrastructure.Add(mgr, infrastructure.AddArgs{
 		Actuator:          NewActuator(),
 		ControllerOptions: options.Controller,
-		Predicates:        infrastructure.DefaultPredicates(openstack.Type, options.IgnoreOperationAnnotation),
+		Predicates:        infrastructure.DefaultPredicates(options.IgnoreOperationAnnotation),
+		Type:              openstack.Type,
 	})
 }
 

--- a/controllers/provider-openstack/pkg/controller/worker/add.go
+++ b/controllers/provider-openstack/pkg/controller/worker/add.go
@@ -53,7 +53,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return worker.Add(mgr, worker.AddArgs{
 		Actuator:          NewActuator(opts.MachineImagesToCloudProfilesMapping),
 		ControllerOptions: opts.Controller,
-		Predicates:        worker.DefaultPredicates(openstack.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        worker.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              openstack.Type,
 	})
 }
 

--- a/controllers/provider-packet/pkg/controller/controlplane/add.go
+++ b/controllers/provider-packet/pkg/controller/controlplane/add.go
@@ -53,7 +53,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 			storageClassChart, nil, NewValuesProvider(logger), extensionscontroller.ChartRendererFactoryFunc(util.NewChartRendererForShoot),
 			imagevector.ImageVector(), "", opts.ShootWebhooks, mgr.GetWebhookServer().Port, logger),
 		ControllerOptions: opts.Controller,
-		Predicates:        controlplane.DefaultPredicates(packet.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        controlplane.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              packet.Type,
 	})
 }
 

--- a/controllers/provider-packet/pkg/controller/infrastructure/add.go
+++ b/controllers/provider-packet/pkg/controller/infrastructure/add.go
@@ -40,7 +40,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return infrastructure.Add(mgr, infrastructure.AddArgs{
 		Actuator:          NewActuator(),
 		ControllerOptions: opts.Controller,
-		Predicates:        infrastructure.DefaultPredicates(packet.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        infrastructure.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              packet.Type,
 	})
 }
 

--- a/controllers/provider-packet/pkg/controller/worker/add.go
+++ b/controllers/provider-packet/pkg/controller/worker/add.go
@@ -53,7 +53,8 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return worker.Add(mgr, worker.AddArgs{
 		Actuator:          NewActuator(opts.MachineImages),
 		ControllerOptions: opts.Controller,
-		Predicates:        worker.DefaultPredicates(packet.Type, opts.IgnoreOperationAnnotation),
+		Predicates:        worker.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              packet.Type,
 	})
 }
 

--- a/pkg/controller/backupbucket/controller.go
+++ b/pkg/controller/backupbucket/controller.go
@@ -45,19 +45,19 @@ type AddArgs struct {
 	// Predicates are the predicates to use.
 	// If unset, GenerationChanged will be used.
 	Predicates []predicate.Predicate
+	// Type is the type of the resource considered for reconciliation.
+	Type string
 }
 
 // DefaultPredicates returns the default predicates for a controlplane reconciler.
-func DefaultPredicates(typeName string, ignoreOperationAnnotation bool) []predicate.Predicate {
+func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 	if ignoreOperationAnnotation {
 		return []predicate.Predicate{
-			extensionspredicate.HasType(typeName),
 			extensionspredicate.GenerationChanged(),
 		}
 	}
 
 	return []predicate.Predicate{
-		extensionspredicate.HasType(typeName),
 		extensionspredicate.Or(
 			extensionspredicate.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
@@ -74,7 +74,8 @@ func DefaultPredicates(typeName string, ignoreOperationAnnotation bool) []predic
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, args AddArgs) error {
 	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator)
-	return add(mgr, args.ControllerOptions, args.Predicates)
+	predicates := extensionspredicate.AddTypePredicate(args.Type, args.Predicates)
+	return add(mgr, args.ControllerOptions, predicates)
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler

--- a/pkg/controller/backupentry/controller.go
+++ b/pkg/controller/backupentry/controller.go
@@ -45,19 +45,19 @@ type AddArgs struct {
 	// Predicates are the predicates to use.
 	// If unset, GenerationChanged will be used.
 	Predicates []predicate.Predicate
+	// Type is the type of the resource considered for reconciliation.
+	Type string
 }
 
 // DefaultPredicates returns the default predicates for a controlplane reconciler.
-func DefaultPredicates(typeName string, ignoreOperationAnnotation bool) []predicate.Predicate {
+func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 	if ignoreOperationAnnotation {
 		return []predicate.Predicate{
-			extensionspredicate.HasType(typeName),
 			extensionspredicate.GenerationChanged(),
 		}
 	}
 
 	return []predicate.Predicate{
-		extensionspredicate.HasType(typeName),
 		extensionspredicate.Or(
 			extensionspredicate.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
@@ -74,7 +74,8 @@ func DefaultPredicates(typeName string, ignoreOperationAnnotation bool) []predic
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, args AddArgs) error {
 	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator)
-	return add(mgr, args.ControllerOptions, args.Predicates)
+	predicates := extensionspredicate.AddTypePredicate(args.Type, args.Predicates)
+	return add(mgr, args.ControllerOptions, predicates)
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler

--- a/pkg/controller/controlplane/controller.go
+++ b/pkg/controller/controlplane/controller.go
@@ -44,19 +44,19 @@ type AddArgs struct {
 	// Predicates are the predicates to use.
 	// If unset, GenerationChanged will be used.
 	Predicates []predicate.Predicate
+	// Type is the type of the resource considered for reconciliation.
+	Type string
 }
 
 // DefaultPredicates returns the default predicates for a controlplane reconciler.
-func DefaultPredicates(typeName string, ignoreOperationAnnotation bool) []predicate.Predicate {
+func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 	if ignoreOperationAnnotation {
 		return []predicate.Predicate{
-			extensionspredicate.HasType(typeName),
 			extensionspredicate.GenerationChanged(),
 		}
 	}
 
 	return []predicate.Predicate{
-		extensionspredicate.HasType(typeName),
 		extensionspredicate.Or(
 			extensionspredicate.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
@@ -80,11 +80,13 @@ func Add(mgr manager.Manager, args AddArgs) error {
 		return err
 	}
 
-	if err := ctrl.Watch(&source.Kind{Type: &extensionsv1alpha1.ControlPlane{}}, &handler.EnqueueRequestForObject{}, args.Predicates...); err != nil {
+	predicates := extensionspredicate.AddTypePredicate(args.Type, args.Predicates)
+
+	if err := ctrl.Watch(&source.Kind{Type: &extensionsv1alpha1.ControlPlane{}}, &handler.EnqueueRequestForObject{}, predicates...); err != nil {
 		return err
 	}
 
 	return ctrl.Watch(&source.Kind{Type: &extensionsv1alpha1.Cluster{}}, &extensionshandler.EnqueueRequestsFromMapFunc{
-		ToRequests: extensionshandler.SimpleMapper(ClusterToControlPlaneMapper(args.Predicates), extensionshandler.UpdateWithNew),
+		ToRequests: extensionshandler.SimpleMapper(ClusterToControlPlaneMapper(predicates), extensionshandler.UpdateWithNew),
 	})
 }

--- a/pkg/controller/network/controller.go
+++ b/pkg/controller/network/controller.go
@@ -44,19 +44,19 @@ type AddArgs struct {
 	// Predicates are the predicates to use.
 	// If unset, GenerationChangedPredicate will be used.
 	Predicates []predicate.Predicate
+	// Type is the type of the resource considered for reconciliation.
+	Type string
 }
 
 // DefaultPredicates returns the default predicates for a Network reconciler.
-func DefaultPredicates(typeName string, ignoreOperationAnnotation bool) []predicate.Predicate {
+func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 	if ignoreOperationAnnotation {
 		return []predicate.Predicate{
-			extensionspredicate.HasType(typeName),
 			extensionspredicate.GenerationChanged(),
 		}
 	}
 
 	return []predicate.Predicate{
-		extensionspredicate.HasType(typeName),
 		extensionspredicate.Or(
 			extensionspredicate.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
@@ -84,11 +84,13 @@ func add(mgr manager.Manager, args AddArgs) error {
 		return err
 	}
 
-	if err := ctrl.Watch(&source.Kind{Type: &extensionsv1alpha1.Network{}}, &handler.EnqueueRequestForObject{}, args.Predicates...); err != nil {
+	predicates := extensionspredicate.AddTypePredicate(args.Type, args.Predicates)
+
+	if err := ctrl.Watch(&source.Kind{Type: &extensionsv1alpha1.Network{}}, &handler.EnqueueRequestForObject{}, predicates...); err != nil {
 		return err
 	}
 	if err := ctrl.Watch(&source.Kind{Type: &extensionsv1alpha1.Cluster{}}, &extensionshandler.EnqueueRequestsFromMapFunc{
-		ToRequests: extensionshandler.SimpleMapper(ClusterToNetworkMapper(args.Predicates), extensionshandler.UpdateWithNew),
+		ToRequests: extensionshandler.SimpleMapper(ClusterToNetworkMapper(predicates), extensionshandler.UpdateWithNew),
 	}); err != nil {
 		return err
 	}

--- a/pkg/controller/operatingsystemconfig/controller.go
+++ b/pkg/controller/operatingsystemconfig/controller.go
@@ -46,25 +46,26 @@ type AddArgs struct {
 	// Predicates are the predicates to use.
 	// If unset, GenerationChanged will be used.
 	Predicates []predicate.Predicate
+	// Type is the type of the resource considered for reconciliation.
+	Type string
 }
 
 // Add adds an operatingsystemconfig controller to the given manager using the given AddArgs.
 func Add(mgr manager.Manager, args AddArgs) error {
 	args.ControllerOptions.Reconciler = NewReconciler(args.Actuator)
-	return add(mgr, args.ControllerOptions, args.Predicates)
+	predicates := extensionspredicate.AddTypePredicate(args.Type, args.Predicates)
+	return add(mgr, args.ControllerOptions, predicates)
 }
 
 // DefaultPredicates returns the default predicates for an operatingsystemconfig reconciler.
-func DefaultPredicates(typeName string, ignoreOperationAnnotation bool) []predicate.Predicate {
+func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 	if ignoreOperationAnnotation {
 		return []predicate.Predicate{
-			extensionspredicate.HasType(typeName),
 			extensionspredicate.GenerationChanged(),
 		}
 	}
 
 	return []predicate.Predicate{
-		extensionspredicate.HasType(typeName),
 		extensionspredicate.Or(
 			extensionspredicate.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),

--- a/pkg/controller/operatingsystemconfig/oscommon/add.go
+++ b/pkg/controller/operatingsystemconfig/oscommon/add.go
@@ -39,7 +39,8 @@ type AddOptions struct {
 func AddToManagerWithOptions(mgr manager.Manager, os string, generator generator.Generator, opts AddOptions) error {
 	return operatingsystemconfig.Add(mgr, operatingsystemconfig.AddArgs{
 		Actuator:          actuator.NewActuator(os, generator),
-		Predicates:        operatingsystemconfig.DefaultPredicates(os, opts.IgnoreOperationAnnotation),
+		Predicates:        operatingsystemconfig.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              os,
 		ControllerOptions: opts.Controller,
 	})
 }

--- a/pkg/controller/worker/controller.go
+++ b/pkg/controller/worker/controller.go
@@ -44,19 +44,19 @@ type AddArgs struct {
 	// Predicates are the predicates to use.
 	// If unset, GenerationChanged will be used.
 	Predicates []predicate.Predicate
+	// Type is the type of the resource considered for reconciliation.
+	Type string
 }
 
 // DefaultPredicates returns the default predicates for a Worker reconciler.
-func DefaultPredicates(typeName string, ignoreOperationAnnotation bool) []predicate.Predicate {
+func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 	if ignoreOperationAnnotation {
 		return []predicate.Predicate{
-			extensionspredicate.HasType(typeName),
 			extensionspredicate.GenerationChanged(),
 		}
 	}
 
 	return []predicate.Predicate{
-		extensionspredicate.HasType(typeName),
 		extensionspredicate.Or(
 			extensionspredicate.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
@@ -74,7 +74,8 @@ func DefaultPredicates(typeName string, ignoreOperationAnnotation bool) []predic
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, args AddArgs) error {
 	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator)
-	return add(mgr, args.ControllerOptions, args.Predicates)
+	predicates := extensionspredicate.AddTypePredicate(args.Type, args.Predicates)
+	return add(mgr, args.ControllerOptions, predicates)
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler

--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -215,3 +215,10 @@ func IsDeleting() predicate.Predicate {
 		return e.Meta.GetDeletionTimestamp() != nil
 	}), CreateTrigger, UpdateNewTrigger, GenericTrigger)
 }
+
+// AddTypePredicate returns a new slice which contains a type predicate and the given `predicates`.
+func AddTypePredicate(extensionType string, predicates []predicate.Predicate) []predicate.Predicate {
+	preds := make([]predicate.Predicate, 0, len(predicates)+1)
+	preds = append(preds, HasType(extensionType))
+	return append(preds, predicates...)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
When actuators add themselves to a controller manager they must pass the extension `type` they want to act upon.

This avoids that actuators are added w/o a proper `type predicate`.

**Which issue(s) this PR fixes**:
Fixes #409

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Developers who write and register actuators with Gardener-Extension means must now pass the extension `type` they want to act upon. This makes sure that reconciliation is only triggered for desired types.
```
