### PR TITLE
(WIP): Add Support for Cilium Networking

### DIFF
--- a/controllers/networking-cilium/cilium/README.md
+++ b/controllers/networking-cilium/cilium/README.md
@@ -1,0 +1,1 @@
+# [Gardener Extension for Cilium Networking](https://gardener.cloud)

--- a/controllers/networking-cilium/cilium/charts/agent/Chart.yaml
+++ b/controllers/networking-cilium/cilium/charts/agent/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+name: agent
+version: 1.6.90
+appVersion: 1.6.90
+tillerVersion: ">=2.7.2"
+description: Helm chart for cilium-agent DaemonSet
+keywords:
+sources:
+  - https://github.com/cilium/cilium
+engine: gotpl

--- a/controllers/networking-cilium/cilium/charts/agent/templates/clusterrole.yaml
+++ b/controllers/networking-cilium/cilium/charts/agent/templates/clusterrole.yaml
@@ -1,0 +1,66 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium
+rules:
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumclusterwidenetworkpolicies
+  - ciliumclusterwidenetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  - ciliumnodes
+  - ciliumnodes/status
+  - ciliumidentities
+  - ciliumidentities/status
+  verbs:
+  - '*'

--- a/controllers/networking-cilium/cilium/charts/agent/templates/clusterrolebinding.yaml
+++ b/controllers/networking-cilium/cilium/charts/agent/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: {{ .Release.Namespace }}

--- a/controllers/networking-cilium/cilium/charts/agent/templates/daemonset.yaml
+++ b/controllers/networking-cilium/cilium/charts/agent/templates/daemonset.yaml
@@ -1,0 +1,340 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: cilium
+  name: cilium
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium
+  template:
+    metadata:
+      annotations:
+{{- if and .Values.global.prometheus.enabled (not .Values.global.prometheus.serviceMonitor.enabled) }}
+        prometheus.io/port: "{{ .Values.global.prometheus.port }}"
+        prometheus.io/scrape: "true"
+{{- end }}
+        # This annotation plus the CriticalAddonsOnly toleration makes
+        # cilium to be a critical pod in the cluster, which ensures cilium
+        # gets priority scheduling.
+        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        k8s-app: cilium
+    spec:
+      containers:
+      - args:
+        - --config-dir=/tmp/cilium/config-map
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_FLANNEL_MASTER_DEVICE
+          valueFrom:
+            configMapKeyRef:
+              key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
+          valueFrom:
+            configMapKeyRef:
+              key: flannel-uninstall-on-exit
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
+{{- if .Values.global.k8sServiceHost }}
+        - name: KUBERNETES_SERVICE_HOST
+          value: {{ .Values.global.k8sServiceHost | quote }}
+{{- end }}
+{{- if .Values.global.k8sServicePort }}
+        - name: KUBERNETES_SERVICE_PORT
+          value: {{ .Values.global.k8sServicePort | quote }}
+{{- end }}
+{{- if contains "/" .Values.image }}
+        image: "{{ .Values.image }}"
+{{- else }}
+        image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.global.tag }}"
+{{- end }}
+        imagePullPolicy: {{ .Values.global.pullPolicy }}
+{{- if .Values.global.cni.install }}
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - "/cni-install.sh"
+              -{{- if .Values.global.debug.enabled }} "--enable-debug=true"{{- else }} "--enable-debug=false"{{- end }}
+          preStop:
+            exec:
+              command:
+              - /cni-uninstall.sh
+{{- end }}
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+            - --brief
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: cilium-agent
+{{- if .Values.global.prometheus.enabled }}
+        ports:
+        - containerPort: {{ .Values.global.prometheus.port }}
+          hostPort: {{ .Values.global.prometheus.port }}
+          name: prometheus
+          protocol: TCP
+{{- end }}
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+            - --brief
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 5
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+            - SYS_MODULE
+          privileged: true
+        volumeMounts:
+{{- /* CRI-O already mounts the BPF filesystem */ -}}
+{{- if not (eq .Values.global.containerRuntime.integration "crio") }}
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+{{- end }}
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: {{ .Values.global.cni.hostConfDirMountPath }}
+          name: etc-cni-netd
+{{- if .Values.global.etcd.enabled }}
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+{{- if or .Values.global.etcd.ssl .Values.global.etcd.managed }}
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+{{- end }}
+{{- end }}
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
+        - mountPath: /tmp/cilium/config-map
+          name: cilium-config-path
+          readOnly: true
+{{- if .Values.global.cni.configMap }}
+        - mountPath: {{ .Values.global.cni.confFileMountPath }}
+          name: cni-configuration
+          readOnly: true
+{{- end }}
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+{{- if .Values.global.encryption.enabled }}
+        - mountPath: {{ .Values.global.encryption.mountPath }}
+          name: cilium-ipsec-secrets
+{{- end }}
+{{- if .Values.global.kubeConfigPath }}
+        - mountPath: {{ .Values.global.kubeConfigPath }}
+          name: kube-config
+          readOnly: true
+{{- end}}
+{{- if .Values.global.etcd.managed }}
+      # In managed etcd mode, Cilium must be able to resolve the DNS name of
+      # the etcd service
+      dnsPolicy: ClusterFirstWithHostNet
+{{- end }}
+      hostNetwork: true
+      initContainers:
+{{- if and .Values.global.nodeinit.enabled (not (eq .Values.global.nodeinit.bootstrapFile "")) }}
+      - name: wait-for-node-init
+        command: ['sh', '-c', 'until stat {{ .Values.global.nodeinit.bootstrapFile }} > /dev/null 2>&1; do echo "Waiting on node-init to run..."; sleep 1; done']
+{{- if contains "/" .Values.image }}
+        image: "{{ .Values.image }}"
+{{- else }}
+        image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.global.tag }}"
+{{- end }}
+        imagePullPolicy: {{ .Values.global.pullPolicy }}
+        volumeMounts:
+        - mountPath: {{ .Values.global.nodeinit.bootstrapFile }}
+          name: cilium-bootstrap-file
+{{- end }}
+      - command:
+        - /init-container.sh
+        env:
+        - name: CILIUM_ALL_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
+{{- if contains "/" .Values.image }}
+        image: "{{ .Values.image }}"
+{{- else }}
+        image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.global.tag }}"
+{{- end }}
+        imagePullPolicy: {{ .Values.global.pullPolicy }}
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+{{- /* CRI-O already mounts the BPF filesystem */ -}}
+{{- if not (eq .Values.global.containerRuntime.integration "crio") }}
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+{{- /* Required for wait-bpf-mount to work */}}
+          mountPropagation: HostToContainer
+{{- end }}
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      restartPolicy: Always
+{{- if and (eq .Release.Namespace "kube-system") (or (gt .Capabilities.KubeVersion.Minor "10") (gt .Capabilities.KubeVersion.Major "1"))}}
+      priorityClassName: system-node-critical
+{{- end }}
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 1
+      tolerations:
+      - operator: Exists
+      volumes:
+        # To keep state between restarts / upgrades
+      - hostPath:
+          path: {{ .Values.global.daemon.runPath }}
+          type: DirectoryOrCreate
+        name: cilium-run
+{{- /* CRI-O already mounts the BPF filesystem */ -}}
+{{- if not (eq .Values.global.containerRuntime.integration "crio") }}
+        # To keep state between restarts / upgrades for bpf maps
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
+{{- end }}
+      # To install cilium cni plugin in the host
+      - hostPath:
+          path:  {{ .Values.global.cni.binPath }}
+          type: DirectoryOrCreate
+        name: cni-path
+        # To install cilium cni configuration in the host
+      - hostPath:
+          path: {{ .Values.global.cni.confPath }}
+          type: DirectoryOrCreate
+        name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+        name: lib-modules
+        # To access iptables concurrently with other processes (e.g. kube-proxy)
+      - hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+        name: xtables-lock
+{{- if .Values.global.kubeConfigPath }}
+      - hostPath:
+          path: {{ .Values.global.kubeConfigPath }}
+          type: FileOrCreate
+        name: kube-config
+{{- end }}
+{{- if and .Values.global.nodeinit.enabled (not (eq .Values.global.nodeinit.bootstrapFile "")) }}
+      - hostPath:
+          path: {{ .Values.global.nodeinit.bootstrapFile }}
+          type: FileOrCreate
+        name: cilium-bootstrap-file
+{{- end }}
+{{- if .Values.global.etcd.enabled }}
+        # To read the etcd config stored in config maps
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
+        # To read the k8s etcd secrets in case the user might want to use TLS
+{{- if or .Values.global.etcd.ssl .Values.global.etcd.managed }}
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
+{{- end }}
+{{- end }}
+        # To read the clustermesh configuration
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+        # To read the configuration from the config map
+      - configMap:
+          name: cilium-config
+        name: cilium-config-path
+{{- if .Values.global.encryption.enabled }}
+      - name: cilium-ipsec-secrets
+        secret:
+          secretName: {{ .Values.global.encryption.secretName }}
+{{- end }}
+{{- if .Values.global.cni.configMap }}
+      - name: cni-configuration
+        configMap:
+          name: {{ .Values.global.cni.configMap }}
+{{- end }}
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: {{ .Values.maxUnavailable }}
+    type: RollingUpdate

--- a/controllers/networking-cilium/cilium/charts/agent/templates/serviceaccount.yaml
+++ b/controllers/networking-cilium/cilium/charts/agent/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium
+  namespace: {{ .Release.Namespace }}

--- a/controllers/networking-cilium/cilium/charts/agent/templates/servicemonitor.yaml
+++ b/controllers/networking-cilium/cilium/charts/agent/templates/servicemonitor.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.global.prometheus.enabled (.Values.global.prometheus.serviceMonitor.enabled) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: cilium-agent
+  {{- if .Values.global.prometheus.serviceMonitor.namespace }}
+  namespace: {{ .Values.global.prometheus.serviceMonitor.namespace }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  endpoints:
+  - port: metrics
+    interval: 10s
+    honorLabels: true
+    path: /metrics
+{{- end }}

--- a/controllers/networking-cilium/cilium/charts/agent/templates/svc.yaml
+++ b/controllers/networking-cilium/cilium/charts/agent/templates/svc.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.global.prometheus.enabled (.Values.global.prometheus.serviceMonitor.enabled) }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: cilium-agent
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: cilium
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+  - name: metrics
+    port: {{ .Values.global.prometheus.port }}
+    protocol: TCP
+    targetPort: prometheus
+  selector:
+    k8s-app: cilium
+{{- end }}

--- a/controllers/networking-cilium/cilium/charts/agent/values.yaml
+++ b/controllers/networking-cilium/cilium/charts/agent/values.yaml
@@ -1,0 +1,5 @@
+image: cilium
+
+# Specifies the maximum number of Pods that can be unavailable during the
+# update process.
+maxUnavailable: 2

--- a/controllers/networking-cilium/cilium/charts/config/Chart.yaml
+++ b/controllers/networking-cilium/cilium/charts/config/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+name: config
+version: 1.6.90
+appVersion: 1.6.90
+tillerVersion: ">=2.7.2"
+description: Helm chart for Cilium configuration
+keywords:
+sources:
+  - https://github.com/cilium/cilium
+engine: gotpl

--- a/controllers/networking-cilium/cilium/charts/config/templates/configmap.yaml
+++ b/controllers/networking-cilium/cilium/charts/config/templates/configmap.yaml
@@ -1,0 +1,303 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-config
+  namespace: {{ .Release.Namespace }}
+data:
+{{- if .Values.global.etcd.enabled }}
+  # The kvstore configuration is used to enable use of a kvstore for state
+  # storage. This can either be provided with an external kvstore or with the
+  # help of cilium-etcd-operator which operates an etcd cluster automatically.
+  kvstore: etcd
+  kvstore-opt: '{"etcd.config": "/var/lib/etcd-config/etcd.config"}'
+
+  # This etcd-config contains the etcd endpoints of your cluster. If you use
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
+  etcd-config: |-
+    ---
+    endpoints:
+{{- if .Values.global.etcd.managed }}
+      - https://cilium-etcd-client.{{ .Release.Namespace }}.svc:2379
+{{- else }}
+{{- range .Values.global.etcd.endpoints }}
+      - {{ . }}
+{{- end }}
+{{- end }}
+{{- if or .Values.global.etcd.ssl .Values.global.etcd.managed }}
+    trusted-ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
+    key-file: '/var/lib/etcd-secrets/etcd-client.key'
+    cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
+{{- end }}
+{{- end }}
+
+  # Identity allocation mode selects how identities are shared between cilium
+  # nodes by setting how they are stored. The options are "crd" or "kvstore".
+  # - "crd" stores identities in kubernetes as CRDs (custom resource definition).
+  #   These can be queried with:
+  #     kubectl get ciliumid
+  # - "kvstore" stores identities in a kvstore, etcd or consul, that is
+  #   configured below. Cilium versions before 1.6 supported only the kvstore
+  #   backend. Upgrades from these older cilium versions should continue using
+  #   the kvstore by commenting out the identity-allocation-mode below, or
+  #   setting it to "kvstore".
+  identity-allocation-mode: {{ .Values.global.identityAllocationMode }}
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: {{ .Values.global.debug.enabled | quote }}
+
+{{- if .Values.global.debug.verbose }}
+  debug-verbose: "{{ .Values.global.debug.verbose }}"
+{{- end }}
+
+{{- if .Values.global.prometheus.enabled }}
+  # If you want metrics enabled in all of your Cilium agents, set the port for
+  # which the Cilium agents will have their metrics exposed.
+  # This option deprecates the "prometheus-serve-addr" in the
+  # "cilium-metrics-config" ConfigMap
+  # NOTE that this will open the port on ALL nodes where Cilium pods are
+  # scheduled.
+  prometheus-serve-addr: ":{{ .Values.global.prometheus.port }}"
+{{- end }}
+
+  # Enable IPv4 addressing. If enabled, all endpoints are allocated an IPv4
+  # address.
+{{- if .Values.global.ipv4 }}
+  enable-ipv4: {{ .Values.global.ipv4.enabled | quote }}
+{{- end }}
+
+  # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
+  # address.
+{{- if .Values.global.ipv6 }}
+  enable-ipv6: {{ .Values.global.ipv6.enabled | quote }}
+{{- end }}
+
+{{- if .Values.global.cleanState }}
+  # If a serious issue occurs during Cilium startup, this
+  # invasive option may be set to true to remove all persistent
+  # state. Endpoints will not be restored using knowledge from a
+  # prior Cilium run, so they may receive new IP addresses upon
+  # restart. This also triggers clean-cilium-bpf-state.
+  clean-cilium-state: "true"
+{{- end }}
+
+{{- if .Values.global.cleanBpfState }}
+  # If you want to clean cilium BPF state, set this to true;
+  # Removes all BPF maps from the filesystem. Upon restart,
+  # endpoints are restored with the same IP addresses, however
+  # any ongoing connections may be disrupted briefly.
+  # Loadbalancing decisions will be reset, so any ongoing
+  # connections via a service may be loadbalanced to a different
+  # backend after restart.
+  clean-cilium-bpf-state: "true"
+{{- end }}
+
+{{- if .Values.global.cni.customConf }}
+  # Users who wish to specify their own custom CNI configuration file must set
+  # custom-cni-conf to "true", otherwise Cilium may overwrite the configuration.
+  custom-cni-conf: "{{ .Values.global.cni.customConf }}"
+{{- end }}
+
+  # If you want cilium monitor to aggregate tracing for packets, set this level
+  # to "low", "medium", or "maximum". The higher the level, the less packets
+  # that will be seen in monitor output.
+  monitor-aggregation: {{ .Values.global.bpf.monitorAggregation }}
+
+  # The monitor aggregation interval governs the typical time between monitor
+  # notification events for each allowed connection.
+  #
+  # Only effective when monitor aggregation is set to "medium" or higher.
+  monitor-aggregation-interval: {{ .Values.global.bpf.monitorInterval }}
+
+  # The monitor aggregation flags determine which TCP flags which, upon the
+  # first observation, cause monitor notifications to be generated.
+  #
+  # Only effective when monitor aggregation is set to "medium" or higher.
+  monitor-aggregation-flags: {{ .Values.global.bpf.monitorFlags }}
+
+  # ct-global-max-entries-* specifies the maximum number of connections
+  # supported across all endpoints, split by protocol: tcp or other. One pair
+  # of maps uses these values for IPv4 connections, and another pair of maps
+  # use these values for IPv6 connections.
+  #
+  # If these values are modified, then during the next Cilium startup the
+  # tracking of ongoing connections may be disrupted. This may lead to brief
+  # policy drops or a change in loadbalancing decisions for a connection.
+  #
+  # For users upgrading from Cilium 1.2 or earlier, to minimize disruption
+  # during the upgrade process, comment out these options.
+  bpf-ct-global-tcp-max: "{{ .Values.global.bpf.ctTcpMax }}"
+  bpf-ct-global-any-max: "{{ .Values.global.bpf.ctAnyMax }}"
+
+  # Pre-allocation of map entries allows per-packet latency to be reduced, at
+  # the expense of up-front memory allocation for the entries in the maps. The
+  # default value below will minimize memory usage in the default installation;
+  # users who are sensitive to latency may consider setting this to "true".
+  #
+  # This option was introduced in Cilium 1.4. Cilium 1.3 and earlier ignore
+  # this option and behave as though it is set to "true".
+  #
+  # If this value is modified, then during the next Cilium startup the restore
+  # of existing endpoints and tracking of ongoing connections may be disrupted.
+  # This may lead to policy drops or a change in loadbalancing decisions for a
+  # connection for some time. Endpoints may need to be recreated to restore
+  # connectivity.
+  #
+  # If this option is set to "false" during an upgrade from 1.3 or earlier to
+  # 1.4 or later, then it may cause one-time disruptions during the upgrade.
+  preallocate-bpf-maps: "{{ .Values.global.bpf.preallocateMaps }}"
+
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
+  # Encapsulation mode for communication between nodes
+  # Possible values:
+  #   - disabled
+  #   - vxlan (default)
+  #   - geneve
+  tunnel: {{ .Values.global.tunnel }}
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: {{ .Values.global.cluster.name }}
+
+{{- if .Values.global.cluster.id }}
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  cluster-id: "{{ .Values.global.cluster.id }}"
+{{- end }}
+
+{{- if .Values.global.eni }}
+  ipam: "eni"
+  enable-endpoint-routes: "true"
+  auto-create-cilium-node-resource: "true"
+  blacklist-conflicting-routes: "false"
+{{- end }}
+
+{{- if .Values.global.flannel.enabled }}
+  # Interface to be used when running Cilium on top of a CNI plugin.
+  # For flannel, use "cni0"
+  flannel-master-device: {{ .Values.global.flannel.masterDevice }}
+
+  # When running Cilium with policy enforcement enabled on top of a CNI plugin
+  # the BPF programs will be installed on the network interface specified in
+  # 'flannel-master-device' and on all network interfaces belonging to
+  # a container. When the Cilium DaemonSet is removed, the BPF programs will
+  # be kept in the interfaces unless this option is set to "true".
+  flannel-uninstall-on-exit: "{{ .Values.global.flannel.uninstallOnExit}}"
+
+{{- end }}
+
+{{- if .Values.global.l7Proxy }}
+
+  # Enables L7 proxy for L7 policy enforcement and visibility
+  enable-l7-proxy: {{ .Values.global.l7Proxy.enabled | quote }}
+{{- end }}
+
+  # DNS Polling periodically issues a DNS lookup for each `matchName` from
+  # cilium-agent. The result is used to regenerate endpoint policy.
+  # DNS lookups are repeated with an interval of 5 seconds, and are made for
+  # A(IPv4) and AAAA(IPv6) addresses. Should a lookup fail, the most recent IP
+  # data is used instead. An IP change will trigger a regeneration of the Cilium
+  # policy for each endpoint and increment the per cilium-agent policy
+  # repository revision.
+  #
+  # This option is disabled by default starting from version 1.4.x in favor
+  # of a more powerful DNS proxy-based implementation, see [0] for details.
+  # Enable this option if you want to use FQDN policies but do not want to use
+  # the DNS proxy.
+  #
+  # To ease upgrade, users may opt to set this option to "true".
+  # Otherwise please refer to the Upgrade Guide [1] which explains how to
+  # prepare policy rules for upgrade.
+  #
+  # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
+  # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
+  tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "{{ .Values.global.bpf.waitForMount }}"
+
+{{- if ne .Values.global.cni.chainingMode "none" }}
+  # Enable chaining with another CNI plugin
+  #
+  # Supported modes:
+  #  - none
+  #  - aws-cni
+  #  - flannel
+  #  - portmap (Enables HostPort support for Cilium)
+  cni-chaining-mode: {{ .Values.global.cni.chainingMode }}
+{{- end }}
+
+  masquerade: {{ .Values.global.masquerade | quote }}
+{{- if .Values.global.egressMasqueradeInterfaces }}
+  egress-masquerade-interfaces: {{ .Values.global.egressMasqueradeInterfaces }}
+{{- end }}
+
+{{- if .Values.global.encryption.enabled }}
+  enable-ipsec: {{ .Values.global.encryption.enabled | quote }}
+  ipsec-key-file: {{ .Values.global.encryption.mountPath }}/{{ .Values.global.encryption.keyFile }}
+{{- if .Values.global.encryption.interface }}
+  encrypt-interface: {{ .Values.global.encryption.interface }}
+{{- end }}
+{{- if .Values.global.encryption.nodeEncryption }}
+  encrypt-node: {{ .Values.global.encryption.nodeEncryption | quote }}
+{{- end }}
+{{- end }}
+
+{{- if .Values.global.hostServices.enabled }}
+  enable-host-reachable-services: "true"
+{{- if ne .Values.global.hostServices.protocols "tcp,udp" }}
+  host-reachable-services-protos: {{ .Values.global.hostServices.protocols }}
+{{- end }}
+{{- end }}
+
+{{- if .Values.global.datapathMode }}
+{{- if eq .Values.global.datapathMode "ipvlan" }}
+  datapath-mode: ipvlan
+  ipvlan-master-device: {{ .Values.global.ipvlan.masterDevice }}
+{{- end }}
+{{- end }}
+
+  install-iptables-rules: {{ .Values.global.installIptablesRules | quote }}
+  auto-direct-node-routes: {{ .Values.global.autoDirectNodeRoutes | quote }}
+{{- if .Values.global.nodePort }}
+  enable-node-port: {{ .Values.global.nodePort.enabled | quote }}
+{{- if .Values.global.nodePort.range }}
+  node-port-range: {{ .Values.global.nodePort.range | quote }}
+{{- end }}
+{{- if .Values.global.nodePort.device }}
+  device: {{ .Values.global.nodePort.device | quote }}
+{{- end }}
+
+{{- end }}
+{{- if and .Values.global.pprof .Values.global.pprof.enabled }}
+  pprof: {{ .Values.global.pprof.enabled | quote }}
+{{- end }}
+{{- if .Values.global.logSystemLoad }}
+  log-system-load: {{ .Values.global.logSystemLoad | quote }}
+{{- end }}
+{{- if and .Values.global.sockops .Values.global.sockops.enabled }}
+  sockops-enable: {{ .Values.global.sockops.enabled | quote }}
+{{- end }}
+{{- if and .Values.global.k8s .Values.global.k8s.requireIPv4PodCIDR }}
+  k8s-require-ipv4-pod-cidr: {{ .Values.global.k8s.requireIPv4PodCIDR | quote }}
+{{- end }}
+{{- if and .Values.global.endpointRoutes .Values.global.endpointRoutes.enabled }}
+  enable-endpoint-routes: {{ .Values.global.endpointRoutes.enabled | quote }}
+{{- end }}
+{{- if .Values.global.cni.configMap }}
+  read-cni-conf: {{ .Values.global.cni.confFileMountPath }}/{{ .Values.global.cni.configMapKey }}
+  write-cni-conf-when-ready: {{ .Values.global.cni.hostConfDirMountPath }}/05-cilium.conflist
+{{- end }}
+{{- if .Values.global.kubeConfigPath }}
+  k8s-kubeconfig-path: {{ .Values.global.kubeConfigPath | quote }}
+{{- end }}
+{{- if not (eq .Values.global.cni.chainingMode "none") }}
+  # Chaining mode was enabled, disabling health checking
+  enable-endpoint-health-checking: "false"
+{{- end }}
+{{- if or .Values.global.wellKnownIdentities.enabled .Values.global.etcd.managed }}
+  enable-well-known-identities: "true"
+{{- else }}
+  enable-well-known-identities: "false"
+{{- end }}

--- a/controllers/networking-cilium/cilium/charts/managed-etcd/Chart.yaml
+++ b/controllers/networking-cilium/cilium/charts/managed-etcd/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+name: managed-etcd
+version: 1.6.90
+appVersion: 1.6.90
+tillerVersion: ">=2.7.2"
+description: Helm chart for managed etcd
+keywords:
+sources:
+  - https://github.com/cilium/cilium
+engine: gotpl

--- a/controllers/networking-cilium/cilium/charts/managed-etcd/templates/cilium-etcd-operator-clusterrole.yaml
+++ b/controllers/networking-cilium/cilium/charts/managed-etcd/templates/cilium-etcd-operator-clusterrole.yaml
@@ -1,0 +1,71 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium-etcd-operator
+rules:
+- apiGroups:
+  - etcd.database.coreos.com
+  resources:
+  - etcdclusters
+  verbs:
+  - get
+  - delete
+  - create
+  - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - delete
+  - get
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - deployments
+  verbs:
+  - delete
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - delete
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - componentstatuses
+  verbs:
+  - get
+- apiGroups:
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - delete
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - delete

--- a/controllers/networking-cilium/cilium/charts/managed-etcd/templates/cilium-etcd-operator-clusterrolebinding.yaml
+++ b/controllers/networking-cilium/cilium/charts/managed-etcd/templates/cilium-etcd-operator-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-etcd-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-etcd-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-etcd-operator
+  namespace: {{ .Release.Namespace }}

--- a/controllers/networking-cilium/cilium/charts/managed-etcd/templates/cilium-etcd-operator-deployment.yaml
+++ b/controllers/networking-cilium/cilium/charts/managed-etcd/templates/cilium-etcd-operator-deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    io.cilium/app: etcd-operator
+    name: cilium-etcd-operator
+  name: cilium-etcd-operator
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: etcd-operator
+      name: cilium-etcd-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        io.cilium/app: etcd-operator
+        name: cilium-etcd-operator
+    spec:
+      containers:
+      - args:
+        #- --etcd-node-selector=disktype=ssd,cputype=high
+        command:
+        - /usr/bin/cilium-etcd-operator
+        env:
+        - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
+          value: "{{ .Values.global.etcd.clusterDomain }}"
+        - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE
+          value: "3"
+        - name: CILIUM_ETCD_OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_ETCD_OPERATOR_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: CILIUM_ETCD_OPERATOR_POD_UID
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.uid
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
+{{- if contains "/" .Values.image }}
+        image: "{{ .Values.image }}"
+{{- else if .Values.registry }}
+        image: "{{ .Values.registry }}/{{ .Values.image }}:{{ .Values.tag }}"
+{{- else }}
+        image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.tag }}"
+{{- end }}
+        imagePullPolicy: {{ .Values.global.pullPolicy }}
+        name: cilium-etcd-operator
+      dnsPolicy: ClusterFirst
+      hostNetwork: true
+      restartPolicy: Always
+      serviceAccount: cilium-etcd-operator
+      serviceAccountName: cilium-etcd-operator
+      tolerations:
+      - operator: Exists

--- a/controllers/networking-cilium/cilium/charts/managed-etcd/templates/cilium-etcd-operator-serviceaccount.yaml
+++ b/controllers/networking-cilium/cilium/charts/managed-etcd/templates/cilium-etcd-operator-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium-etcd-operator
+  namespace: {{ .Release.Namespace }}

--- a/controllers/networking-cilium/cilium/charts/managed-etcd/templates/etcd-operator-clusterrole.yaml
+++ b/controllers/networking-cilium/cilium/charts/managed-etcd/templates/etcd-operator-clusterrole.yaml
@@ -1,0 +1,52 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcd-operator
+rules:
+- apiGroups:
+  - etcd.database.coreos.com
+  resources:
+  - etcdclusters
+  - etcdbackups
+  - etcdrestores
+  verbs:
+  - '*'
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - deployments
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - '*'
+- apiGroups:
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get

--- a/controllers/networking-cilium/cilium/charts/managed-etcd/templates/etcd-operator-clusterrolebinding.yaml
+++ b/controllers/networking-cilium/cilium/charts/managed-etcd/templates/etcd-operator-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-etcd-sa
+  namespace: {{ .Release.Namespace }}

--- a/controllers/networking-cilium/cilium/charts/managed-etcd/templates/etcd-operator-serviceaccount.yaml
+++ b/controllers/networking-cilium/cilium/charts/managed-etcd/templates/etcd-operator-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium-etcd-sa
+  namespace: {{ .Release.Namespace }}

--- a/controllers/networking-cilium/cilium/charts/managed-etcd/values.yaml
+++ b/controllers/networking-cilium/cilium/charts/managed-etcd/values.yaml
@@ -1,0 +1,2 @@
+image: cilium-etcd-operator
+tag: v2.0.7

--- a/controllers/networking-cilium/cilium/charts/nodeinit/Chart.yaml
+++ b/controllers/networking-cilium/cilium/charts/nodeinit/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+name: nodeinit
+version: 1.6.90
+appVersion: 1.6.90
+tillerVersion: ">=2.7.2"
+description: Helm chart for node initialization
+keywords:
+sources:
+  - https://github.com/cilium/cilium
+engine: gotpl

--- a/controllers/networking-cilium/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/controllers/networking-cilium/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -1,0 +1,114 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: cilium-node-init
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: cilium-node-init
+spec:
+  selector:
+    matchLabels:
+      app: cilium-node-init
+  template:
+    metadata:
+      labels:
+        app: cilium-node-init
+    spec:
+      tolerations:
+      - operator: Exists
+      hostPID: true
+      hostNetwork: true
+      containers:
+        - name: node-init
+          image: gcr.io/google-containers/startup-script:v1
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          env:
+          # STARTUP_SCRIPT is the script run on node bootstrap. Node
+          # bootstrapping can be customized in this script.
+          - name: STARTUP_SCRIPT
+            value: |
+              #!/bin/bash
+
+              set -o errexit
+              set -o pipefail
+              set -o nounset
+
+              mount | grep "/sys/fs/bpf type bpf" || {
+                # Mount the filesystem until next reboot
+                echo "Mounting BPF filesystem..."
+                mount bpffs /sys/fs/bpf -t bpf
+              }
+        
+              echo "Installing BPF filesystem mount"
+              cat >/tmp/sys-fs-bpf.mount <<EOF
+              [Unit]
+              Description=Mount BPF filesystem (Cilium)
+              Documentation=http://docs.cilium.io/
+              DefaultDependencies=no
+              Before=local-fs.target umount.target
+              After=swap.target
+
+              [Mount]
+              What=bpffs
+              Where=/sys/fs/bpf
+              Type=bpf
+
+              [Install]
+              WantedBy=multi-user.target
+              EOF
+
+              if [ -d "/etc/systemd/system/" ]; then
+                mv /tmp/sys-fs-bpf.mount /etc/systemd/system/
+                echo "Installed sys-fs-bpf.mount to /etc/systemd/system/"
+              elif [ -d "/lib/systemd/system/" ]; then
+                mv /tmp/sys-fs-bpf.mount /lib/systemd/system/
+                echo "Installed sys-fs-bpf.mount to /lib/systemd/system/"
+              fi
+
+              # Ensure that filesystem gets mounted on next reboot
+              systemctl enable sys-fs-bpf.mount
+              systemctl start sys-fs-bpf.mount
+
+              echo "Link information:"
+              ip link
+
+              echo "Routing table:"
+              ip route
+
+              echo "Addressing:"
+              ip -4 a
+              ip -6 a
+
+{{- if .Values.removeCbrBridge }}
+              if ip link show cbr0; then
+                echo "Detected cbr0 bridge. Deleting interface..."
+                ip link del cbr0
+              fi
+{{- end }}
+
+{{- if .Values.restartPods }}
+              echo "Restarting kubenet managed pods"
+              if grep -q 'docker' /etc/crictl.yaml; then
+                # Works for COS, ubuntu
+                for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do docker rm -f $(cat $f) || true; done
+              else
+                # COS-beta (with containerd)
+                for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do crictl stopp $(cat $f) || true; done
+              fi
+{{- end }}
+
+{{- if .Values.reconfigureKubelet }}
+              # GKE: Alter the kubelet configuration to run in CNI mode
+              echo "Changing kubelet configuration to --network-plugin=cni --cni-bin-dir={{ .Values.global.cni.binPath }}"
+              mkdir -p {{ .Values.global.cni.binPath }}
+              sed -i "s:--network-plugin=kubenet:--network-plugin=cni\ --cni-bin-dir={{ .Values.global.cni.binPath }}:g" /etc/default/kubelet
+              echo "Restarting kubelet..."
+              systemctl restart kubelet
+{{- end }}
+
+{{- if not (eq .Values.global.nodeinit.bootstrapFile "") }}
+              date > {{ .Values.global.nodeinit.bootstrapFile }}
+{{- end }}
+              echo "Node initialization complete"

--- a/controllers/networking-cilium/cilium/charts/nodeinit/values.yaml
+++ b/controllers/networking-cilium/cilium/charts/nodeinit/values.yaml
@@ -1,0 +1,13 @@
+# Restart existing pods when initializing the node to force all pods being
+# managed by Cilium (GKE)
+restartPods: false
+
+# Reconfigure Kubelet to run in CNI mode (GKE)
+reconfigureKubelet: false
+
+# Delete the cbr0 bridge if it exists (GKE)
+removeCbrBridge: false
+
+# Wait for the /var/run/azure-vnet.json file to be created before continuing the
+# script
+azure: false

--- a/controllers/networking-cilium/cilium/charts/operator/Chart.yaml
+++ b/controllers/networking-cilium/cilium/charts/operator/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+name: operator
+version: 1.6.90
+appVersion: 1.6.90
+tillerVersion: ">=2.7.2"
+description: Helm chart for cilium-operator deployment
+keywords:
+sources:
+  - https://github.com/cilium/cilium
+engine: gotpl

--- a/controllers/networking-cilium/cilium/charts/operator/templates/clusterrole.yaml
+++ b/controllers/networking-cilium/cilium/charts/operator/templates/clusterrole.yaml
@@ -1,0 +1,47 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
+  - services
+  - endpoints
+  # to check apiserver connectivity
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumclusterwidenetworkpolicies
+  - ciliumclusterwidenetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  - ciliumnodes
+  - ciliumnodes/status
+  - ciliumidentities
+  - ciliumidentities/status
+  verbs:
+  - '*'

--- a/controllers/networking-cilium/cilium/charts/operator/templates/clusterrolebinding.yaml
+++ b/controllers/networking-cilium/cilium/charts/operator/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: {{ .Release.Namespace }}

--- a/controllers/networking-cilium/cilium/charts/operator/templates/deployment.yaml
+++ b/controllers/networking-cilium/cilium/charts/operator/templates/deployment.yaml
@@ -1,0 +1,203 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
+  name: cilium-operator
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+{{- if and .Values.global.prometheus.enabled (not .Values.global.prometheus.serviceMonitor.enabled) }}
+        prometheus.io/port: "6942"
+        prometheus.io/scrape: "true"
+{{- end }}
+      labels:
+        io.cilium/app: operator
+        name: cilium-operator
+    spec:
+      containers:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --identity-allocation-mode=$(CILIUM_IDENTITY_ALLOCATION_MODE)
+{{- if .Values.global.prometheus.enabled }}
+        - --enable-metrics
+{{- end }}
+{{- if .Values.global.kubeConfigPath }}
+        - --k8s-kubeconfig-path={{ .Values.global.kubeConfigPath }}
+{{- end }}
+        command:
+        - cilium-operator
+        env:
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_IPAM
+          valueFrom:
+            configMapKeyRef:
+              key: ipam
+              name: cilium-config
+              optional: true
+        - name: CILIUM_DISABLE_ENDPOINT_CRD
+          valueFrom:
+            configMapKeyRef:
+              key: disable-endpoint-crd
+              name: cilium-config
+              optional: true
+        - name: CILIUM_KVSTORE
+          valueFrom:
+            configMapKeyRef:
+              key: kvstore
+              name: cilium-config
+              optional: true
+        - name: CILIUM_KVSTORE_OPT
+          valueFrom:
+            configMapKeyRef:
+              key: kvstore-opt
+              name: cilium-config
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: cilium-aws
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: cilium-aws
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              key: AWS_DEFAULT_REGION
+              name: cilium-aws
+              optional: true
+        - name: CILIUM_IDENTITY_ALLOCATION_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: identity-allocation-mode
+              name: cilium-config
+              optional: true
+{{- if .Values.global.k8sServiceHost }}
+        - name: KUBERNETES_SERVICE_HOST
+          value: {{ .Values.global.k8sServiceHost | quote }}
+{{- end }}
+{{- if .Values.global.k8sServicePort }}
+        - name: KUBERNETES_SERVICE_PORT
+          value: {{ .Values.global.k8sServicePort | quote }}
+{{- end }}
+{{- if contains "/" .Values.image }}
+        image: "{{ .Values.image }}"
+{{- else }}
+        image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.global.tag }}"
+{{- end }}
+        imagePullPolicy: {{ .Values.global.pullPolicy }}
+        name: cilium-operator
+{{- if .Values.global.prometheus.enabled }}
+        ports:
+        - containerPort: 6942
+          hostPort: 6942
+          name: prometheus
+          protocol: TCP
+{{- end }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
+{{- if or .Values.global.etcd.enabled .Values.global.kubeConfigPath }}
+        volumeMounts:
+{{- end }}
+{{- if .Values.global.etcd.enabled }}
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+{{- if or .Values.global.etcd.ssl .Values.global.etcd.managed }}
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+{{- end }}
+{{- end }}
+{{- if .Values.global.kubeConfigPath }}
+        - mountPath: {{ .Values.global.kubeConfigPath }}
+          name: kube-config
+          readOnly: true
+{{- end}}
+      hostNetwork: true
+{{- if .Values.global.etcd.managed }}
+      # In managed etcd mode, Cilium must be able to resolve the DNS name of
+      # the etcd service
+      dnsPolicy: ClusterFirstWithHostNet
+{{- end }}
+      restartPolicy: Always
+      serviceAccount: cilium-operator
+      serviceAccountName: cilium-operator
+{{- if or .Values.global.etcd.enabled .Values.global.kubeConfigPath }}
+      volumes:
+{{- end }}
+{{- if .Values.global.etcd.enabled }}
+      # To read the etcd config stored in config maps
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
+{{- if or .Values.global.etcd.ssl .Values.global.etcd.managed }}
+        # To read the k8s etcd secrets in case the user might want to use TLS
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
+{{- end }}
+{{- end }}
+{{- if .Values.global.kubeConfigPath }}
+      - hostPath:
+          path: {{ .Values.global.kubeConfigPath }}
+          type: FileOrCreate
+        name: kube-config
+{{- end }}

--- a/controllers/networking-cilium/cilium/charts/operator/templates/serviceaccount.yaml
+++ b/controllers/networking-cilium/cilium/charts/operator/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium-operator
+  namespace: {{ .Release.Namespace }}

--- a/controllers/networking-cilium/cilium/charts/operator/templates/servicemonitor.yaml
+++ b/controllers/networking-cilium/cilium/charts/operator/templates/servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.global.prometheus.enabled (.Values.global.prometheus.serviceMonitor.enabled) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: cilium-operator
+  {{- if .Values.global.prometheus.serviceMonitor.namespace }}
+  namespace: {{ .Values.global.prometheus.serviceMonitor.namespace }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  endpoints:
+  - port: metrics
+    interval: 10s
+    honorLabels: true
+    path: /metrics
+{{- end }}

--- a/controllers/networking-cilium/cilium/charts/operator/templates/svc.yaml
+++ b/controllers/networking-cilium/cilium/charts/operator/templates/svc.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.global.prometheus.enabled (.Values.global.prometheus.serviceMonitor.enabled) }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: cilium-operator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+  - name: metrics
+    port: 6942
+    protocol: TCP
+    targetPort: prometheus
+  selector:
+    io.cilium/app: operator
+    name: cilium-operator
+{{- end }}

--- a/controllers/networking-cilium/cilium/charts/operator/values.yaml
+++ b/controllers/networking-cilium/cilium/charts/operator/values.yaml
@@ -1,0 +1,1 @@
+image: operator

--- a/controllers/networking-cilium/cilium/charts/preflight/Chart.yaml
+++ b/controllers/networking-cilium/cilium/charts/preflight/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+name: preflight
+version: 1.6.90
+appVersion: 1.6.90
+tillerVersion: ">=2.7.2"
+description: Helm chart for pre-flight functionality
+keywords:
+sources:
+  - https://github.com/cilium/cilium
+engine: gotpl

--- a/controllers/networking-cilium/cilium/charts/preflight/templates/daemonset.yaml
+++ b/controllers/networking-cilium/cilium/charts/preflight/templates/daemonset.yaml
@@ -1,0 +1,167 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cilium-pre-flight-check
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium-pre-flight-check
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        k8s-app: cilium-pre-flight-check
+        kubernetes.io/cluster-service: "true"
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: "k8s-app"
+                operator: In
+                values:
+                - cilium
+            topologyKey: "kubernetes.io/hostname"
+      initContainers:
+        - name: clean-cilium-state
+{{- if contains "/" .Values.image }}
+          image: "{{ .Values.image }}"
+{{- else }}
+          image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.global.tag }}"
+{{- end }}
+          imagePullPolicy: {{ .Values.global.pullPolicy }}
+          command: ["/bin/echo"]
+          args:
+          - "hello"
+      containers:
+{{- if contains "/" .Values.image }}
+        - image: "{{ .Values.image }}"
+{{- else }}
+        - image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.global.tag }}"
+{{- end }}
+          imagePullPolicy: {{ .Values.global.pullPolicy }}
+          name: cilium-pre-flight-check
+          command: ["/bin/sh"]
+          args:
+          - -c
+          - "touch /tmp/ready; sleep 1h"
+          livenessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/ready
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/ready
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+          - mountPath: /var/run/cilium
+            name: cilium-run
+{{- if .Values.global.etcd.enabled }}
+          - mountPath: /var/lib/etcd-config
+            name: etcd-config-path
+            readOnly: true
+{{- if or .Values.global.etcd.ssl .Values.global.etcd.managed }}
+          - mountPath: /var/lib/etcd-secrets
+            name: etcd-secrets
+            readOnly: true
+{{- end }}
+{{- end }}
+
+{{- if ne .Values.tofqdnsPreCache "" }}
+{{- if contains "/" .Values.image }}
+        - image: "{{ .Values.image }}"
+{{- else }}
+        - image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.global.tag }}"
+{{- end }}
+          imagePullPolicy: {{ .Values.global.pullPolicy }}
+          name: cilium-pre-flight-check
+          command: ["/bin/sh"]
+          args:
+          - -c
+          - "cilium preflight fqdn-poller --tofqdns-pre-cache {{ .Values.tofqdnsPreCache }} && touch /tmp/ready-tofqdns-precache"
+          livenessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/read-tofqdns-precachey
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/read-tofqdns-precachey
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+          - mountPath: /var/run/cilium
+            name: cilium-run
+{{- if .Values.global.etcd.enabled }}
+          - mountPath: /var/lib/etcd-config
+            name: etcd-config-path
+            readOnly: true
+{{- if or .Values.global.etcd.ssl .Values.global.etcd.managed }}
+          - mountPath: /var/lib/etcd-secrets
+            name: etcd-secrets
+            readOnly: true
+{{- end }}
+{{- end }}
+{{- end }}
+      hostNetwork: true
+      # This is here to seamlessly allow migrate-identity to work with
+      # etcd-operator setups. The assumption is that other cases would also
+      # work since the cluster DNS would forward the request on.
+      # This differs from the cilium-agent daemonset, where this is only
+      # enabled when global.etcd.managed=true
+      dnsPolicy: ClusterFirstWithHostNet
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 1
+      tolerations:
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+        - key: CriticalAddonsOnly
+          operator: "Exists"
+      volumes:
+        # To keep state between restarts / upgrades
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
+{{- if .Values.global.etcd.enabled }}
+        # To read the etcd config stored in config maps
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
+        # To read the k8s etcd secrets in case the user might want to use TLS
+{{- if or .Values.global.etcd.ssl .Values.global.etcd.managed }}
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
+{{- end }}
+{{- end }}
+

--- a/controllers/networking-cilium/cilium/charts/preflight/values.yaml
+++ b/controllers/networking-cilium/cilium/charts/preflight/values.yaml
@@ -1,0 +1,1 @@
+image: cilium

--- a/controllers/networking-cilium/hubble/charts/Chart.yaml
+++ b/controllers/networking-cilium/hubble/charts/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+name: hubble
+version: 0.0.1
+appVersion: 0.0.1
+tillerVersion: ">=2.7.2"
+description: Helm chart for the Hubble server
+keywords:
+sources:
+  - https://github.com/cilium/hubble
+engine: gotpl

--- a/controllers/networking-cilium/hubble/charts/templates/clusterrole.yaml
+++ b/controllers/networking-cilium/hubble/charts/templates/clusterrole.yaml
@@ -1,0 +1,57 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hubble
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+{{- if .Values.ui.enabled }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hubble-ui 
+rules:
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - componentstatuses
+      - endpoints
+      - namespaces
+      - nodes
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cilium.io
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+      - watch
+{{- end }}

--- a/controllers/networking-cilium/hubble/charts/templates/clusterrolebinding.yaml
+++ b/controllers/networking-cilium/hubble/charts/templates/clusterrolebinding.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hubble
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hubble
+subjects:
+- kind: ServiceAccount
+  name: hubble
+  namespace: {{ .Release.Namespace }}
+{{- if .Values.ui.enabled }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hubble-ui
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hubble-ui 
+subjects:
+  - kind: ServiceAccount
+    namespace: {{ .Release.Namespace }}
+    name: hubble-ui 
+{{- end }}

--- a/controllers/networking-cilium/hubble/charts/templates/daemonset.yaml
+++ b/controllers/networking-cilium/hubble/charts/templates/daemonset.yaml
@@ -1,0 +1,124 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: hubble
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      k8s-app: hubble
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      annotations:
+        # This annotation plus the CriticalAddonsOnly toleration makes
+        # hubble to be a critical pod in the cluster, which ensures hubble
+        # gets priority scheduling, same as cilium-agent.
+        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+{{- if .Values.metrics.enabled }}
+        prometheus.io/port: {{ regexReplaceAll ":([0-9]+)$" .Values.metrics.address "${1}" | quote }}
+        prometheus.io/scrape: "true"
+{{- end }}
+      labels:
+        k8s-app: hubble
+        kubernetes.io/cluster-service: "true"
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: "k8s-app"
+                operator: In
+                values:
+                - cilium
+            topologyKey: "kubernetes.io/hostname"
+            namespaces:
+            {{- if .Values.ciliumNamespace }}
+            - {{ .Values.ciliumNamespace }}
+            {{- else }}
+            - cilium
+            - kube-system
+            {{- end }}
+      containers:
+      - name: hubble
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - hubble
+        args:
+        - serve
+{{- range .Values.listenClientUrls }}
+        - --listen-client-urls={{ . }}
+{{- end }}
+{{- if and .Values.ui.enabled (not (has "0.0.0.0:50051" .Values.listenClientUrls)) }}
+        - --listen-client-urls=0.0.0.0:50051
+{{- if not .Values.listenClientUrls }}
+        - --listen-client-urls=unix:///var/run/hubble.sock
+{{- end }}
+{{- end }}
+{{- if .Values.maxFlows }}
+        - --max-flows
+        - {{ .Values.maxFlows }}
+{{- end }}
+{{- if eq .Values.cri.runtime "docker" }}
+        - --cri-endpoint
+        - "unix:///hostrun/dockershim.sock"
+{{- end }}
+{{- if .Values.metrics.enabled }}
+        - --metrics-server
+        - {{ .Values.metrics.address | quote }}
+{{- range .Values.metrics.enabled }}
+        - --metric={{ . }}
+{{- end }}
+{{- end }}
+        env:
+          - name: HUBBLE_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: HUBBLE_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        ports:
+{{- if .Values.metrics.enabled }}
+        - containerPort: {{ regexReplaceAll ":([0-9]+)$" .Values.metrics.address "${1}" }}
+          protocol: TCP
+{{- end }}
+        readinessProbe:
+          exec:
+            command:
+            - hubble
+            - status
+  {{- if .Values.server }}
+            - --server={{ .Values.server }}
+  {{- end }}
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 5
+        volumeMounts:
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      restartPolicy: Always
+      serviceAccount: hubble
+      serviceAccountName: hubble
+      terminationGracePeriodSeconds: 1
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          # We need to access Cilium's monitor socket
+          path: /var/run/cilium
+          type: Directory
+        name: cilium-run
+{{- if eq .Values.cri.runtime "docker" }}
+      # Mount /var/run so that hubble can access docker CRI endpoint /var/run/dockershim.sock.
+      - hostPath:
+          path: /var/run
+          type: Directory
+        name: host-run
+{{- end }}

--- a/controllers/networking-cilium/hubble/charts/templates/deployment.yaml
+++ b/controllers/networking-cilium/hubble/charts/templates/deployment.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ui.enabled }}
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: hubble-ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: hubble-ui
+  template:
+    metadata:
+      labels:
+        k8s-app: hubble-ui
+    spec:
+      serviceAccountName: hubble-ui
+      containers:
+        - name: hubble-ui
+          image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
+          imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: LOG_LEVEL
+              value: "info"
+            - name: HUBBLE
+              value: "true"
+            - name: HUBBLE_SERVICE
+              value: "hubble-grpc.{{ .Release.Namespace }}.svc.cluster.local"
+            - name: HUBBLE_PORT
+              value: "50051"
+          ports:
+            - containerPort: 12000
+              name: http
+{{- end }}

--- a/controllers/networking-cilium/hubble/charts/templates/serviceaccount.yaml
+++ b/controllers/networking-cilium/hubble/charts/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hubble
+  namespace: {{ .Release.Namespace }}
+{{- if .Values.ui.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: hubble-ui 
+{{- end }}

--- a/controllers/networking-cilium/hubble/charts/templates/svc.yaml
+++ b/controllers/networking-cilium/hubble/charts/templates/svc.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.ui.enabled }}
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: hubble-grpc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: hubble
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    k8s-app: hubble
+  ports:
+  - targetPort: 50051
+    protocol: TCP
+    port: 50051
+---
+kind: Service
+apiVersion: v1
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: hubble-ui
+spec:
+  selector:
+    k8s-app: hubble-ui
+  ports:
+    - name: http
+      port: 12000
+      targetPort: 12000
+  type: ClusterIP
+---
+{{- end }}

--- a/controllers/networking-cilium/hubble/charts/values.yaml
+++ b/controllers/networking-cilium/hubble/charts/values.yaml
@@ -1,0 +1,46 @@
+# image used for hubble server
+image:
+  # repository of the docker image
+  repository: quay.io/cilium/hubble
+  # tag is the container image tag to use
+  tag: latest
+  # pullPolicy is the container image pull policy
+  pullPolicy: Always
+
+# URL to listen to client requests. If this parameter is not specified, it
+# defaults to using unix domain socket.
+listenClientUrls: ~
+
+# Server URL to connect to hubble server. If this parameter is not specified,
+# it defaults to using unix domain socket.
+server: ~
+
+# maxFlows the server will store in memory
+maxFlows: ~
+
+# Namespace in which Cilium is installed
+ciliumNamespace: ~
+
+# Configuration for container runtime interface. When enabled, Hubble uses CRI to get additional
+# metadata such as container name and image name.
+cri:
+  # CRI is disabled if runtime field is set to "". Set this to one of the following values to
+  # enable it.
+  #   - docker
+  runtime: ""
+
+metrics:
+  enabled:
+   - drop
+  address: ":6943"
+
+# Configuration for hubble ui
+ui:
+  enabled: false
+  image:
+    # repository of the docker image
+    repository: quay.io/isovalent/hubble-ui
+    # tag is the container image tag to use
+    tag: latest
+    # pullPolicy is the container image pull policy
+    pullPolicy: Always

--- a/controllers/networking-cilium/pkg/apis/cilium/doc.go
+++ b/controllers/networking-cilium/pkg/apis/cilium/doc.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +k8s:deepcopy-gen=package
+// +groupName="cilium.networking.extensions.gardener.cloud"
+
+//go:generate ../../../hack/generate-code
+
+package cilium // import "github.com/gardener/gardener-extensions/controllers/networking-cilium/pkg/apis/cilium"

--- a/controllers/networking-cilium/pkg/apis/cilium/register.go
+++ b/controllers/networking-cilium/pkg/apis/cilium/register.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cilium
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// GroupName is the group name use in this package
+const GroupName = "cilium.networking.extensions.gardener.cloud"
+
+// SchemeGroupVersion is group version used to register these objects
+var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}
+
+// Kind takes an unqualified kind and returns a Group qualified GroupKind
+func Kind(kind string) schema.GroupKind {
+	return SchemeGroupVersion.WithKind(kind).GroupKind()
+}
+
+// Resource takes an unqualified resource and returns a Group qualified GroupResource
+func Resource(resource string) schema.GroupResource {
+	return SchemeGroupVersion.WithResource(resource).GroupResource()
+}
+
+var (
+	// SchemeBuilder used to register the Shoot resource.
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	// AddToScheme is a pointer to SchemeBuilder.AddToScheme.
+	AddToScheme = SchemeBuilder.AddToScheme
+)
+
+// Adds the list of known types to api.Scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&NetworkConfig{},
+		&NetworkStatus{},
+	)
+	return nil
+}

--- a/controllers/networking-cilium/pkg/apis/cilium/types_network.go
+++ b/controllers/networking-cilium/pkg/apis/cilium/types_network.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cilium


### PR DESCRIPTION
This is a Work In Progress PR.(DO NOT MERGE)
Add Cilium Networking as an additional Network-extension to
gardener-extensions.
Cilium is open source software for transparently securing the network
connectivity between application services deployed using Linux container
management platforms like Docker and Kubernetes that depends on the new
Linux kernel technology called BPF.

Fixes: #129
Signed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>
