### PR TITLE
Certificate extension copes with no DNS shoots

### DIFF
--- a/controllers/extension-shoot-cert-service/pkg/controller/actuator.go
+++ b/controllers/extension-shoot-cert-service/pkg/controller/actuator.go
@@ -157,9 +157,9 @@ func (a *actuator) createSeedResources(ctx context.Context, ex *extensionsv1alph
 		return err
 	}
 
-	shootDomain := cluster.Shoot.Spec.DNS.Domain
-	if shootDomain == nil {
-		return fmt.Errorf("no domain given for shoot %s/%s", cluster.Shoot.Name, cluster.Shoot.Namespace)
+	if cluster.Shoot.Spec.DNS == nil || cluster.Shoot.Spec.DNS.Domain == nil {
+		a.logger.Info("no domain given for shoot %s/%s - aborting", cluster.Shoot.Name, cluster.Shoot.Namespace)
+		return nil
 	}
 
 	shootKubeconfig, err := a.createKubeconfigForCertManagement(ctx, namespace)
@@ -171,7 +171,7 @@ func (a *actuator) createSeedResources(ctx context.Context, ex *extensionsv1alph
 		"replicaCount": controller.GetReplicas(cluster, 1),
 		"defaultProvider": map[string]interface{}{
 			"name":    a.serviceConfig.IssuerName,
-			"domains": shootDomain,
+			"domains": cluster.Shoot.Spec.DNS.Domain,
 		},
 		"issuers":            issuers,
 		"shootClusterSecret": v1alpha1.CertManagementKubecfg,


### PR DESCRIPTION
**What this PR does / why we need it**:
If a shoot does not not have a DNS domain (which is possible as of gardener/gardener#1617) then the certificate-service extension does not do anything.

**Special notes for your reviewer**:
/assign @timuthy 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
