### PR TITLE
Remove all rules from default AWS VPC security group

### DIFF
--- a/controllers/provider-aws/charts/internal/aws-infra/templates/main.tf
+++ b/controllers/provider-aws/charts/internal/aws-infra/templates/main.tf
@@ -29,6 +29,10 @@ resource "aws_vpc_dhcp_options_association" "vpc_dhcp_options_association" {
   dhcp_options_id = "${aws_vpc_dhcp_options.vpc_dhcp_options.id}"
 }
 
+resource "aws_default_security_group" "default" {
+  vpc_id = "${aws_vpc.vpc.id}"
+}
+
 resource "aws_internet_gateway" "igw" {
   vpc_id = "{{ required "vpc.id is required" .Values.vpc.id }}"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes all ingress and egress rules from the default AWS VPC security group in case it is managed by Gardener.

**Special notes for your reviewer**:
/cc @vlerenc @ThormaehlenFred 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
The AWS infrastructure controller does now remove all ingress and egress rules from the default VPC security group in case it is managed by Gardener. It doesn't touch the default VPC security group in case a shoot uses an already existing VPC.
```
