### PR TITLE
[ci:component:github.com/gardener/cert-management:0.2.7->0.2.8]

### DIFF
--- a/controllers/extension-shoot-cert-service/charts/images.yaml
+++ b/controllers/extension-shoot-cert-service/charts/images.yaml
@@ -2,4 +2,4 @@ images:
 - name: cert-management
   sourceRepository: github.com/gardener/cert-management
   repository: eu.gcr.io/gardener-project/cert-controller-manager
-  tag: "0.2.7"
+  tag: "0.2.8"


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/cert-management #9 @MartinWeindel
Existing certificate secrets with type `kubernetes.io/tls` can be updated
to simplify migration from cert-broker/cert-manager.
```