### PR TITLE
[ci:component:github.com/gardener/cert-management:0.2.8->v0.2.9]

### DIFF
--- a/controllers/extension-shoot-cert-service/charts/images.yaml
+++ b/controllers/extension-shoot-cert-service/charts/images.yaml
@@ -2,4 +2,4 @@ images:
 - name: cert-management
   sourceRepository: github.com/gardener/cert-management
   repository: eu.gcr.io/gardener-project/cert-controller-manager
-  tag: "0.2.8"
+  tag: "v0.2.9"


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/cert-management #10 @MartinWeindel
The release tags from now are prefixed with `v`.
```