### PR TITLE
Switch from job to pod for terraform apply/destroy

### DIFF
--- a/controllers/provider-alicloud/pkg/controller/common/terraform.go
+++ b/controllers/provider-alicloud/pkg/controller/common/terraform.go
@@ -44,9 +44,7 @@ func NewTerraformer(factory terraformer.Factory, config *rest.Config, credential
 
 	return tf.
 		SetVariablesEnvironment(variablesEnvironment).
-		SetJobBackoffLimit(0).
 		SetActiveDeadlineSeconds(630).
 		SetDeadlineCleaning(5 * time.Minute).
-		SetDeadlinePod(15 * time.Minute).
-		SetDeadlineJob(15 * time.Minute), nil
+		SetDeadlinePod(15 * time.Minute), nil
 }

--- a/controllers/provider-alicloud/pkg/controller/common/terraform_test.go
+++ b/controllers/provider-alicloud/pkg/controller/common/terraform_test.go
@@ -63,11 +63,9 @@ var _ = Describe("Terraform", func() {
 					TerraformVarAccessKeyID:     accessKeyID,
 					TerraformVarAccessKeySecret: accessKeySecret,
 				}).Return(tf),
-				tf.EXPECT().SetJobBackoffLimit(int32(0)).Return(tf),
 				tf.EXPECT().SetActiveDeadlineSeconds(int64(630)).Return(tf),
 				tf.EXPECT().SetDeadlineCleaning(5*time.Minute).Return(tf),
 				tf.EXPECT().SetDeadlinePod(15*time.Minute).Return(tf),
-				tf.EXPECT().SetDeadlineJob(15*time.Minute).Return(tf),
 			)
 
 			actual, err := NewTerraformer(factory, &config, &credentials, purpose, namespace, name)

--- a/controllers/provider-alicloud/pkg/controller/infrastructure/actuator_test.go
+++ b/controllers/provider-alicloud/pkg/controller/infrastructure/actuator_test.go
@@ -170,11 +170,9 @@ var _ = Describe("Actuator", func() {
 						common.TerraformVarAccessKeyID:     accessKeyID,
 						common.TerraformVarAccessKeySecret: accessKeySecret,
 					}).Return(terraformer),
-					terraformer.EXPECT().SetJobBackoffLimit(int32(0)).Return(terraformer),
 					terraformer.EXPECT().SetActiveDeadlineSeconds(int64(630)).Return(terraformer),
 					terraformer.EXPECT().SetDeadlineCleaning(5*time.Minute).Return(terraformer),
 					terraformer.EXPECT().SetDeadlinePod(15*time.Minute).Return(terraformer),
-					terraformer.EXPECT().SetDeadlineJob(15*time.Minute).Return(terraformer),
 
 					alicloudClientFactory.EXPECT().NewVPC(region, accessKeyID, accessKeySecret).Return(vpcClient, nil),
 

--- a/controllers/provider-aws/pkg/controller/infrastructure/actuator.go
+++ b/controllers/provider-aws/pkg/controller/infrastructure/actuator.go
@@ -83,17 +83,15 @@ func (a *actuator) Delete(ctx context.Context, config *extensionsv1alpha1.Infras
 // Helper functions
 
 func (a *actuator) newTerraformer(purpose, namespace, name string) (terraformer.Terraformer, error) {
-	t, err := terraformer.NewForConfig(glogger.NewLogger("info"), a.restConfig, purpose, namespace, name, imagevector.TerraformerImage())
+	tf, err := terraformer.NewForConfig(glogger.NewLogger("info"), a.restConfig, purpose, namespace, name, imagevector.TerraformerImage())
 	if err != nil {
 		return nil, err
 	}
 
-	return t.
-		SetJobBackoffLimit(0).
+	return tf.
 		SetActiveDeadlineSeconds(630).
 		SetDeadlineCleaning(5 * time.Minute).
-		SetDeadlinePod(15 * time.Minute).
-		SetDeadlineJob(15 * time.Minute), nil
+		SetDeadlinePod(15 * time.Minute), nil
 }
 
 func generateTerraformInfraVariablesEnvironment(secret *corev1.Secret) map[string]string {

--- a/controllers/provider-azure/pkg/internal/terraform.go
+++ b/controllers/provider-azure/pkg/internal/terraform.go
@@ -60,9 +60,7 @@ func NewTerraformer(
 
 	return tf.
 		SetVariablesEnvironment(variables).
-		SetJobBackoffLimit(0).
 		SetActiveDeadlineSeconds(630).
 		SetDeadlineCleaning(5 * time.Minute).
-		SetDeadlinePod(15 * time.Minute).
-		SetDeadlineJob(15 * time.Minute), nil
+		SetDeadlinePod(15 * time.Minute), nil
 }

--- a/controllers/provider-gcp/pkg/internal/terraform.go
+++ b/controllers/provider-gcp/pkg/internal/terraform.go
@@ -64,9 +64,7 @@ func NewTerraformer(
 
 	return tf.
 		SetVariablesEnvironment(variables).
-		SetJobBackoffLimit(0).
 		SetActiveDeadlineSeconds(630).
 		SetDeadlineCleaning(5 * time.Minute).
-		SetDeadlinePod(15 * time.Minute).
-		SetDeadlineJob(15 * time.Minute), nil
+		SetDeadlinePod(15 * time.Minute), nil
 }

--- a/controllers/provider-openstack/pkg/internal/terraform.go
+++ b/controllers/provider-openstack/pkg/internal/terraform.go
@@ -57,9 +57,7 @@ func NewTerraformer(
 
 	return tf.
 		SetVariablesEnvironment(variables).
-		SetJobBackoffLimit(0).
 		SetActiveDeadlineSeconds(630).
 		SetDeadlineCleaning(5 * time.Minute).
-		SetDeadlinePod(15 * time.Minute).
-		SetDeadlineJob(15 * time.Minute), nil
+		SetDeadlinePod(15 * time.Minute), nil
 }

--- a/controllers/provider-packet/pkg/controller/infrastructure/actuator.go
+++ b/controllers/provider-packet/pkg/controller/infrastructure/actuator.go
@@ -26,14 +26,11 @@ import (
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	glogger "github.com/gardener/gardener/pkg/logger"
-
 	"github.com/go-logr/logr"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/rest"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -82,17 +79,15 @@ func (a *actuator) Delete(ctx context.Context, config *extensionsv1alpha1.Infras
 // Helper functions
 
 func (a *actuator) newTerraformer(purpose, namespace, name string) (terraformer.Terraformer, error) {
-	t, err := terraformer.NewForConfig(glogger.NewLogger("info"), a.restConfig, purpose, namespace, name, imagevector.TerraformerImage())
+	tf, err := terraformer.NewForConfig(glogger.NewLogger("info"), a.restConfig, purpose, namespace, name, imagevector.TerraformerImage())
 	if err != nil {
 		return nil, err
 	}
 
-	return t.
-		SetJobBackoffLimit(0).
+	return tf.
 		SetActiveDeadlineSeconds(630).
 		SetDeadlineCleaning(5 * time.Minute).
-		SetDeadlinePod(15 * time.Minute).
-		SetDeadlineJob(15 * time.Minute), nil
+		SetDeadlinePod(15 * time.Minute), nil
 }
 
 func generateTerraformInfraVariablesEnvironment(secret *corev1.Secret) map[string]string {

--- a/pkg/mock/gardener-extensions/terraformer/mocks.go
+++ b/pkg/mock/gardener-extensions/terraformer/mocks.go
@@ -142,20 +142,6 @@ func (mr *MockTerraformerMockRecorder) SetDeadlineCleaning(arg0 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDeadlineCleaning", reflect.TypeOf((*MockTerraformer)(nil).SetDeadlineCleaning), arg0)
 }
 
-// SetDeadlineJob mocks base method
-func (m *MockTerraformer) SetDeadlineJob(arg0 time.Duration) terraformer.Terraformer {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetDeadlineJob", arg0)
-	ret0, _ := ret[0].(terraformer.Terraformer)
-	return ret0
-}
-
-// SetDeadlineJob indicates an expected call of SetDeadlineJob
-func (mr *MockTerraformerMockRecorder) SetDeadlineJob(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDeadlineJob", reflect.TypeOf((*MockTerraformer)(nil).SetDeadlineJob), arg0)
-}
-
 // SetDeadlinePod mocks base method
 func (m *MockTerraformer) SetDeadlinePod(arg0 time.Duration) terraformer.Terraformer {
 	m.ctrl.T.Helper()
@@ -168,20 +154,6 @@ func (m *MockTerraformer) SetDeadlinePod(arg0 time.Duration) terraformer.Terrafo
 func (mr *MockTerraformerMockRecorder) SetDeadlinePod(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDeadlinePod", reflect.TypeOf((*MockTerraformer)(nil).SetDeadlinePod), arg0)
-}
-
-// SetJobBackoffLimit mocks base method
-func (m *MockTerraformer) SetJobBackoffLimit(arg0 int32) terraformer.Terraformer {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetJobBackoffLimit", arg0)
-	ret0, _ := ret[0].(terraformer.Terraformer)
-	return ret0
-}
-
-// SetJobBackoffLimit indicates an expected call of SetJobBackoffLimit
-func (mr *MockTerraformerMockRecorder) SetJobBackoffLimit(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetJobBackoffLimit", reflect.TypeOf((*MockTerraformer)(nil).SetJobBackoffLimit), arg0)
 }
 
 // SetVariablesEnvironment mocks base method

--- a/pkg/terraformer/state.go
+++ b/pkg/terraformer/state.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"

--- a/pkg/terraformer/terraform_test.go
+++ b/pkg/terraformer/terraform_test.go
@@ -64,9 +64,9 @@ var _ = Describe("terraformer", func() {
 			)
 
 			var (
-				ObjectMeta = metav1.ObjectMeta{Namespace: namespace, Name: name}
+				objectMeta = metav1.ObjectMeta{Namespace: namespace, Name: name}
 				expected   = &corev1.ConfigMap{
-					ObjectMeta: ObjectMeta,
+					ObjectMeta: objectMeta,
 					Data: map[string]string{
 						MainKey:      main,
 						VariablesKey: variables,
@@ -76,7 +76,7 @@ var _ = Describe("terraformer", func() {
 
 			gomock.InOrder(
 				c.EXPECT().
-					Get(gomock.Any(), kutil.Key(namespace, name), &corev1.ConfigMap{ObjectMeta: ObjectMeta}).
+					Get(gomock.Any(), kutil.Key(namespace, name), &corev1.ConfigMap{ObjectMeta: objectMeta}).
 					Return(apierrors.NewNotFound(configMapGroupResource, name)),
 				c.EXPECT().
 					Create(gomock.Any(), expected.DeepCopy()),
@@ -98,9 +98,9 @@ var _ = Describe("terraformer", func() {
 			)
 
 			var (
-				ObjectMeta = metav1.ObjectMeta{Namespace: namespace, Name: name}
+				objectMeta = metav1.ObjectMeta{Namespace: namespace, Name: name}
 				expected   = &corev1.ConfigMap{
-					ObjectMeta: ObjectMeta,
+					ObjectMeta: objectMeta,
 					Data: map[string]string{
 						StateKey: state,
 					},
@@ -123,9 +123,9 @@ var _ = Describe("terraformer", func() {
 
 			var (
 				tfVars     = []byte("tfvars")
-				ObjectMeta = metav1.ObjectMeta{Namespace: namespace, Name: name}
+				objectMeta = metav1.ObjectMeta{Namespace: namespace, Name: name}
 				expected   = &corev1.Secret{
-					ObjectMeta: ObjectMeta,
+					ObjectMeta: objectMeta,
 					Data: map[string][]byte{
 						TFVarsKey: tfVars,
 					},
@@ -134,7 +134,7 @@ var _ = Describe("terraformer", func() {
 
 			gomock.InOrder(
 				c.EXPECT().
-					Get(gomock.Any(), kutil.Key(namespace, name), &corev1.Secret{ObjectMeta: ObjectMeta}).
+					Get(gomock.Any(), kutil.Key(namespace, name), &corev1.Secret{ObjectMeta: objectMeta}).
 					Return(apierrors.NewNotFound(secretGroupResource, name)),
 				c.EXPECT().
 					Create(gomock.Any(), expected.DeepCopy()),
@@ -241,6 +241,15 @@ var _ = Describe("terraformer", func() {
 			)
 
 			Expect(runInitializer(false)).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("#Apply", func() {
+		It("should return err when config is not defined", func() {
+			tf := New(nil, c, nil, "purpose", "namespace", "name", "image")
+
+			err := tf.Apply()
+			Expect(err).To((HaveOccurred()))
 		})
 	})
 

--- a/pkg/terraformer/waiter.go
+++ b/pkg/terraformer/waiter.go
@@ -21,15 +21,38 @@ import (
 
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
-
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-// waitForCleanEnvironment waits until no Terraform Job and Pod(s) exist for the current instance
+// waitForCleanEnvironment waits until no Terraform Pod(s) exist for the current instance
 // of the Terraformer.
 func (t *terraformer) waitForCleanEnvironment(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, t.deadlineCleaning)
+	defer cancel()
+
+	return retry.Until(ctx, 5*time.Second, func(ctx context.Context) (done bool, err error) {
+		podList, err := t.listTerraformerPods(ctx)
+		if err != nil {
+			return retry.SevereError(err)
+		}
+		if len(podList.Items) != 0 {
+			labels := fmt.Sprintf("%s=%s,%s=%s", TerraformerLabelKeyName, t.name, TerraformerLabelKeyPurpose, t.purpose)
+			t.logger.Infof("Waiting until no Terraform Pods with labels '%s' exist any more in namespace '%s'...", labels, t.namespace)
+			return retry.MinorError(fmt.Errorf("terraform pods with labels '%s' still exist in namespace '%s'", labels, t.namespace))
+		}
+
+		return retry.Ok()
+	})
+}
+
+// waitForCleanEnvironmentDeprecated waits until no Terraform Job and Pod(s) exist for the current instance
+// of the Terraformer.
+//
+// Deprecated: Terraformer does no longer uses a Job. Kept for backwards compatibility.
+// TODO: Remove after several releases.
+func (t *terraformer) waitForCleanEnvironmentDeprecated(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, t.deadlineCleaning)
 	defer cancel()
 
@@ -49,36 +72,36 @@ func (t *terraformer) waitForCleanEnvironment(ctx context.Context) error {
 		}
 		if len(jobPodList.Items) != 0 {
 			t.logger.Infof("Waiting until no Terraform Pods with label 'job-name=%s' exist any more...", t.jobName)
-			return retry.MinorError(fmt.Errorf("terraform pods with label 'job-name%s' still exist", t.jobName))
+			return retry.MinorError(fmt.Errorf("terraform pods with label 'job-name=%s' still exist", t.jobName))
 		}
 
 		return retry.Ok()
 	})
 }
 
-// waitForPod waits for the Terraform validation Pod to be completed (either successful or failed).
+// waitForPod waits for the Terraform Pod to be completed (either successful or failed).
 // It checks the Pod status field to identify the state.
-func (t *terraformer) waitForPod(ctx context.Context) int32 {
+func (t *terraformer) waitForPod(ctx context.Context, podName string, deadline time.Duration) int32 {
 	// 'terraform plan' returns exit code 2 if the plan succeeded and there is a diff
 	// If we can't read the terminated state of the container we simply force that the Terraform
 	// job gets created.
 	var exitCode int32 = 2
-	ctx, cancel := context.WithTimeout(ctx, t.deadlinePod)
+	ctx, cancel := context.WithTimeout(ctx, deadline)
 	defer cancel()
 
 	if err := retry.Until(ctx, 5*time.Second, func(ctx context.Context) (done bool, err error) {
-		t.logger.Infof("Waiting for Terraform validation Pod '%s' to be completed...", t.podName)
+		t.logger.Infof("Waiting for Terraform Pod '%s' to be completed...", podName)
 		pod := &corev1.Pod{}
-		err = t.client.Get(ctx, kutil.Key(t.namespace, t.podName), pod)
+		err = t.client.Get(ctx, kutil.Key(t.namespace, podName), pod)
 		if apierrors.IsNotFound(err) {
-			t.logger.Warn("Terraform validation Pod disappeared unexpectedly, somebody must have manually deleted it!")
+			t.logger.Warnf("Terraform Pod '%s' disappeared unexpectedly, somebody must have manually deleted it!", podName)
 			return retry.Ok()
 		}
 		if err != nil {
 			return retry.SevereError(err)
 		}
 
-		// Check whether the Job has been successful (at least one succeeded Pod)
+		// Check whether the Pod has been successful
 		var (
 			phase             = pod.Status.Phase
 			containerStatuses = pod.Status.ContainerStatuses
@@ -91,46 +114,10 @@ func (t *terraformer) waitForPod(ctx context.Context) int32 {
 			return retry.Ok()
 		}
 
-		return retry.MinorError(fmt.Errorf("job was not successful (phase=%s, no-of-container-states=%d)", phase, len(containerStatuses)))
+		return retry.MinorError(fmt.Errorf("pod was not successful (phase=%s, no-of-container-states=%d)", phase, len(containerStatuses)))
 	}); err != nil {
 		exitCode = 1
 	}
 
 	return exitCode
-}
-
-// waitForJob waits for the Terraform Job to be completed (either successful or failed). It checks the
-// Job status field to identify the state.
-func (t *terraformer) waitForJob(ctx context.Context) bool {
-	ctx, cancel := context.WithTimeout(ctx, t.deadlineJob)
-	defer cancel()
-
-	var succeeded = false
-	if err := retry.Until(ctx, 5*time.Second, func(ctx context.Context) (done bool, err error) {
-		t.logger.Infof("Waiting for Terraform Job '%s' to be completed...", t.jobName)
-		job := &batchv1.Job{}
-		err = t.client.Get(ctx, kutil.Key(t.namespace, t.jobName), job)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				t.logger.Warnf("Terraform Job %s disappeared unexpectedly, somebody must have manually deleted it!", t.jobName)
-				return retry.Ok()
-			}
-			return retry.SevereError(err)
-		}
-		// Check the job conditions to identify whether the job has been completed or failed.
-		for _, cond := range job.Status.Conditions {
-			if cond.Type == batchv1.JobComplete && cond.Status == corev1.ConditionTrue {
-				succeeded = true
-				return retry.Ok()
-			}
-			if cond.Type == batchv1.JobFailed && cond.Status == corev1.ConditionTrue {
-				t.logger.Errorf("Terraform Job %s failed for reason '%s': '%s'", t.jobName, cond.Reason, cond.Message)
-				return retry.Ok()
-			}
-		}
-		return retry.MinorError(fmt.Errorf("job %q is not yet completed", t.jobName))
-	}); err != nil {
-		t.logger.Errorf("Error while waiting for Terraform job: '%s'", err.Error())
-	}
-	return succeeded
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently we use Job for terraform apply/destroy operations. The Job controller starts a  new Pod if the first Pod fails or is deleted. When the first `tf-job` Pod is deleted, it is being gracefully terminated for given period of `activeDeadlineSeconds` (630 in our case). However the Job controller start a new `tf-job` Pod which at the end of its execution overrides the correct terraform state of the first `tf-job` Pod.
This PR adapts the terraformer package (`pkg/terraformer`) to use Pod to prevent multiple Pods executing simultaneously terraform apply/destroy.

**Which issue(s) this PR fixes**:
Fixes #182
Fixes #202
Fixes #428

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`pkg/terraformer` package does now use a Pod for `terraform apply/destroy` operations. The motivation for this changes is to prevent multiple Pods to execute `apply/destroy` commands simultaneously in some cases.
```
```improvement operator
`pkg/terraformer` package does no longer deploy a Terraformer validation pod. It executes directly `terraform apply/destroy`.
```
```action developer
`pkg/terraformer` package has renamed and deleted funcs. If you are vendoring this package in your project, make sure to adapt to these changes when adopting the new version of `gardener/gardener-extensions`.
```
