### PR TITLE
Add bucket lifecycle rule for incomplete multipart uploads

### DIFF
--- a/controllers/provider-aws/pkg/aws/client/client.go
+++ b/controllers/provider-aws/pkg/aws/client/client.go
@@ -238,12 +238,36 @@ func (c *Client) CreateBucketIfNotExists(ctx context.Context, bucket, region str
 	}
 
 	if _, err := c.S3.CreateBucketWithContext(ctx, createBucketInput); err != nil {
-		if aerr, ok := err.(awserr.Error); ok && (aerr.Code() == s3.ErrCodeBucketAlreadyExists || aerr.Code() == s3.ErrCodeBucketAlreadyOwnedByYou) {
-			return nil
+		if aerr, ok := err.(awserr.Error); !ok {
+			return err
+		} else if aerr.Code() != s3.ErrCodeBucketAlreadyExists && aerr.Code() != s3.ErrCodeBucketAlreadyOwnedByYou {
+			return err
 		}
-		return err
 	}
-	return nil
+
+	// Set lifecycle rule to purge incomplete multipart upload orphaned because of force shutdown or rescheduling or networking issue with etcd-backup-restore.
+	putBucketLifecycleConfigurationInput := &s3.PutBucketLifecycleConfigurationInput{
+		Bucket: aws.String(bucket),
+		LifecycleConfiguration: &s3.BucketLifecycleConfiguration{
+			Rules: []*s3.LifecycleRule{
+				&s3.LifecycleRule{
+					// Note: Though as per documentation at https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleRule.html the Filter field is
+					// optional, if not specified the SDK API fails with `Malformed XML` error code. Cross verified same behavior with aws-cli client as well.
+					// Please do not remove it.
+					Filter: &s3.LifecycleRuleFilter{
+						Prefix: aws.String(""),
+					},
+					AbortIncompleteMultipartUpload: &s3.AbortIncompleteMultipartUpload{
+						DaysAfterInitiation: aws.Int64(7),
+					},
+					Status: aws.String(s3.ExpirationStatusEnabled),
+				},
+			},
+		},
+	}
+
+	_, err := c.S3.PutBucketLifecycleConfigurationWithContext(ctx, putBucketLifecycleConfigurationInput)
+	return err
 }
 
 // DeleteBucketIfExists deletes the s3 bucket with name <bucket>. If it does not exist,


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:
Add bucket lifecycle rule for AWS and Alicloud to cleanup incomplete multipart uploads after expiration period.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Please do-not-merge until i confirm anything is missing. The code wise and documentation wise PR is ready. But to test that, its actually taking effect, i have created a bucket with partial multipart uploads for both OSS and AWS account. The lifecycle configuration is set using controller. But i will check post two days if configuration  does clear these incomplete parts.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Add bucket lifecycle rule on AWS S3 and OSS bucket to cleanup incomplete multipart uploads after expiration period.
```
