### PR TITLE
OpenStack: set the "default" name for a default storage class

### DIFF
--- a/controllers/provider-openstack/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
+++ b/controllers/provider-openstack/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
@@ -4,6 +4,16 @@ kind: StorageClass
 metadata:
   name: default-class
   annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+provisioner: kubernetes.io/cinder
+parameters:
+  availability: {{ .Values.availability }}
+---
+apiVersion: {{ include "storageclassversion" . }}
+kind: StorageClass
+metadata:
+  name: default
+  annotations:
     storageclass.kubernetes.io/is-default-class: "true"
 provisioner: kubernetes.io/cinder
 parameters:


### PR DESCRIPTION
**What this PR does / why we need it**:

All default storage classes have the `default` name, but OpenStack storage class has the `default-class`. This breaks multi-cluster compatibility.

**Special notes for your reviewer**:

@rfranzke suggested to keep an old `default-class` for a while, therefore we keep it as non-default.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
OpenStack: rename the default storage class from "default-class" to "default"
```
