### PR TITLE
Introduced checksums for shoot controlplane chart values

### DIFF
--- a/controllers/provider-alicloud/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-alicloud/pkg/controller/controlplane/valuesprovider.go
@@ -294,6 +294,7 @@ func (vp *valuesProvider) GetControlPlaneShootChartValues(
 	ctx context.Context,
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
+	checksums map[string]string,
 ) (map[string]interface{}, error) {
 	// Get credentials from the referenced secret
 	credentials, err := alicloud.ReadCredentialsFromSecretRef(ctx, vp.client, &cp.Spec.SecretRef)

--- a/controllers/provider-alicloud/pkg/controller/controlplane/valuesprovider_test.go
+++ b/controllers/provider-alicloud/pkg/controller/controlplane/valuesprovider_test.go
@@ -229,7 +229,7 @@ var _ = Describe("ValuesProvider", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Call GetControlPlaneChartValues method and check the result
-			values, err := vp.GetControlPlaneShootChartValues(context.TODO(), cp, cluster)
+			values, err := vp.GetControlPlaneShootChartValues(context.TODO(), cp, cluster, checksums)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(controlPlaneShootChartValues))
 		})

--- a/controllers/provider-packet/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-packet/pkg/controller/controlplane/valuesprovider.go
@@ -211,6 +211,7 @@ func (vp *valuesProvider) GetControlPlaneShootChartValues(
 	ctx context.Context,
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
+	checksum map[string]string,
 ) (map[string]interface{}, error) {
 	// Get credentials from the referenced secret
 	credentials, err := vp.getCredentials(ctx, cp)

--- a/controllers/provider-packet/pkg/controller/controlplane/valuesprovider_test.go
+++ b/controllers/provider-packet/pkg/controller/controlplane/valuesprovider_test.go
@@ -187,7 +187,7 @@ var _ = Describe("ValuesProvider", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Call GetControlPlaneChartValues method and check the result
-			values, err := vp.GetControlPlaneShootChartValues(context.TODO(), cp, cluster)
+			values, err := vp.GetControlPlaneShootChartValues(context.TODO(), cp, cluster, checksums)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(controlPlaneShootChartValues))
 		})

--- a/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/pkg/controller/controlplane/genericactuator/actuator.go
@@ -46,15 +46,15 @@ import (
 // ValuesProvider provides values for the 2 charts applied by this actuator.
 type ValuesProvider interface {
 	// GetConfigChartValues returns the values for the config chart applied by this actuator.
-	GetConfigChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster) (map[string]interface{}, error)
+	GetConfigChartValues(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, cluster *extensionscontroller.Cluster) (map[string]interface{}, error)
 	// GetControlPlaneChartValues returns the values for the control plane chart applied by this actuator.
-	GetControlPlaneChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster, map[string]string, bool) (map[string]interface{}, error)
+	GetControlPlaneChartValues(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, cluster *extensionscontroller.Cluster, checksums map[string]string, scaledDown bool) (map[string]interface{}, error)
 	// GetControlPlaneShootChartValues returns the values for the control plane shoot chart applied by this actuator.
-	GetControlPlaneShootChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster) (map[string]interface{}, error)
+	GetControlPlaneShootChartValues(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, cluster *extensionscontroller.Cluster, checksums map[string]string) (map[string]interface{}, error)
 	// GetStorageClassesChartValues returns the values for the storage classes chart applied by this actuator.
-	GetStorageClassesChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster) (map[string]interface{}, error)
+	GetStorageClassesChartValues(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, cluster *extensionscontroller.Cluster) (map[string]interface{}, error)
 	// GetControlPlaneExposureChartValues returns the values for the control plane exposure chart applied by this actuator.
-	GetControlPlaneExposureChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster, map[string]string) (map[string]interface{}, error)
+	GetControlPlaneExposureChartValues(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, cluster *extensionscontroller.Cluster, checksums map[string]string) (map[string]interface{}, error)
 }
 
 // NewActuator creates a new Actuator that acts upon and updates the status of ControlPlane resources.
@@ -319,7 +319,7 @@ func (a *actuator) reconcileControlPlane(
 	}
 
 	// Get control plane shoot chart values
-	values, err = a.vp.GetControlPlaneShootChartValues(ctx, cp, cluster)
+	values, err = a.vp.GetControlPlaneShootChartValues(ctx, cp, cluster, checksums)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controller/controlplane/genericactuator/actuator_test.go
+++ b/pkg/controller/controlplane/genericactuator/actuator_test.go
@@ -348,7 +348,7 @@ var _ = Describe("Actuator", func() {
 				vp.EXPECT().GetConfigChartValues(ctx, cp, cluster).Return(configChartValues, nil)
 			}
 			vp.EXPECT().GetControlPlaneChartValues(ctx, cp, cluster, checksums, false).Return(controlPlaneChartValues, nil)
-			vp.EXPECT().GetControlPlaneShootChartValues(ctx, cp, cluster).Return(controlPlaneShootChartValues, nil)
+			vp.EXPECT().GetControlPlaneShootChartValues(ctx, cp, cluster, checksums).Return(controlPlaneShootChartValues, nil)
 			vp.EXPECT().GetStorageClassesChartValues(ctx, cp, cluster).Return(storageClassesChartValues, nil)
 
 			// Create actuator

--- a/pkg/controller/controlplane/genericactuator/noopvaluesprovider.go
+++ b/pkg/controller/controlplane/genericactuator/noopvaluesprovider.go
@@ -34,7 +34,7 @@ func (vp *NoopValuesProvider) GetControlPlaneChartValues(context.Context, *exten
 }
 
 // GetControlPlaneShootChartValues returns the values for the control plane shoot chart applied by this actuator.
-func (vp *NoopValuesProvider) GetControlPlaneShootChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster) (map[string]interface{}, error) {
+func (vp *NoopValuesProvider) GetControlPlaneShootChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster, map[string]string) (map[string]interface{}, error) {
 	return nil, nil
 }
 

--- a/pkg/mock/gardener-extensions/controller/controlplane/genericactuator/mocks.go
+++ b/pkg/mock/gardener-extensions/controller/controlplane/genericactuator/mocks.go
@@ -81,18 +81,18 @@ func (mr *MockValuesProviderMockRecorder) GetControlPlaneExposureChartValues(arg
 }
 
 // GetControlPlaneShootChartValues mocks base method
-func (m *MockValuesProvider) GetControlPlaneShootChartValues(arg0 context.Context, arg1 *v1alpha1.ControlPlane, arg2 *controller.Cluster) (map[string]interface{}, error) {
+func (m *MockValuesProvider) GetControlPlaneShootChartValues(arg0 context.Context, arg1 *v1alpha1.ControlPlane, arg2 *controller.Cluster, arg3 map[string]string) (map[string]interface{}, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetControlPlaneShootChartValues", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetControlPlaneShootChartValues", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(map[string]interface{})
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetControlPlaneShootChartValues indicates an expected call of GetControlPlaneShootChartValues
-func (mr *MockValuesProviderMockRecorder) GetControlPlaneShootChartValues(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockValuesProviderMockRecorder) GetControlPlaneShootChartValues(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetControlPlaneShootChartValues", reflect.TypeOf((*MockValuesProvider)(nil).GetControlPlaneShootChartValues), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetControlPlaneShootChartValues", reflect.TypeOf((*MockValuesProvider)(nil).GetControlPlaneShootChartValues), arg0, arg1, arg2, arg3)
 }
 
 // GetStorageClassesChartValues mocks base method


### PR DESCRIPTION
Co-authored-by: Uwe Krueger <uwe.krueger@sap.com>

**What this PR does / why we need it**:
Add checksum to shoot control plane chart values interface. Those checksum might be needed for in-cluster object which have to be restarted when their corresponding secret object changes (e.g. `csi-node-plugin`).

**Release note**:
```improvement developer

```
