### PR TITLE
feat: configure shoot worker node calico port mtu

### DIFF
--- a/controllers/networking-calico/charts/internal/calico/templates/node/configmap-calico-config.yaml
+++ b/controllers/networking-calico/charts/internal/calico/templates/node/configmap-calico-config.yaml
@@ -16,7 +16,7 @@ data:
   # Configure the Calico backend to use.
   calico_backend: "{{ .Values.config.backend }}"
   # Configure the MTU to use
-  veth_mtu: "1440"
+  vethMTU: "{{ .Values.config.vethMTU }}"
   # The CNI network configuration to install on each node.
   cni_network_config: |-
     {

--- a/controllers/networking-calico/charts/internal/calico/templates/node/configmap-calico-config.yaml
+++ b/controllers/networking-calico/charts/internal/calico/templates/node/configmap-calico-config.yaml
@@ -16,7 +16,7 @@ data:
   # Configure the Calico backend to use.
   calico_backend: "{{ .Values.config.backend }}"
   # Configure the MTU to use
-  vethMTU: "{{ .Values.config.vethMTU }}"
+  veth_mtu: "{{ .Values.config.veth_mtu }}"
   # The CNI network configuration to install on each node.
   cni_network_config: |-
     {

--- a/controllers/networking-calico/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/controllers/networking-calico/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -76,7 +76,7 @@ spec:
             valueFrom:
               configMapKeyRef:
                 name: calico-config
-                key: vethMTU
+                key: veth_mtu
           # Prevents the container from sleeping forever.
           - name: SLEEP
             value: "false"
@@ -140,7 +140,7 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: calico-config
-                  key: vethMTU
+                  key: veth_mtu
             # Wait for the datastore.
             - name: WAIT_FOR_DATASTORE
               value: "true"

--- a/controllers/networking-calico/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/controllers/networking-calico/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -76,7 +76,7 @@ spec:
             valueFrom:
               configMapKeyRef:
                 name: calico-config
-                key: veth_mtu
+                key: vethMTU
           # Prevents the container from sleeping forever.
           - name: SLEEP
             value: "false"
@@ -140,7 +140,7 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: calico-config
-                  key: veth_mtu
+                  key: vethMTU
             # Wait for the datastore.
             - name: WAIT_FOR_DATASTORE
               value: "true"

--- a/controllers/networking-calico/charts/internal/calico/values.yaml
+++ b/controllers/networking-calico/charts/internal/calico/values.yaml
@@ -1,7 +1,7 @@
 global:
   podCIDR: ""
 config:
-  vethMTU: 1440
+  veth_mtu: 1440
   backend: bird
   ipam:
     type: "host-local"

--- a/controllers/networking-calico/charts/internal/calico/values.yaml
+++ b/controllers/networking-calico/charts/internal/calico/values.yaml
@@ -1,6 +1,7 @@
 global:
   podCIDR: ""
 config:
+  vethMTU: 1440
   backend: bird
   ipam:
     type: "host-local"

--- a/controllers/networking-calico/docs/usage-as-end-user.md
+++ b/controllers/networking-calico/docs/usage-as-end-user.md
@@ -18,6 +18,7 @@ kind: NetworkConfig
 ipam:
   type: host-local
   cidr: usePodCIDR
+vethMTU: 1440
 backend: bird
 typha:
   enabled: true
@@ -70,6 +71,7 @@ spec:
       kind: NetworkConfig
       ipam:
         type: host-local
+      vethMTU: 1440
       backend: bird
       typha:
         enabled: false

--- a/controllers/networking-calico/hack/api-reference/calico.md
+++ b/controllers/networking-calico/hack/api-reference/calico.md
@@ -100,6 +100,18 @@ Typha
 </tr>
 <tr>
 <td>
+<code>vethMTU</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>VethMTU settings used to configure calico port mtu</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>ipip</code></br>
 <em>
 <a href="#calico.networking.extensions.gardener.cloud/v1alpha1.IPv4PoolMode">

--- a/controllers/networking-calico/pkg/apis/calico/types_network.go
+++ b/controllers/networking-calico/pkg/apis/calico/types_network.go
@@ -71,6 +71,8 @@ type NetworkConfig struct {
 	IPv4 *IPv4
 	// Typha settings to use for calico-typha component
 	Typha *Typha
+	// VethMTU settings used to configure calico port mtu
+	VethMTU *string
 
 	// DEPRECATED.
 	// IPIP is the IPIP Mode for the IPv4 Pool (e.g. Always, Never, CrossSubnet)

--- a/controllers/networking-calico/pkg/apis/calico/v1alpha1/types_network.go
+++ b/controllers/networking-calico/pkg/apis/calico/v1alpha1/types_network.go
@@ -79,6 +79,9 @@ type NetworkConfig struct {
 	// Typha settings to use for calico-typha component
 	// +optional
 	Typha *Typha `json:"typha,omitempty"`
+	// VethMTU settings used to configure calico port mtu
+	// +optional
+	VethMTU *string `json:"vethMTU,omitempty"`
 
 	// DEPRECATED.
 	// IPIP is the IPIP Mode for the IPv4 Pool (e.g. Always, Never, CrossSubnet)

--- a/controllers/networking-calico/pkg/apis/calico/v1alpha1/zz_generated.conversion.go
+++ b/controllers/networking-calico/pkg/apis/calico/v1alpha1/zz_generated.conversion.go
@@ -139,6 +139,7 @@ func autoConvert_v1alpha1_NetworkConfig_To_calico_NetworkConfig(in *NetworkConfi
 	out.IPAM = (*calico.IPAM)(unsafe.Pointer(in.IPAM))
 	out.IPv4 = (*calico.IPv4)(unsafe.Pointer(in.IPv4))
 	out.Typha = (*calico.Typha)(unsafe.Pointer(in.Typha))
+	out.VethMTU = (*string)(unsafe.Pointer(in.VethMTU))
 	out.IPIP = (*calico.IPv4PoolMode)(unsafe.Pointer(in.IPIP))
 	out.IPAutoDetectionMethod = (*string)(unsafe.Pointer(in.IPAutoDetectionMethod))
 	return nil
@@ -154,6 +155,7 @@ func autoConvert_calico_NetworkConfig_To_v1alpha1_NetworkConfig(in *calico.Netwo
 	out.IPAM = (*IPAM)(unsafe.Pointer(in.IPAM))
 	out.IPv4 = (*IPv4)(unsafe.Pointer(in.IPv4))
 	out.Typha = (*Typha)(unsafe.Pointer(in.Typha))
+	out.VethMTU = (*string)(unsafe.Pointer(in.VethMTU))
 	out.IPIP = (*IPv4PoolMode)(unsafe.Pointer(in.IPIP))
 	out.IPAutoDetectionMethod = (*string)(unsafe.Pointer(in.IPAutoDetectionMethod))
 	return nil

--- a/controllers/networking-calico/pkg/apis/calico/v1alpha1/zz_generated.deepcopy.go
+++ b/controllers/networking-calico/pkg/apis/calico/v1alpha1/zz_generated.deepcopy.go
@@ -100,6 +100,11 @@ func (in *NetworkConfig) DeepCopyInto(out *NetworkConfig) {
 		*out = new(Typha)
 		**out = **in
 	}
+	if in.VethMTU != nil {
+		in, out := &in.VethMTU, &out.VethMTU
+		*out = new(string)
+		**out = **in
+	}
 	if in.IPIP != nil {
 		in, out := &in.IPIP, &out.IPIP
 		*out = new(IPv4PoolMode)

--- a/controllers/networking-calico/pkg/apis/calico/zz_generated.deepcopy.go
+++ b/controllers/networking-calico/pkg/apis/calico/zz_generated.deepcopy.go
@@ -100,6 +100,11 @@ func (in *NetworkConfig) DeepCopyInto(out *NetworkConfig) {
 		*out = new(Typha)
 		**out = **in
 	}
+	if in.VethMTU != nil {
+		in, out := &in.VethMTU, &out.VethMTU
+		*out = new(string)
+		**out = **in
+	}
 	if in.IPIP != nil {
 		in, out := &in.IPIP, &out.IPIP
 		*out = new(IPv4PoolMode)

--- a/controllers/networking-calico/pkg/charts/charts_test.go
+++ b/controllers/networking-calico/pkg/charts/charts_test.go
@@ -156,7 +156,7 @@ var _ = Describe("Chart package test", func() {
 					"typha": map[string]interface{}{
 						"enabled": trueVar,
 					},
-					"vethMTU": defaultMtu,
+					"veth_mtu": defaultMtu,
 					"felix": map[string]interface{}{
 						"ipinip": map[string]interface{}{
 							"enabled": true,
@@ -198,7 +198,7 @@ var _ = Describe("Chart package test", func() {
 					"typha": map[string]interface{}{
 						"enabled": trueVar,
 					},
-					"vethMTU": defaultMtu,
+					"veth_mtu": defaultMtu,
 					"felix": map[string]interface{}{
 						"ipinip": map[string]interface{}{
 							"enabled": false,
@@ -240,7 +240,7 @@ var _ = Describe("Chart package test", func() {
 					"typha": map[string]interface{}{
 						"enabled": trueVar,
 					},
-					"vethMTU": defaultMtu,
+					"veth_mtu": defaultMtu,
 					"felix": map[string]interface{}{
 						"ipinip": map[string]interface{}{
 							"enabled": true,
@@ -279,7 +279,7 @@ var _ = Describe("Chart package test", func() {
 					"typha": map[string]interface{}{
 						"enabled": trueVar,
 					},
-					"vethMTU": mtuVar,
+					"veth_mtu": mtuVar,
 					"felix": map[string]interface{}{
 						"ipinip": map[string]interface{}{
 							"enabled": true,
@@ -321,7 +321,7 @@ var _ = Describe("Chart package test", func() {
 					"typha": map[string]interface{}{
 						"enabled": trueVar,
 					},
-					"vethMTU": defaultMtu,
+					"veth_mtu": defaultMtu,
 					"felix": map[string]interface{}{
 						"ipinip": map[string]interface{}{
 							"enabled": true,

--- a/controllers/networking-calico/pkg/charts/utils.go
+++ b/controllers/networking-calico/pkg/charts/utils.go
@@ -37,7 +37,7 @@ type calicoConfig struct {
 	IPv4    ipv4                   `json:"ipv4"`
 	IPAM    ipam                   `json:"ipam"`
 	Typha   typha                  `json:"typha"`
-	VethMTU string                 `json:"vethMTU"`
+	VethMTU string                 `json:"veth_mtu"`
 }
 
 type felix struct {

--- a/controllers/networking-calico/pkg/charts/utils.go
+++ b/controllers/networking-calico/pkg/charts/utils.go
@@ -28,6 +28,7 @@ import (
 const (
 	hostLocal  = "host-local"
 	usePodCIDR = "usePodCidr"
+	defaultMTU = "1440"
 )
 
 type calicoConfig struct {
@@ -36,6 +37,7 @@ type calicoConfig struct {
 	IPv4    ipv4                   `json:"ipv4"`
 	IPAM    ipam                   `json:"ipam"`
 	Typha   typha                  `json:"typha"`
+	VethMTU string                 `json:"vethMTU"`
 }
 
 type felix struct {
@@ -80,6 +82,7 @@ var defaultCalicoConfig = calicoConfig{
 	Typha: typha{
 		Enabled: true,
 	},
+	VethMTU: defaultMTU,
 }
 
 func newCalicoConfig() calicoConfig {
@@ -193,6 +196,10 @@ func generateChartValues(config *calicov1alpha1.NetworkConfig) (*calicoConfig, e
 
 	if config.Typha != nil {
 		c.Typha.Enabled = config.Typha.Enabled
+	}
+
+	if config.VethMTU != nil {
+		c.VethMTU = *config.VethMTU
 	}
 
 	return &c, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
let user configure the mtu for shoot worker node
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
NONE
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
If you wish to configure the MTU value of calico then you can set the `.spec.vethMTU` field in the `calico.networking.extensions.gardener.cloud/v1alpha1.NetworkConfig`. Please make sure that all the MTUs in your environment, failure to do so will result in performance penalties and packet loss.
```
