### PR TITLE
Use defaults for env vars

### DIFF
--- a/controllers/os-suse-jeos/pkg/generator/generator.go
+++ b/controllers/os-suse-jeos/pkg/generator/generator.go
@@ -15,7 +15,6 @@
 package generator
 
 import (
-	"fmt"
 	"os"
 	"strings"
 	"text/template"
@@ -33,6 +32,9 @@ const (
 	// Depends on the OSC format and the infrastructure platform.
 	// Well known valid values are `"/bin/bash %s"` and `"/usr/bin/cloud-init clean && /usr/bin/cloud-init --file %s init"`.
 	BootCommand = "BOOT_COMMAND"
+
+	defaultOsConfigFormat = "script"
+	defaultBootCommand    = "/bin/bash %s"
 )
 
 //go:generate packr2
@@ -43,13 +45,13 @@ func NewCloudInitGenerator() (*template_gen.CloudInitGenerator, error) {
 
 	templateName, exists := os.LookupEnv(OsConfigFormat)
 	if !exists || templateName == "" {
-		return nil, fmt.Errorf("Environment variable %s must be defined", OsConfigFormat)
+		templateName = defaultOsConfigFormat
 	}
 	templateName = strings.ToLower(templateName) + "/suse-jeos.template"
 
 	bootCmd, exists := os.LookupEnv(BootCommand)
 	if !exists || bootCmd == "" {
-		return nil, fmt.Errorf("Environment variable %s must be defined", BootCommand)
+		bootCmd = defaultBootCommand
 	}
 
 	cloudInitTemplateString, err := box.FindString(templateName)

--- a/controllers/os-suse-jeos/pkg/generator/invalid_config_test.go
+++ b/controllers/os-suse-jeos/pkg/generator/invalid_config_test.go
@@ -15,43 +15,43 @@
 package generator
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"os"
 )
 
 var _ = Describe("JeOS Cloud-init Generator Test", func() {
 
-	It("should fail creating generator without OS_CONFIG_FORMAT variable", func() {
+	It("should not fail creating generator without OS_CONFIG_FORMAT variable", func() {
 		os.Unsetenv(OsConfigFormat)
 		os.Setenv(BootCommand, "boot-command")
 		_, err := NewCloudInitGenerator()
 
-		Expect(err).To(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("should fail creating generator with empty OS_CONFIG_FORMAT variable", func() {
+	It("should not fail creating generator with empty OS_CONFIG_FORMAT variable", func() {
 		os.Setenv(OsConfigFormat, "")
 		os.Setenv(BootCommand, "boot-command")
 		_, err := NewCloudInitGenerator()
 
-		Expect(err).To(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("should fail creating generator with empty BOOT_COMMAND variable", func() {
+	It("should not fail creating generator with empty BOOT_COMMAND variable", func() {
 		os.Setenv(OsConfigFormat, "")
 		os.Setenv(BootCommand, "")
 		_, err := NewCloudInitGenerator()
 
-		Expect(err).To(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("should fail creating generator without BOOT_COMMAND variable", func() {
-		os.Setenv(OsConfigFormat, "os-format")
+	It("should not fail creating generator without BOOT_COMMAND variable", func() {
 		os.Unsetenv(BootCommand)
 		_, err := NewCloudInitGenerator()
 
-		Expect(err).To(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should fail creating generator with invalid OS_CONFIG_FORMAT", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
With the recently merged #297 env vars were introduced to allow configuration of the SuSE-JeOS controller. It turns out that these env vars are indirectly required by all extensions when the hyper binary is used. Now if these env vars are unset, default values will be used instead to fail.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Make the env vars `OS_CONFIG_FORMAT` and `BOOT_COMMAND` optional to allow the hyper binary to run without them.
```
