### PR TITLE
[ci:component:github.com/gardener/cert-management:0.2.5->0.2.6]

### DIFF
--- a/controllers/extension-shoot-cert-service/charts/images.yaml
+++ b/controllers/extension-shoot-cert-service/charts/images.yaml
@@ -2,4 +2,4 @@ images:
 - name: cert-management
   sourceRepository: github.com/gardener/cert-management
   repository: eu.gcr.io/gardener-project/cert-controller-manager
-  tag: "0.2.5"
+  tag: "0.2.6"


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/cert-management $5fa6f75bde5b7747e30fcdd12206bda85d6fc779
helm charts: splitting value `createCRDs` into two separate values
`createCRDs.issuers` and `createCRDs.certificates`
```