### PR TITLE
[ci:component:github.com/gardener/cert-management:0.2.6->0.2.7]

### DIFF
--- a/controllers/extension-shoot-cert-service/charts/images.yaml
+++ b/controllers/extension-shoot-cert-service/charts/images.yaml
@@ -2,4 +2,4 @@ images:
 - name: cert-management
   sourceRepository: github.com/gardener/cert-management
   repository: eu.gcr.io/gardener-project/cert-controller-manager
-  tag: "0.2.6"
+  tag: "0.2.7"


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/cert-management #7 @MartinWeindel
fix for "Panic if ingress spec.tls.hosts not specified" (issue #6)
```

``` improvement operator github.com/gardener/cert-management $80a07c00937a3ac7a53af07fa0e8a4203678c28f
fix for "Panic if ingress spec.tls.hosts not specified" (issue #6)
```