### PR TITLE
Fix defaulting for storage classes

### DIFF
--- a/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/pkg/controller/controlplane/genericactuator/actuator.go
@@ -324,7 +324,7 @@ func (a *actuator) reconcileControlPlane(
 		return false, err
 	}
 
-	if err := extensionscontroller.RenderChartAndCreateManagedResource(ctx, cp.Namespace, controlPlaneShootChartResourceName, a.client, chartRenderer, a.controlPlaneShootChart, values, a.imageVector, metav1.NamespaceSystem, version, true); err != nil {
+	if err := extensionscontroller.RenderChartAndCreateManagedResource(ctx, cp.Namespace, controlPlaneShootChartResourceName, a.client, chartRenderer, a.controlPlaneShootChart, values, a.imageVector, metav1.NamespaceSystem, version, true, false); err != nil {
 		return false, errors.Wrapf(err, "could not apply control plane shoot chart for controlplane '%s'", util.ObjectName(cp))
 	}
 
@@ -334,7 +334,7 @@ func (a *actuator) reconcileControlPlane(
 		return false, err
 	}
 
-	if err := extensionscontroller.RenderChartAndCreateManagedResource(ctx, cp.Namespace, storageClassesChartResourceName, a.client, chartRenderer, a.storageClassesChart, values, a.imageVector, metav1.NamespaceSystem, version, true); err != nil {
+	if err := extensionscontroller.RenderChartAndCreateManagedResource(ctx, cp.Namespace, storageClassesChartResourceName, a.client, chartRenderer, a.storageClassesChart, values, a.imageVector, metav1.NamespaceSystem, version, true, true); err != nil {
 		return false, errors.Wrapf(err, "could not apply storage classes chart for controlplane '%s'", util.ObjectName(cp))
 	}
 

--- a/pkg/controller/controlplane/genericactuator/actuator_test.go
+++ b/pkg/controller/controlplane/genericactuator/actuator_test.go
@@ -62,8 +62,8 @@ const (
 )
 
 var (
-	vFalse = false
-	pFalse = &vFalse
+	vFalse, vTrue = false, true
+	pFalse, pTrue = &vFalse, &vTrue
 )
 
 func TestControlplane(t *testing.T) {
@@ -137,8 +137,9 @@ var _ = Describe("Actuator", func() {
 				SecretRefs: []corev1.LocalObjectReference{
 					{Name: controlPlaneShootChartResourceName},
 				},
-				InjectLabels: map[string]string{extensionscontroller.ShootNoCleanupLabel: "true"},
-				KeepObjects:  pFalse,
+				InjectLabels:              map[string]string{extensionscontroller.ShootNoCleanupLabel: "true"},
+				KeepObjects:               pFalse,
+				ForceOverwriteAnnotations: pFalse,
 			},
 		}
 		deletedMRSecretForCPShootChart = &corev1.Secret{
@@ -160,8 +161,9 @@ var _ = Describe("Actuator", func() {
 				SecretRefs: []corev1.LocalObjectReference{
 					{Name: storageClassesChartResourceName},
 				},
-				InjectLabels: map[string]string{extensionscontroller.ShootNoCleanupLabel: "true"},
-				KeepObjects:  pFalse,
+				InjectLabels:              map[string]string{extensionscontroller.ShootNoCleanupLabel: "true"},
+				KeepObjects:               pFalse,
+				ForceOverwriteAnnotations: pTrue,
 			},
 		}
 		deletedMRSecretForStorageClassesChart = &corev1.Secret{

--- a/pkg/controller/worker/genericactuator/machine_controller_manager.go
+++ b/pkg/controller/worker/genericactuator/machine_controller_manager.go
@@ -100,7 +100,7 @@ func (a *genericActuator) applyMachineControllerManagerShootChart(ctx context.Co
 		return err
 	}
 
-	if err := extensionscontroller.RenderChartAndCreateManagedResource(ctx, workerObj.Namespace, mcmShootResourceName, a.client, chartRenderer, a.mcmShootChart, values, a.imageVector, metav1.NamespaceSystem, cluster.Shoot.Spec.Kubernetes.Version, true); err != nil {
+	if err := extensionscontroller.RenderChartAndCreateManagedResource(ctx, workerObj.Namespace, mcmShootResourceName, a.client, chartRenderer, a.mcmShootChart, values, a.imageVector, metav1.NamespaceSystem, cluster.Shoot.Spec.Kubernetes.Version, true, false); err != nil {
 		return errors.Wrapf(err, "could not apply control plane shoot chart for worker '%s'", util.ObjectName(workerObj))
 	}
 


### PR DESCRIPTION
Co-Authored-by: Tim Ebert <tim.ebert@sap.com>

**What this PR does / why we need it**:
Previously the storage class name was `default`, however, this PR https://github.com/gardener/gardener-extensions/pull/415 caused two default storage classes to co-exist at the same time. To avoid this, we now use the `forceOverwriteAnnotations` flag from the `gardener-resource-manager` to ensure that all the annotations are updated accordingly.  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This is done for all storage-class charts. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
The default storage class annotations are now overwritten to the desired values using the `forceOverwriteAnnotation` parameter in the `extension-controlplane-storageclasses` managed resource. 
```
