### PR TITLE
Update dns-controller-manager to v0.7.3

### DIFF
--- a/controllers/extension-shoot-dns-service/charts/images.yaml
+++ b/controllers/extension-shoot-dns-service/charts/images.yaml
@@ -2,4 +2,4 @@ images:
 - name: dns-controller-manager
   sourceRepository: github.com/gardener/external-dns-management
   repository: eu.gcr.io/gardener-project/dns-controller-manager
-  tag: "0.7.2"
+  tag: "v0.7.3"


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/external-dns-management #47 @ialidzhikov
The release tags from now are prefixed with `v`.
```
```improvement operator github.com/gardener/external-dns-management #50 @MartinWeindel 
aws-route53: avoid temporary deletion of DNS records after restart with unavailable or throttled route53 API
```