### PR TITLE
Change computation of hash value for machine resources

### DIFF
--- a/controllers/provider-alicloud/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-alicloud/pkg/controller/worker/machines_test.go
@@ -120,6 +120,9 @@ var _ = Describe("Machines", func() {
 				zone1        string
 				zone2        string
 
+				workerPoolHash1 string
+				workerPoolHash2 string
+
 				shootVersionMajorMinor string
 				shootVersion           string
 				machineImages          []config.MachineImage
@@ -284,6 +287,9 @@ var _ = Describe("Machines", func() {
 				_ = alicloudv1alpha1.AddToScheme(scheme)
 				decoder = serializer.NewCodecFactory(scheme).UniversalDecoder()
 
+				workerPoolHash1, _ = worker.WorkerPoolHash(w.Spec.Pools[0], cluster)
+				workerPoolHash2, _ = worker.WorkerPoolHash(w.Spec.Pools[1], cluster)
+
 				workerDelegate = NewWorkerDelegate(c, scheme, decoder, machineImages, chartApplier, "", w, cluster)
 			})
 
@@ -326,15 +332,10 @@ var _ = Describe("Machines", func() {
 					machineClassNamePool2Zone1 = fmt.Sprintf("%s-%s-%s", namespace, namePool2, zone1)
 					machineClassNamePool2Zone2 = fmt.Sprintf("%s-%s-%s", namespace, namePool2, zone2)
 
-					machineClassHashPool1Zone1 = worker.MachineClassHash(machineClassPool1Zone1, shootVersionMajorMinor)
-					machineClassHashPool1Zone2 = worker.MachineClassHash(machineClassPool1Zone2, shootVersionMajorMinor)
-					machineClassHashPool2Zone1 = worker.MachineClassHash(machineClassPool2Zone1, shootVersionMajorMinor)
-					machineClassHashPool2Zone2 = worker.MachineClassHash(machineClassPool2Zone2, shootVersionMajorMinor)
-
-					machineClassWithHashPool1Zone1 = fmt.Sprintf("%s-%s", machineClassNamePool1Zone1, machineClassHashPool1Zone1)
-					machineClassWithHashPool1Zone2 = fmt.Sprintf("%s-%s", machineClassNamePool1Zone2, machineClassHashPool1Zone2)
-					machineClassWithHashPool2Zone1 = fmt.Sprintf("%s-%s", machineClassNamePool2Zone1, machineClassHashPool2Zone1)
-					machineClassWithHashPool2Zone2 = fmt.Sprintf("%s-%s", machineClassNamePool2Zone2, machineClassHashPool2Zone2)
+					machineClassWithHashPool1Zone1 = fmt.Sprintf("%s-%s", machineClassNamePool1Zone1, workerPoolHash1)
+					machineClassWithHashPool1Zone2 = fmt.Sprintf("%s-%s", machineClassNamePool1Zone2, workerPoolHash1)
+					machineClassWithHashPool2Zone1 = fmt.Sprintf("%s-%s", machineClassNamePool2Zone1, workerPoolHash2)
+					machineClassWithHashPool2Zone2 = fmt.Sprintf("%s-%s", machineClassNamePool2Zone2, workerPoolHash2)
 				)
 
 				addNameAndSecretToMachineClass(machineClassPool1Zone1, alicloudAccessKeyID, alicloudAccessKeySecret, machineClassWithHashPool1Zone1)

--- a/controllers/provider-aws/pkg/controller/worker/machines.go
+++ b/controllers/provider-aws/pkg/controller/worker/machines.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gardener/gardener-extensions/controllers/provider-aws/pkg/aws"
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	"github.com/gardener/gardener-extensions/pkg/controller/worker"
-	"github.com/gardener/gardener-extensions/pkg/util"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
@@ -91,11 +90,6 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 		return err
 	}
 
-	shootVersionMajorMinor, err := util.VersionMajorMinor(w.cluster.Shoot.Spec.Kubernetes.Version)
-	if err != nil {
-		return err
-	}
-
 	infrastructureStatus := &awsapi.InfrastructureStatus{}
 	if _, _, err := w.decoder.Decode(w.worker.Spec.InfrastructureProviderStatus.Raw, nil, infrastructureStatus); err != nil {
 		return err
@@ -112,6 +106,11 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 
 	for _, pool := range w.worker.Spec.Pools {
 		zoneLen := len(pool.Zones)
+
+		workerPoolHash, err := worker.WorkerPoolHash(pool, w.cluster)
+		if err != nil {
+			return err
+		}
 
 		ami, err := w.findMachineImage(pool.MachineImage.Name, pool.MachineImage.Version, w.worker.Spec.Region)
 		if err != nil {
@@ -177,9 +176,8 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			}
 
 			var (
-				machineClassSpecHash = worker.MachineClassHash(machineClassSpec, shootVersionMajorMinor)
-				deploymentName       = fmt.Sprintf("%s-%s-z%d", w.worker.Namespace, pool.Name, zoneIndex+1)
-				className            = fmt.Sprintf("%s-%s", deploymentName, machineClassSpecHash)
+				deploymentName = fmt.Sprintf("%s-%s-z%d", w.worker.Namespace, pool.Name, zoneIndex+1)
+				className      = fmt.Sprintf("%s-%s", deploymentName, workerPoolHash)
 			)
 
 			machineDeployments = append(machineDeployments, worker.MachineDeployment{

--- a/controllers/provider-aws/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-aws/pkg/controller/worker/machines_test.go
@@ -118,6 +118,9 @@ var _ = Describe("Machines", func() {
 				zone1       string
 				zone2       string
 
+				workerPoolHash1 string
+				workerPoolHash2 string
+
 				shootVersionMajorMinor   string
 				shootVersion             string
 				machineImageToAMIMapping []config.MachineImage
@@ -297,6 +300,9 @@ var _ = Describe("Machines", func() {
 				_ = awsv1alpha1.AddToScheme(scheme)
 				decoder = serializer.NewCodecFactory(scheme).UniversalDecoder()
 
+				workerPoolHash1, _ = worker.WorkerPoolHash(w.Spec.Pools[0], cluster)
+				workerPoolHash2, _ = worker.WorkerPoolHash(w.Spec.Pools[1], cluster)
+
 				workerDelegate = NewWorkerDelegate(c, scheme, decoder, machineImageToAMIMapping, chartApplier, "", w, cluster)
 			})
 
@@ -373,15 +379,10 @@ var _ = Describe("Machines", func() {
 					machineClassNamePool2Zone1 = fmt.Sprintf("%s-%s-z1", namespace, namePool2)
 					machineClassNamePool2Zone2 = fmt.Sprintf("%s-%s-z2", namespace, namePool2)
 
-					machineClassHashPool1Zone1 = worker.MachineClassHash(machineClassPool1Zone1, shootVersionMajorMinor)
-					machineClassHashPool1Zone2 = worker.MachineClassHash(machineClassPool1Zone2, shootVersionMajorMinor)
-					machineClassHashPool2Zone1 = worker.MachineClassHash(machineClassPool2Zone1, shootVersionMajorMinor)
-					machineClassHashPool2Zone2 = worker.MachineClassHash(machineClassPool2Zone2, shootVersionMajorMinor)
-
-					machineClassWithHashPool1Zone1 = fmt.Sprintf("%s-%s", machineClassNamePool1Zone1, machineClassHashPool1Zone1)
-					machineClassWithHashPool1Zone2 = fmt.Sprintf("%s-%s", machineClassNamePool1Zone2, machineClassHashPool1Zone2)
-					machineClassWithHashPool2Zone1 = fmt.Sprintf("%s-%s", machineClassNamePool2Zone1, machineClassHashPool2Zone1)
-					machineClassWithHashPool2Zone2 = fmt.Sprintf("%s-%s", machineClassNamePool2Zone2, machineClassHashPool2Zone2)
+					machineClassWithHashPool1Zone1 = fmt.Sprintf("%s-%s", machineClassNamePool1Zone1, workerPoolHash1)
+					machineClassWithHashPool1Zone2 = fmt.Sprintf("%s-%s", machineClassNamePool1Zone2, workerPoolHash1)
+					machineClassWithHashPool2Zone1 = fmt.Sprintf("%s-%s", machineClassNamePool2Zone1, workerPoolHash2)
+					machineClassWithHashPool2Zone2 = fmt.Sprintf("%s-%s", machineClassNamePool2Zone2, workerPoolHash2)
 				)
 
 				addNameAndSecretToMachineClass(machineClassPool1Zone1, awsAccessKeyID, awsSecretAccessKey, machineClassWithHashPool1Zone1)

--- a/controllers/provider-azure/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-azure/pkg/controller/worker/machines_test.go
@@ -112,6 +112,9 @@ var _ = Describe("Machines", func() {
 				maxSurgePool2       intstr.IntOrString
 				maxUnavailablePool2 intstr.IntOrString
 
+				workerPoolHash1 string
+				workerPoolHash2 string
+
 				shootVersionMajorMinor string
 				shootVersion           string
 				machineImages          []config.MachineImage
@@ -253,6 +256,9 @@ var _ = Describe("Machines", func() {
 				_ = azurev1alpha1.AddToScheme(scheme)
 				decoder = serializer.NewCodecFactory(scheme).UniversalDecoder()
 
+				workerPoolHash1, _ = worker.WorkerPoolHash(w.Spec.Pools[0], cluster)
+				workerPoolHash2, _ = worker.WorkerPoolHash(w.Spec.Pools[1], cluster)
+
 				workerDelegate = NewWorkerDelegate(c, scheme, decoder, machineImages, chartApplier, "", w, cluster)
 			})
 
@@ -291,11 +297,8 @@ var _ = Describe("Machines", func() {
 					machineClassNamePool1 = fmt.Sprintf("%s-%s", namespace, namePool1)
 					machineClassNamePool2 = fmt.Sprintf("%s-%s", namespace, namePool2)
 
-					machineClassHashPool1 = worker.MachineClassHash(machineClassPool1, shootVersionMajorMinor)
-					machineClassHashPool2 = worker.MachineClassHash(machineClassPool2, shootVersionMajorMinor)
-
-					machineClassWithHashPool1 = fmt.Sprintf("%s-%s", machineClassNamePool1, machineClassHashPool1)
-					machineClassWithHashPool2 = fmt.Sprintf("%s-%s", machineClassNamePool2, machineClassHashPool2)
+					machineClassWithHashPool1 = fmt.Sprintf("%s-%s", machineClassNamePool1, workerPoolHash1)
+					machineClassWithHashPool2 = fmt.Sprintf("%s-%s", machineClassNamePool2, workerPoolHash2)
 				)
 
 				addNameAndSecretsToMachineClass(machineClassPool1, azureClientID, azureClientSecret, azureSubscriptionID, azureTenantID, machineClassWithHashPool1)

--- a/controllers/provider-openstack/pkg/controller/worker/machines.go
+++ b/controllers/provider-openstack/pkg/controller/worker/machines.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gardener/gardener-extensions/controllers/provider-openstack/pkg/openstack"
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	"github.com/gardener/gardener-extensions/pkg/controller/worker"
-	"github.com/gardener/gardener-extensions/pkg/util"
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -95,11 +94,6 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 		return err
 	}
 
-	shootVersionMajorMinor, err := util.VersionMajorMinor(w.cluster.Shoot.Spec.Kubernetes.Version)
-	if err != nil {
-		return err
-	}
-
 	infrastructureStatus := &openstackapi.InfrastructureStatus{}
 	if _, _, err := w.decoder.Decode(w.worker.Spec.InfrastructureProviderStatus.Raw, nil, infrastructureStatus); err != nil {
 		return err
@@ -112,6 +106,11 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 
 	for _, pool := range w.worker.Spec.Pools {
 		zoneLen := len(pool.Zones)
+
+		workerPoolHash, err := worker.WorkerPoolHash(pool, w.cluster)
+		if err != nil {
+			return err
+		}
 
 		machineImage, err := w.findMachineImage(pool.MachineImage.Name, pool.MachineImage.Version, w.cluster.CloudProfile.Name)
 		if err != nil {
@@ -143,9 +142,8 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			}
 
 			var (
-				machineClassSpecHash = worker.MachineClassHash(machineClassSpec, shootVersionMajorMinor)
-				deploymentName       = fmt.Sprintf("%s-%s-z%d", w.worker.Namespace, pool.Name, zoneIndex+1)
-				className            = fmt.Sprintf("%s-%s", deploymentName, machineClassSpecHash)
+				deploymentName = fmt.Sprintf("%s-%s-z%d", w.worker.Namespace, pool.Name, zoneIndex+1)
+				className      = fmt.Sprintf("%s-%s", deploymentName, workerPoolHash)
 			)
 
 			machineDeployments = append(machineDeployments, worker.MachineDeployment{

--- a/controllers/provider-openstack/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-openstack/pkg/controller/worker/machines_test.go
@@ -115,6 +115,9 @@ var _ = Describe("Machines", func() {
 				zone1 string
 				zone2 string
 
+				workerPoolHash1 string
+				workerPoolHash2 string
+
 				shootVersionMajorMinor             string
 				shootVersion                       string
 				machineImageToCloudProfilesMapping []config.MachineImage
@@ -278,6 +281,9 @@ var _ = Describe("Machines", func() {
 				_ = openstackv1alpha1.AddToScheme(scheme)
 				decoder = serializer.NewCodecFactory(scheme).UniversalDecoder()
 
+				workerPoolHash1, _ = worker.WorkerPoolHash(w.Spec.Pools[0], cluster)
+				workerPoolHash2, _ = worker.WorkerPoolHash(w.Spec.Pools[1], cluster)
+
 				workerDelegate = NewWorkerDelegate(c, scheme, decoder, machineImageToCloudProfilesMapping, chartApplier, "", w, cluster)
 			})
 
@@ -313,15 +319,10 @@ var _ = Describe("Machines", func() {
 					machineClassNamePool2Zone1 = fmt.Sprintf("%s-%s-z1", namespace, namePool2)
 					machineClassNamePool2Zone2 = fmt.Sprintf("%s-%s-z2", namespace, namePool2)
 
-					machineClassHashPool1Zone1 = worker.MachineClassHash(machineClassPool1Zone1, shootVersionMajorMinor)
-					machineClassHashPool1Zone2 = worker.MachineClassHash(machineClassPool1Zone2, shootVersionMajorMinor)
-					machineClassHashPool2Zone1 = worker.MachineClassHash(machineClassPool2Zone1, shootVersionMajorMinor)
-					machineClassHashPool2Zone2 = worker.MachineClassHash(machineClassPool2Zone2, shootVersionMajorMinor)
-
-					machineClassWithHashPool1Zone1 = fmt.Sprintf("%s-%s", machineClassNamePool1Zone1, machineClassHashPool1Zone1)
-					machineClassWithHashPool1Zone2 = fmt.Sprintf("%s-%s", machineClassNamePool1Zone2, machineClassHashPool1Zone2)
-					machineClassWithHashPool2Zone1 = fmt.Sprintf("%s-%s", machineClassNamePool2Zone1, machineClassHashPool2Zone1)
-					machineClassWithHashPool2Zone2 = fmt.Sprintf("%s-%s", machineClassNamePool2Zone2, machineClassHashPool2Zone2)
+					machineClassWithHashPool1Zone1 = fmt.Sprintf("%s-%s", machineClassNamePool1Zone1, workerPoolHash1)
+					machineClassWithHashPool1Zone2 = fmt.Sprintf("%s-%s", machineClassNamePool1Zone2, workerPoolHash1)
+					machineClassWithHashPool2Zone1 = fmt.Sprintf("%s-%s", machineClassNamePool2Zone1, workerPoolHash2)
+					machineClassWithHashPool2Zone2 = fmt.Sprintf("%s-%s", machineClassNamePool2Zone2, workerPoolHash2)
 				)
 
 				addNameAndSecretToMachineClass(machineClassPool1Zone1, openstackAuthURL, openstackDomainName, openstackTenantName, openstackUserName, openstackPassword, machineClassWithHashPool1Zone1)

--- a/controllers/provider-packet/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-packet/pkg/controller/worker/machines_test.go
@@ -108,6 +108,9 @@ var _ = Describe("Machines", func() {
 				zone1 = region + "a"
 				zone2 = region + "b"
 
+				workerPoolHash1 string
+				workerPoolHash2 string
+
 				shootVersionMajorMinor string
 				shootVersion           string
 				machineImages          []config.MachineImage
@@ -227,6 +230,9 @@ var _ = Describe("Machines", func() {
 				_ = packetv1alpha1.AddToScheme(scheme)
 				decoder = serializer.NewCodecFactory(scheme).UniversalDecoder()
 
+				workerPoolHash1, _ = worker.WorkerPoolHash(w.Spec.Pools[0], cluster)
+				workerPoolHash2, _ = worker.WorkerPoolHash(w.Spec.Pools[1], cluster)
+
 				workerDelegate = NewWorkerDelegate(c, scheme, decoder, machineImages, chartApplier, "", w, cluster)
 			})
 
@@ -260,11 +266,8 @@ var _ = Describe("Machines", func() {
 					machineClassNamePool1 = fmt.Sprintf("%s-%s", namespace, namePool1)
 					machineClassNamePool2 = fmt.Sprintf("%s-%s", namespace, namePool2)
 
-					machineClassHashPool1 = worker.MachineClassHash(machineClassPool1, shootVersionMajorMinor)
-					machineClassHashPool2 = worker.MachineClassHash(machineClassPool2, shootVersionMajorMinor)
-
-					machineClassWithHashPool1 = fmt.Sprintf("%s-%s", machineClassNamePool1, machineClassHashPool1)
-					machineClassWithHashPool2 = fmt.Sprintf("%s-%s", machineClassNamePool2, machineClassHashPool2)
+					machineClassWithHashPool1 = fmt.Sprintf("%s-%s", machineClassNamePool1, workerPoolHash1)
+					machineClassWithHashPool2 = fmt.Sprintf("%s-%s", machineClassNamePool2, workerPoolHash2)
 				)
 
 				addNameAndSecretToMachineClass(machineClassPool1, packetAPIToken, machineClassWithHashPool1)

--- a/go.sum
+++ b/go.sum
@@ -187,6 +187,7 @@ github.com/gardener/gardener v0.0.0-20191004085047-5707d498b40c/go.mod h1:zvajWs
 github.com/gardener/gardener v0.0.0-20191028054636-32cb0027c126/go.mod h1:Ow7vOXQYgQeHTRFn2HdbEIptelrSB5NLmVFIt2rgNeY=
 github.com/gardener/gardener v0.0.0-20191127162005-7672763b3716 h1:kgId28oDm4L3YZBxLetHlSZxh5WtaGrqEbtbvLIDnlc=
 github.com/gardener/gardener v0.0.0-20191127162005-7672763b3716/go.mod h1:1jloIC1rnp1/+tADocrCsCuPuZL0o5PfgWAu3DQ2w10=
+github.com/gardener/gardener v0.32.0 h1:spFtOkukfbZGw+zyH/FKsMYuwrmWeXZf1BqAFILFmNs=
 github.com/gardener/gardener-extensions v0.0.0-20190725050243-a80ef643c64b/go.mod h1:uXjtl3KeVdQXuGIP26+84wJY1Kwru67l0FXm7A5DiME=
 github.com/gardener/gardener-extensions v0.0.0-20190820050625-a15de8a82f6b/go.mod h1:q69+1cUGSfQ8gSMWzU7GFz/R8K8MpOLQBT2wJJcCjEA=
 github.com/gardener/gardener-extensions v0.0.0-20190906160200-5c329d46ae81/go.mod h1:OBUAbab8OMm8pvzr/1/cdwIQnQYuMoGDTNR2c+i9nYo=


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to prevent undesired rolling updates the hash value for machine resources is now computed only out of 
* machine type
* volume type + size
* worker pool provider config
* kubernetes version
* machine image name + version

**Special notes for your reviewer**:
/cc @vlerenc 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
:warning: In order to prevent undesired rolling updates of machine resources the hash value computation has changed. A rolling update of worker nodes is now only happening if one of the following properties is changed: Kubernetes major/minor version, machine image name or version, machine type, volume type or size, worker pool provider configuration. Deploying this change will, one last time, roll out all nodes of all clusters.
```
