### PR TITLE
Fix typha calico-typha-vertical-autoscaler

### DIFF
--- a/controllers/networking-calico/charts/internal/calico/templates/typha-vertical-autoscaling-config.yaml
+++ b/controllers/networking-calico/charts/internal/calico/templates/typha-vertical-autoscaling-config.yaml
@@ -11,7 +11,7 @@ metadata:
 data:
   typha-autoscaler: |-
     {
-      "calico-typha-deploy": {
+      "calico-typha": {
         "requests": {
           "cpu": {
             "base": "120m",


### PR DESCRIPTION
**What this PR does / why we need it**:
According to `kubernetes-incubator/cluster-proportional-vertical-autoscaler` the config name in the ConfigMap (`calico-typha-deploy`) should match the container name (`calico-typha`)in the target resource.

**Which issue(s) this PR fixes**:
Fixes #454

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue preventing `calico-typha-vertical-autoscaler` to patch (scale) `calico-typha-deploy` is now fixed.
```
