### PR TITLE
Put Infrastructure state into status as runtime.RawExtension

### DIFF
--- a/controllers/provider-alicloud/pkg/controller/infrastructure/actuator_test.go
+++ b/controllers/provider-alicloud/pkg/controller/infrastructure/actuator_test.go
@@ -35,6 +35,7 @@ import (
 	mockterraformer "github.com/gardener/gardener-extensions/pkg/mock/gardener-extensions/terraformer"
 	mockgardenerchartrenderer "github.com/gardener/gardener-extensions/pkg/mock/gardener/chartrenderer"
 	"github.com/gardener/gardener-extensions/pkg/mock/go-logr/logr"
+	realterraformer "github.com/gardener/gardener-extensions/pkg/terraformer"
 	"github.com/gardener/gardener-extensions/pkg/util/chart"
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 
@@ -168,6 +169,10 @@ var _ = Describe("Actuator", func() {
 					natGatewayID    = "natGatewayID"
 					securityGroupID = "sgID"
 					keyPairName     = "keyPairName"
+					rawState        = &realterraformer.RawState{
+						Data:     "",
+						Encoding: "none",
+					}
 				)
 
 				describeNATGatewaysReq := vpc.CreateDescribeNatGatewaysRequest()
@@ -228,7 +233,7 @@ var _ = Describe("Actuator", func() {
 						},
 					}, nil),
 
-					terraformerFactory.EXPECT().DefaultInitializer(c, mainContent, variablesContent, []byte(tfVarsContent)).Return(initializer),
+					terraformerFactory.EXPECT().DefaultInitializer(c, mainContent, variablesContent, []byte(tfVarsContent), "").Return(initializer),
 
 					terraformer.EXPECT().InitializeWith(initializer).Return(terraformer),
 
@@ -255,7 +260,7 @@ var _ = Describe("Actuator", func() {
 							TerraformerOutputKeySecurityGroupID: securityGroupID,
 							TerraformerOutputKeyKeyPairName:     keyPairName,
 						}, nil),
-
+					terraformer.EXPECT().GetRawState(context.TODO()).Return(rawState, nil),
 					c.EXPECT().Status().Return(c),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: infra.Namespace, Name: infra.Name}, &infra),
 

--- a/controllers/provider-azure/pkg/controller/infrastructure/actuator.go
+++ b/controllers/provider-azure/pkg/controller/infrastructure/actuator.go
@@ -16,7 +16,6 @@ package infrastructure
 
 import (
 	"context"
-
 	azurev1alpha1 "github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/apis/azure/v1alpha1"
 	infrainternal "github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/internal/infrastructure"
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
@@ -79,8 +78,18 @@ func (a *actuator) updateProviderStatus(
 		return err
 	}
 
+	state, err := tf.GetRawState(ctx)
+	if err != nil {
+		return err
+	}
+	stateByte, err := state.Marshal()
+	if err != nil {
+		return err
+	}
+
 	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, a.client, infra, func() error {
 		infra.Status.ProviderStatus = &runtime.RawExtension{Object: status}
+		infra.Status.State = &runtime.RawExtension{Raw: stateByte}
 		return nil
 	})
 }

--- a/controllers/provider-azure/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/controllers/provider-azure/pkg/controller/infrastructure/actuator_reconcile.go
@@ -39,6 +39,11 @@ func (a *actuator) Reconcile(ctx context.Context, infra *extensionsv1alpha1.Infr
 		return err
 	}
 
+	terraformState, err := terraformer.UnmarshalRawState(infra.Status.State)
+	if err != nil {
+		return err
+	}
+
 	terraformFiles, err := infrastructure.RenderTerraformerChart(a.chartRenderer, infra, clientAuth, config, cluster)
 	if err != nil {
 		return err
@@ -50,7 +55,7 @@ func (a *actuator) Reconcile(ctx context.Context, infra *extensionsv1alpha1.Infr
 	}
 
 	if err := tf.
-		InitializeWith(terraformer.DefaultInitializer(a.client, terraformFiles.Main, terraformFiles.Variables, terraformFiles.TFVars)).
+		InitializeWith(terraformer.DefaultInitializer(a.client, terraformFiles.Main, terraformFiles.Variables, terraformFiles.TFVars, terraformState.Data)).
 		Apply(); err != nil {
 
 		a.logger.Error(err, "failed to apply the terraform config", "infrastructure", infra.Name)

--- a/controllers/provider-gcp/pkg/controller/infrastructure/actuator.go
+++ b/controllers/provider-gcp/pkg/controller/infrastructure/actuator.go
@@ -79,8 +79,18 @@ func (a *actuator) updateProviderStatus(
 		return err
 	}
 
+	state, err := tf.GetRawState(ctx)
+	if err != nil {
+		return err
+	}
+	stateByte, err := state.Marshal()
+	if err != nil {
+		return err
+	}
+
 	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, a.client, infra, func() error {
 		infra.Status.ProviderStatus = &runtime.RawExtension{Object: status}
+		infra.Status.State = &runtime.RawExtension{Raw: stateByte}
 		return nil
 	})
 }

--- a/controllers/provider-gcp/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/controllers/provider-gcp/pkg/controller/infrastructure/actuator_reconcile.go
@@ -39,6 +39,11 @@ func (a *actuator) Reconcile(ctx context.Context, infra *extensionsv1alpha1.Infr
 		return err
 	}
 
+	terraformState, err := terraformer.UnmarshalRawState(infra.Status.State)
+	if err != nil {
+		return err
+	}
+
 	terraformFiles, err := infrastructure.RenderTerraformerChart(a.chartRenderer, infra, serviceAccount, config, cluster)
 	if err != nil {
 		return err
@@ -50,7 +55,7 @@ func (a *actuator) Reconcile(ctx context.Context, infra *extensionsv1alpha1.Infr
 	}
 
 	if err := tf.
-		InitializeWith(terraformer.DefaultInitializer(a.client, terraformFiles.Main, terraformFiles.Variables, terraformFiles.TFVars)).
+		InitializeWith(terraformer.DefaultInitializer(a.client, terraformFiles.Main, terraformFiles.Variables, terraformFiles.TFVars, terraformState.Data)).
 		Apply(); err != nil {
 
 		a.logger.Error(err, "failed to apply the terraform config", "infrastructure", infra.Name)

--- a/controllers/provider-openstack/pkg/controller/infrastructure/actuator.go
+++ b/controllers/provider-openstack/pkg/controller/infrastructure/actuator.go
@@ -16,6 +16,7 @@ package infrastructure
 
 import (
 	"context"
+
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	"k8s.io/client-go/util/retry"
 
@@ -101,8 +102,18 @@ func (a *actuator) updateProviderStatus(
 		return err
 	}
 
+	state, err := tf.GetRawState(ctx)
+	if err != nil {
+		return err
+	}
+	stateByte, err := state.Marshal()
+	if err != nil {
+		return err
+	}
+
 	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, a.client, infra, func() error {
 		infra.Status.ProviderStatus = &runtime.RawExtension{Object: status}
+		infra.Status.State = &runtime.RawExtension{Raw: stateByte}
 		return nil
 	})
 }

--- a/controllers/provider-openstack/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/controllers/provider-openstack/pkg/controller/infrastructure/actuator_reconcile.go
@@ -38,6 +38,11 @@ func (a *actuator) reconcile(ctx context.Context, infra *extensionsv1alpha1.Infr
 		return err
 	}
 
+	terraformState, err := terraformer.UnmarshalRawState(infra.Status.State)
+	if err != nil {
+		return err
+	}
+
 	terraformFiles, err := infrastructure.RenderTerraformerChart(a.chartRenderer, infra, creds, config, cluster)
 	if err != nil {
 		return err
@@ -49,7 +54,7 @@ func (a *actuator) reconcile(ctx context.Context, infra *extensionsv1alpha1.Infr
 	}
 
 	if err := tf.
-		InitializeWith(terraformer.DefaultInitializer(a.client, terraformFiles.Main, terraformFiles.Variables, terraformFiles.TFVars)).
+		InitializeWith(terraformer.DefaultInitializer(a.client, terraformFiles.Main, terraformFiles.Variables, terraformFiles.TFVars, terraformState.Data)).
 		Apply(); err != nil {
 
 		a.logger.Error(err, "failed to apply the terraform config", "infrastructure", infra.Name)

--- a/pkg/mock/gardener-extensions/terraformer/mocks.go
+++ b/pkg/mock/gardener-extensions/terraformer/mocks.go
@@ -5,6 +5,7 @@
 package terraformer
 
 import (
+	context "context"
 	terraformer "github.com/gardener/gardener-extensions/pkg/terraformer"
 	gomock "github.com/golang/mock/gomock"
 	logrus "github.com/sirupsen/logrus"
@@ -79,6 +80,21 @@ func (m *MockTerraformer) Destroy() error {
 func (mr *MockTerraformerMockRecorder) Destroy() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockTerraformer)(nil).Destroy))
+}
+
+// GetRawState mocks base method
+func (m *MockTerraformer) GetRawState(arg0 context.Context) (*terraformer.RawState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRawState", arg0)
+	ret0, _ := ret[0].(*terraformer.RawState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRawState indicates an expected call of GetRawState
+func (mr *MockTerraformerMockRecorder) GetRawState(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRawState", reflect.TypeOf((*MockTerraformer)(nil).GetRawState), arg0)
 }
 
 // GetStateOutputVariables mocks base method
@@ -231,17 +247,17 @@ func (m *MockFactory) EXPECT() *MockFactoryMockRecorder {
 }
 
 // DefaultInitializer mocks base method
-func (m *MockFactory) DefaultInitializer(arg0 client.Client, arg1, arg2 string, arg3 []byte) terraformer.Initializer {
+func (m *MockFactory) DefaultInitializer(arg0 client.Client, arg1, arg2 string, arg3 []byte, arg4 string) terraformer.Initializer {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DefaultInitializer", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "DefaultInitializer", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(terraformer.Initializer)
 	return ret0
 }
 
 // DefaultInitializer indicates an expected call of DefaultInitializer
-func (mr *MockFactoryMockRecorder) DefaultInitializer(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockFactoryMockRecorder) DefaultInitializer(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultInitializer", reflect.TypeOf((*MockFactory)(nil).DefaultInitializer), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultInitializer", reflect.TypeOf((*MockFactory)(nil).DefaultInitializer), arg0, arg1, arg2, arg3, arg4)
 }
 
 // New mocks base method

--- a/pkg/terraformer/raw_state.go
+++ b/pkg/terraformer/raw_state.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package terraformer
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Marshal transform RawState to []byte representation. It encodes the raw state data
+func (trs *RawState) Marshal() ([]byte, error) {
+	return json.Marshal(trs.encodeBase64())
+}
+
+// UnmarshalRawState transform passed rawState to RawState struct. It tries to decode the state
+func UnmarshalRawState(rawState interface{}) (*RawState, error) {
+	var rawData []byte
+
+	switch v := rawState.(type) {
+	case *runtime.RawExtension:
+		if v == nil {
+			rawData = nil
+		} else {
+			rawData = v.Raw
+		}
+	case []byte:
+		rawData = v
+	case string:
+		rawData = []byte(v)
+	case nil:
+		rawData = nil
+	default:
+		return nil, fmt.Errorf("unsupported type '%T' for unmarshaling Raw Terraform State", rawState)
+	}
+
+	terraformStateObj, err := buildRawState(rawData)
+	if err != nil {
+		return nil, err
+	}
+	return terraformStateObj.decode()
+}
+
+// buildRawState returns RawState from byte slice
+func buildRawState(terraformRawState []byte) (*RawState, error) {
+	trs := &RawState{}
+
+	if terraformRawState == nil {
+		return &RawState{
+			Data:     "",
+			Encoding: NoneEncoding,
+		}, nil
+	}
+
+	if err := json.Unmarshal(terraformRawState, trs); err != nil {
+		return nil, err
+	}
+	return trs, nil
+}
+
+// encodeBase64 encode the RawState.Data if it is not already base64 encoded
+func (trs *RawState) encodeBase64() *RawState {
+	if trs.Encoding != Base64Encoding {
+		trs.Data = base64.StdEncoding.EncodeToString([]byte(trs.Data))
+		trs.Encoding = Base64Encoding
+	}
+	return trs
+}
+
+// decode tries to decode RawState.Data
+func (trs *RawState) decode() (*RawState, error) {
+	switch trs.Encoding {
+	case Base64Encoding:
+		trsDec, err := base64.StdEncoding.DecodeString(trs.Data)
+		if err != nil {
+			return nil, err
+		}
+		trs.Data = string(trsDec)
+		trs.Encoding = NoneEncoding
+	case NoneEncoding:
+		//do nothing
+	default:
+		return nil, fmt.Errorf("unrecognised encoding %q for RawState.Data", trs.Encoding)
+	}
+
+	return trs, nil
+}

--- a/pkg/terraformer/terraform_test.go
+++ b/pkg/terraformer/terraform_test.go
@@ -195,7 +195,7 @@ var _ = Describe("terraformer", func() {
 		)
 
 		runInitializer := func(initializeState bool) error {
-			return DefaultInitializer(c, main, variables, tfVars).Initialize(&InitializerConfig{
+			return DefaultInitializer(c, main, variables, tfVars, "").Initialize(&InitializerConfig{
 				Namespace:         namespace,
 				ConfigurationName: configurationName,
 				VariablesName:     variablesName,

--- a/pkg/terraformer/terraformer.go
+++ b/pkg/terraformer/terraformer.go
@@ -58,8 +58,8 @@ func (f factory) New(logger logrus.FieldLogger, client client.Client, coreV1Clie
 	return New(logger, client, coreV1Client, purpose, namespace, name, image)
 }
 
-func (f factory) DefaultInitializer(c client.Client, main, variables string, tfVars []byte) Initializer {
-	return DefaultInitializer(c, main, variables, tfVars)
+func (f factory) DefaultInitializer(c client.Client, main, variables string, tfVars []byte, state string) Initializer {
+	return DefaultInitializer(c, main, variables, tfVars, state)
 }
 
 // DefaultFactory returns the default factory.

--- a/pkg/terraformer/types.go
+++ b/pkg/terraformer/types.go
@@ -15,6 +15,7 @@
 package terraformer
 
 import (
+	"context"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -63,6 +64,12 @@ type terraformer struct {
 	deadlinePod      time.Duration
 }
 
+// RawState represent the terraformer state's raw data
+type RawState struct {
+	Data     string `json:"data"`
+	Encoding string `json:"encoding"`
+}
+
 const (
 	numberOfConfigResources = 3
 
@@ -80,6 +87,12 @@ const (
 	// Deprecated: Terraformer does no longer uses a Job. Kept for backwards compatibility.
 	// TODO: Remove after several releases.
 	TerraformerJobSuffix = ".tf-job"
+
+	// Base64Encoding denotes base64 encoding for the RawState.Data
+	Base64Encoding = "base64"
+
+	// NoneEncoding denotes none encoding for the RawState.Data
+	NoneEncoding = "none"
 )
 
 // Terraformer is the Terraformer interface.
@@ -93,6 +106,7 @@ type Terraformer interface {
 	Destroy() error
 	GetStateOutputVariables(variables ...string) (map[string]string, error)
 	ConfigExists() (bool, error)
+	GetRawState(context.Context) (*RawState, error)
 }
 
 // Initializer can initialize a Terraformer.
@@ -104,5 +118,5 @@ type Initializer interface {
 type Factory interface {
 	NewForConfig(logger logrus.FieldLogger, config *rest.Config, purpose, namespace, name, image string) (Terraformer, error)
 	New(logger logrus.FieldLogger, client client.Client, coreV1Client corev1client.CoreV1Interface, purpose, namespace, name, image string) Terraformer
-	DefaultInitializer(c client.Client, main, variables string, tfVars []byte) Initializer
+	DefaultInitializer(c client.Client, main, variables string, tfVars []byte, state string) Initializer
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR we copy the terraformer state from the configmap <shoot-name>.infra.tf-state into the Infrastructure's Status under State as runtime.RawExtension. The State is base64 encoded to make the infra resource small as posible. 
**Which issue(s) this PR fixes**:
Part of [#1631](https://github.com/gardener/gardener/issues/1631)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
All `Infrastructure` extension controllers do now copy the Terraformer state into the `Infrastructure`'s `.status.state` field.
```
