### PR TITLE
add role to allow bootstrap token creation in the kube-system namespce of the shoot by MCM

### DIFF
--- a/controllers/provider-alicloud/charts/internal/machine-controller-manager/shoot/templates/role-machine-controller-manager.yaml
+++ b/controllers/provider-alicloud/charts/internal/machine-controller-manager/shoot/templates/role-machine-controller-manager.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: kube-system
+  name: extensions.gardener.cloud:{{ .Values.providerName }}:machine-controller-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list

--- a/controllers/provider-alicloud/charts/internal/machine-controller-manager/shoot/templates/rolebinding-machine-controller-manager.yaml
+++ b/controllers/provider-alicloud/charts/internal/machine-controller-manager/shoot/templates/rolebinding-machine-controller-manager.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: extensions.gardener.cloud:{{ .Values.providerName }}:machine-controller-manager
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extensions.gardener.cloud:{{ .Values.providerName }}:machine-controller-manager
+subjects:
+- kind: User
+  name: system:machine-controller-manager

--- a/controllers/provider-aws/charts/internal/machine-controller-manager/shoot/templates/role-machine-controller-manager.yaml
+++ b/controllers/provider-aws/charts/internal/machine-controller-manager/shoot/templates/role-machine-controller-manager.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: kube-system
+  name: extensions.gardener.cloud:{{ .Values.providerName }}:machine-controller-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list

--- a/controllers/provider-aws/charts/internal/machine-controller-manager/shoot/templates/rolebinding-machine-controller-manager.yaml
+++ b/controllers/provider-aws/charts/internal/machine-controller-manager/shoot/templates/rolebinding-machine-controller-manager.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: extensions.gardener.cloud:{{ .Values.providerName }}:machine-controller-manager
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extensions.gardener.cloud:{{ .Values.providerName }}:machine-controller-manager
+subjects:
+- kind: User
+  name: system:machine-controller-manager

--- a/controllers/provider-azure/charts/internal/machine-controller-manager/shoot/templates/role-machine-controller-manager.yaml
+++ b/controllers/provider-azure/charts/internal/machine-controller-manager/shoot/templates/role-machine-controller-manager.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: kube-system
+  name: extensions.gardener.cloud:{{ .Values.providerName }}:machine-controller-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list

--- a/controllers/provider-azure/charts/internal/machine-controller-manager/shoot/templates/rolebinding-machine-controller-manager.yaml
+++ b/controllers/provider-azure/charts/internal/machine-controller-manager/shoot/templates/rolebinding-machine-controller-manager.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: extensions.gardener.cloud:{{ .Values.providerName }}:machine-controller-manager
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extensions.gardener.cloud:{{ .Values.providerName }}:machine-controller-manager
+subjects:
+- kind: User
+  name: system:machine-controller-manager

--- a/controllers/provider-gcp/charts/internal/machine-controller-manager/shoot/templates/role-machine-controller-manager.yaml
+++ b/controllers/provider-gcp/charts/internal/machine-controller-manager/shoot/templates/role-machine-controller-manager.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: kube-system
+  name: extensions.gardener.cloud:{{ .Values.providerName }}:machine-controller-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list

--- a/controllers/provider-gcp/charts/internal/machine-controller-manager/shoot/templates/rolebinding-machine-controller-manager.yaml
+++ b/controllers/provider-gcp/charts/internal/machine-controller-manager/shoot/templates/rolebinding-machine-controller-manager.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: extensions.gardener.cloud:{{ .Values.providerName }}:machine-controller-manager
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extensions.gardener.cloud:{{ .Values.providerName }}:machine-controller-manager
+subjects:
+- kind: User
+  name: system:machine-controller-manager

--- a/controllers/provider-openstack/charts/internal/machine-controller-manager/shoot/templates/role-machine-controller-manager.yaml
+++ b/controllers/provider-openstack/charts/internal/machine-controller-manager/shoot/templates/role-machine-controller-manager.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: kube-system
+  name: extensions.gardener.cloud:{{ .Values.providerName }}:machine-controller-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list

--- a/controllers/provider-openstack/charts/internal/machine-controller-manager/shoot/templates/rolebinding-machine-controller-manager.yaml
+++ b/controllers/provider-openstack/charts/internal/machine-controller-manager/shoot/templates/rolebinding-machine-controller-manager.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: extensions.gardener.cloud:{{ .Values.providerName }}:machine-controller-manager
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extensions.gardener.cloud:{{ .Values.providerName }}:machine-controller-manager
+subjects:
+- kind: User
+  name: system:machine-controller-manager

--- a/controllers/provider-packet/charts/internal/machine-controller-manager/shoot/templates/role-machine-controller-manager.yaml
+++ b/controllers/provider-packet/charts/internal/machine-controller-manager/shoot/templates/role-machine-controller-manager.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: kube-system
+  name: extensions.gardener.cloud:{{ .Values.providerName }}:machine-controller-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list

--- a/controllers/provider-packet/charts/internal/machine-controller-manager/shoot/templates/rolebinding-machine-controller-manager.yaml
+++ b/controllers/provider-packet/charts/internal/machine-controller-manager/shoot/templates/rolebinding-machine-controller-manager.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: extensions.gardener.cloud:{{ .Values.providerName }}:machine-controller-manager
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extensions.gardener.cloud:{{ .Values.providerName }}:machine-controller-manager
+subjects:
+- kind: User
+  name: system:machine-controller-manager


### PR DESCRIPTION
**What this PR does / why we need it**:
This is prerequisite for solving issue #[179](https://github.com/gardener/machine-controller-manager/issues/179)
With this PR MCM will have permissions to create bootsrap token in the shoot cluster

**Which issue(s) this PR fixes**:
Part of [#179](https://github.com/gardener/machine-controller-manager/issues/179)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
MCM has new role for create, delete and list secrets in shoot's kube-system namespace
```
