### PR TITLE
Restrict terraformer to delete jobs and pods only in its namespace

### DIFF
--- a/pkg/terraformer/terraformer.go
+++ b/pkg/terraformer/terraformer.go
@@ -460,7 +460,9 @@ func (t *terraformer) podSpec(scriptName string) *corev1.PodSpec {
 // listJobPods lists all pods which have a label 'job-name' whose value is equal to the Terraformer job name.
 func (t *terraformer) listJobPods(ctx context.Context) (*corev1.PodList, error) {
 	podList := &corev1.PodList{}
-	if err := t.client.List(ctx, podList, client.MatchingLabels(map[string]string{jobNameLabel: t.jobName})); err != nil {
+	if err := t.client.List(ctx, podList,
+		client.InNamespace(t.namespace),
+		client.MatchingLabels{jobNameLabel: t.jobName}); err != nil {
 		return nil, err
 	}
 	return podList, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Restrict terraformer to delete jobs and pods only in its namespace.

**Which issue(s) this PR fixes**:
Fixes #424 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
terraformer does now delete job and pods only in its namespace. This fixes an issue that prevents simultaneous creation of Shoots with the same name (but different projects) on the same Seed.
```
