### PR TITLE
Use MTU of 1460 for all SUSE nodes

### DIFF
--- a/controllers/networking-calico/docs/usage-as-end-user.md
+++ b/controllers/networking-calico/docs/usage-as-end-user.md
@@ -8,8 +8,6 @@ In this document we are describing how this configuration looks like for Calico 
 
 Calico Typha is an optional component of Project Calico designed to offload the Kubernetes API server. The Typha daemon sits between the datastore (such as the Kubernetes API server which is the one used by Gardener managed Kubernetes) and many instances of Felix. Typha’s main purpose is to increase scale by reducing each node’s impact on the datastore. You can opt-out Typha via `.spec.networking.providerConfig.typha.enabled=false` of your Shoot manifest. By default the Typha is enabled.
 
-> Note: On some cloud providers combined with some operating systems the Typha is not working properly. You may try to disable it in your Shoot manifest if you experience such issues.
-
 ## Example `NetworkingConfig` manifest
 
 An example `NetworkingConfig` for the Calico extension looks as follows:

--- a/controllers/os-suse-jeos/pkg/generator/templates/cloud-init/suse-jeos.template
+++ b/controllers/os-suse-jeos/pkg/generator/templates/cloud-init/suse-jeos.template
@@ -28,6 +28,8 @@ write_files:
 runcmd:
 - "until zypper -q install -y docker wget socat jq nfs-client; [ $? -ne 7 ]; do sleep 1; done"
 - systemctl daemon-reload
+- ip link set dev eth0 mtu 1460
+- grep -q '^MTU' /etc/sysconfig/network/ifcfg-eth0 && sed -i 's/^MTU.*/MTU=1460/' /etc/sysconfig/network/ifcfg-eth0 || echo 'MTU=1460' >> /etc/sysconfig/network/ifcfg-eth0
 {{ if .Bootstrap -}}
 - ln -s /usr/bin/docker /bin/docker
 - ln -s /bin/ip /usr/bin/ip

--- a/controllers/os-suse-jeos/pkg/generator/templates/script/suse-jeos.template
+++ b/controllers/os-suse-jeos/pkg/generator/templates/script/suse-jeos.template
@@ -26,6 +26,8 @@ mkdir -p '{{ $unit.DropIns.Path }}'
 
 until zypper -q install -y docker wget socat jq nfs-client; [ $? -ne 7 ]; do sleep 1; done
 systemctl daemon-reload
+ip link set dev eth0 mtu 1460
+grep -q '^MTU' /etc/sysconfig/network/ifcfg-eth0 && sed -i 's/^MTU.*/MTU=1460/' /etc/sysconfig/network/ifcfg-eth0 || echo 'MTU=1460' >> /etc/sysconfig/network/ifcfg-eth0
 {{ if .Bootstrap -}}
 ln -s /usr/bin/docker /bin/docker
 ln -s /bin/ip /usr/bin/ip

--- a/controllers/os-suse-jeos/pkg/generator/testfiles/cloud-init/cloud-init
+++ b/controllers/os-suse-jeos/pkg/generator/testfiles/cloud-init/cloud-init
@@ -16,6 +16,8 @@ write_files:
 runcmd:
 - "until zypper -q install -y docker wget socat jq nfs-client; [ $? -ne 7 ]; do sleep 1; done"
 - systemctl daemon-reload
+- ip link set dev eth0 mtu 1460
+- grep -q '^MTU' /etc/sysconfig/network/ifcfg-eth0 && sed -i 's/^MTU.*/MTU=1460/' /etc/sysconfig/network/ifcfg-eth0 || echo 'MTU=1460' >> /etc/sysconfig/network/ifcfg-eth0
 - ln -s /usr/bin/docker /bin/docker
 - ln -s /bin/ip /usr/bin/ip
 - if [ ! -s /etc/hostname ]; then hostname > /etc/hostname; fi

--- a/controllers/os-suse-jeos/pkg/generator/testfiles/script/cloud-init
+++ b/controllers/os-suse-jeos/pkg/generator/testfiles/script/cloud-init
@@ -17,6 +17,8 @@ EOF
 
 until zypper -q install -y docker wget socat jq nfs-client; [ $? -ne 7 ]; do sleep 1; done
 systemctl daemon-reload
+ip link set dev eth0 mtu 1460
+grep -q '^MTU' /etc/sysconfig/network/ifcfg-eth0 && sed -i 's/^MTU.*/MTU=1460/' /etc/sysconfig/network/ifcfg-eth0 || echo 'MTU=1460' >> /etc/sysconfig/network/ifcfg-eth0
 ln -s /usr/bin/docker /bin/docker
 ln -s /bin/ip /usr/bin/ip
 if [ ! -s /etc/hostname ]; then hostname > /etc/hostname; fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Use MTU of 1460 for all SUSE nodes

**Which issue(s) this PR fixes**:
Fixes #497 

**Special notes for your reviewer**:
Thanks to @marwinski  and @zanetworker .

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
SuSE nodes are now using mtu of 1460 on all infrastructures.
```

```improvement user
An issue where calico typha was not working with SuSE nodes has been fixed. Now SuSE based cluster can enable calico typha again and benefit from it.
```
