### PR TITLE
[release-1.0] Upgrade shoot-cert-service image version to v0.2.10

### DIFF
--- a/controllers/extension-shoot-cert-service/charts/images.yaml
+++ b/controllers/extension-shoot-cert-service/charts/images.yaml
@@ -2,4 +2,4 @@ images:
 - name: cert-management
   sourceRepository: github.com/gardener/cert-management
   repository: eu.gcr.io/gardener-project/cert-controller-manager
-  tag: "0.2.8"
+  tag: "v0.2.10"


### PR DESCRIPTION
**What this PR does / why we need it**:
Prior to v0.2.9 of cert-management, the image name generated in component_descriptor is controller-manager, while in extension-shoot-cert-service/charts/images.yml, the name is cert-management. This is causing cc-utils to be unable to read image information from component_descriptor using the images.yml extension-shoot-cert-service provide.
From v0.2.9, the image name in component_descriptor of cert-management is changed to cert-management so that it can be read by cc-utils.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
``` improvement operator github.com/gardener/cert-management #12 @MartinWeindel
improved behaviour if same certificate is requested multiple times simultaneously
```
``` improvement operator github.com/gardener/cert-management #10 @MartinWeindel
The release tags from now are prefixed with `v`.
```
