### PR TITLE
Set dns-controller-manager version to 0.7.2

### DIFF
--- a/controllers/extension-shoot-dns-service/charts/images.yaml
+++ b/controllers/extension-shoot-dns-service/charts/images.yaml
@@ -2,4 +2,4 @@ images:
 - name: dns-controller-manager
   sourceRepository: github.com/gardener/external-dns-management
   repository: eu.gcr.io/gardener-project/dns-controller-manager
-  tag: "0.7.1"
+  tag: "0.7.2"


### PR DESCRIPTION
**What this PR does / why we need it**:
dns-controller-manager version 0.7.2 fixes the issue that the name of image in component descriptor. Now the image name is the same as what is used by *extension-shoot-dns-service*. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
``` improvement user github.com/gardener/external-dns-management #43 @mandelsoft
For openstack designate it is possible now to 
specify a CA certificate in the credentails. The key is CACERT.
Additionally a dedicated client certificate and key can used
for the https requests (CLIENTCERT/CLIENTKEY)
```