### PR TITLE
Support for Kubernetes v1.17

### DIFF
--- a/controllers/provider-alicloud/README.md
+++ b/controllers/provider-alicloud/README.md
@@ -23,6 +23,7 @@ This extension controller supports the following Kubernetes versions:
 
 | Version         | Support     | Conformance test results |
 | --------------- | ----------- | ------------------------ |
+| Kubernetes 1.17 | 1.17.0+     | TBD |
 | Kubernetes 1.16 | 1.16.0+     | [![Gardener v1.16 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.16%20Alibaba%20Cloud/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.16%20Alibaba%20Cloud) |
 | Kubernetes 1.15 | 1.15.0+     | [![Gardener v1.15 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.15%20Alibaba%20Cloud/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.15%20Alibaba%20Cloud) |
 | Kubernetes 1.14 | 1.14.0+     | [![Gardener v1.14 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.14%20Alibaba%20Cloud/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.14%20Alibaba%20Cloud) |

--- a/controllers/provider-aws/README.md
+++ b/controllers/provider-aws/README.md
@@ -23,6 +23,7 @@ This extension controller supports the following Kubernetes versions:
 
 | Version         | Support     | Conformance test results |
 | --------------- | ----------- | ------------------------ |
+| Kubernetes 1.17 | 1.17.0+     | TBD |
 | Kubernetes 1.16 | 1.16.0+     | [![Gardener v1.16 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.16%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.16%20AWS) |
 | Kubernetes 1.15 | 1.15.0+     | [![Gardener v1.15 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.15%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.15%20AWS) |
 | Kubernetes 1.14 | 1.14.0+, except 1.14.7 | [![Gardener v1.14 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.14%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.14%20AWS) |

--- a/controllers/provider-aws/charts/images.yaml
+++ b/controllers/provider-aws/charts/images.yaml
@@ -3,9 +3,15 @@ images:
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
   tag: "0.17.0"
-- name: hyperkube
+- name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/kubernetes
   repository: k8s.gcr.io/hyperkube
+  targetVersion: "< 1.17"
+- name: cloud-controller-manager
+  sourceRepository: github.com/gardener/cloud-provider-aws
+  repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-aws
+  tag: "v1.17.0"
+  targetVersion: ">= 1.17"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager

--- a/controllers/provider-aws/charts/internal/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/controllers/provider-aws/charts/internal/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -53,11 +53,15 @@ spec:
         operator: Exists
       containers:
       - name: aws-cloud-controller-manager
-        image: {{ index .Values.images "hyperkube" }}
+        image: {{ index .Values.images "cloud-controller-manager" }}
         imagePullPolicy: IfNotPresent
         command:
+        {{- if semverCompare "< 1.17" .Values.kubernetesVersion }}
         - /hyperkube
         - cloud-controller-manager
+        {{- else }}
+        - /aws-cloud-controller-manager
+        {{- end }}
         - --allocate-node-cidrs=true
         - --cloud-provider=aws
         - --cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf

--- a/controllers/provider-aws/charts/internal/cloud-controller-manager/values.yaml
+++ b/controllers/provider-aws/charts/internal/cloud-controller-manager/values.yaml
@@ -7,7 +7,7 @@ featureGates: {}
   # CustomResourceValidation: true
   # RotateKubeletServerCertificate: false
 images:
-  hyperkube: image-repository:image-tag
+  cloud-controller-manager: image-repository:image-tag
 resources:
   requests:
     cpu: 11m

--- a/controllers/provider-aws/pkg/aws/types.go
+++ b/controllers/provider-aws/pkg/aws/types.go
@@ -26,8 +26,8 @@ const (
 	MachineControllerManagerImageName = "machine-controller-manager"
 	// TerraformerImageName is the name of the Terraformer image.
 	TerraformerImageName = "terraformer"
-	// HyperkubeImageName is the name of the hyperkube image.
-	HyperkubeImageName = "hyperkube"
+	// CloudControllerManagerImageName is the name of the cloud-controller-manager image.
+	CloudControllerManagerImageName = "cloud-controller-manager"
 	// ETCDBackupRestoreImageName is the name of the etcd backup and restore image.
 	ETCDBackupRestoreImageName = "etcd-backup-restore"
 	// AWSLBReadvertiserImageName is the name of the AWSLBReadvertiser image.

--- a/controllers/provider-aws/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-aws/pkg/controller/controlplane/valuesprovider.go
@@ -127,7 +127,7 @@ var configChart = &chart.Chart{
 var ccmChart = &chart.Chart{
 	Name:   "cloud-controller-manager",
 	Path:   filepath.Join(aws.InternalChartsPath, "cloud-controller-manager"),
-	Images: []string{aws.HyperkubeImageName},
+	Images: []string{aws.CloudControllerManagerImageName},
 	Objects: []*chart.Object{
 		{Type: &corev1.Service{}, Name: "cloud-controller-manager"},
 		{Type: &appsv1.Deployment{}, Name: "cloud-controller-manager"},

--- a/controllers/provider-aws/pkg/webhook/controlplane/ensurer_test.go
+++ b/controllers/provider-aws/pkg/webhook/controlplane/ensurer_test.go
@@ -19,15 +19,17 @@ import (
 	"testing"
 
 	"github.com/gardener/gardener-extensions/controllers/provider-aws/pkg/aws"
+	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener-extensions/pkg/util"
 	extensionswebhook "github.com/gardener/gardener-extensions/pkg/webhook"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane/genericmutator"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane/test"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 
 	"github.com/coreos/go-systemd/unit"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -40,9 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 )
 
-const (
-	namespace = "test"
-)
+const namespace = "test"
 
 func TestController(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -53,7 +53,29 @@ var _ = Describe("Ensurer", func() {
 	var (
 		ctrl *gomock.Controller
 
-		dummyContext = genericmutator.NewEnsurerContext(nil, nil)
+		dummyContext   = genericmutator.NewEnsurerContext(nil, nil)
+		eContextK8s116 = genericmutator.NewInternalEnsurerContext(
+			&extensionscontroller.Cluster{
+				Shoot: &gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Kubernetes: gardencorev1beta1.Kubernetes{
+							Version: "1.16.0",
+						},
+					},
+				},
+			},
+		)
+		eContextK8s117 = genericmutator.NewInternalEnsurerContext(
+			&extensionscontroller.Cluster{
+				Shoot: &gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Kubernetes: gardencorev1beta1.Kubernetes{
+							Version: "1.17.0",
+						},
+					},
+				},
+			},
+		)
 
 		secretKey = client.ObjectKey{Namespace: namespace, Name: v1beta1constants.SecretNameCloudProvider}
 		secret    = &corev1.Secret{
@@ -88,7 +110,7 @@ var _ = Describe("Ensurer", func() {
 	})
 
 	Describe("#EnsureKubeAPIServerDeployment", func() {
-		It("should add missing elements to kube-apiserver deployment", func() {
+		It("should add missing elements to kube-apiserver deployment (k8s < 1.17)", func() {
 			var (
 				dep = &appsv1.Deployment{
 					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1beta1constants.DeploymentNameKubeAPIServer},
@@ -117,9 +139,43 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
-			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dummyContext, dep)
+			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), eContextK8s116, dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeAPIServerDeployment(dep, annotations)
+			checkKubeAPIServerDeployment(dep, annotations, true)
+		})
+
+		It("should add missing elements to kube-apiserver deployment (k8s >= 1.17)", func() {
+			var (
+				dep = &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1beta1constants.DeploymentNameKubeAPIServer},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "kube-apiserver",
+									},
+								},
+							},
+						},
+					},
+				}
+			)
+
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
+			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
+
+			// Create ensurer
+			ensurer := NewEnsurer(logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Call EnsureKubeAPIServerDeployment method and check the result
+			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), eContextK8s117, dep)
+			Expect(err).To(Not(HaveOccurred()))
+			checkKubeAPIServerDeployment(dep, annotations, false)
 		})
 
 		It("should modify existing elements of kube-apiserver deployment", func() {
@@ -167,14 +223,14 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
-			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dummyContext, dep)
+			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), eContextK8s116, dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeAPIServerDeployment(dep, annotations)
+			checkKubeAPIServerDeployment(dep, annotations, true)
 		})
 	})
 
 	Describe("#EnsureKubeControllerManagerDeployment", func() {
-		It("should add missing elements to kube-controller-manager deployment", func() {
+		It("should add missing elements to kube-controller-manager deployment (k8s < 1.17)", func() {
 			var (
 				dep = &appsv1.Deployment{
 					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1beta1constants.DeploymentNameKubeControllerManager},
@@ -203,9 +259,43 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeControllerManagerDeployment method and check the result
-			err = ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), dummyContext, dep)
+			err = ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), eContextK8s116, dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels)
+			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels, true)
+		})
+
+		It("should add missing elements to kube-controller-manager deployment (k8s >= 1.17)", func() {
+			var (
+				dep = &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1beta1constants.DeploymentNameKubeControllerManager},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "kube-controller-manager",
+									},
+								},
+							},
+						},
+					},
+				}
+			)
+
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
+			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
+
+			// Create ensurer
+			ensurer := NewEnsurer(logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Call EnsureKubeControllerManagerDeployment method and check the result
+			err = ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), eContextK8s117, dep)
+			Expect(err).To(Not(HaveOccurred()))
+			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels, false)
 		})
 
 		It("should modify existing elements of kube-controller-manager deployment", func() {
@@ -252,9 +342,9 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeControllerManagerDeployment method and check the result
-			err = ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), dummyContext, dep)
+			err = ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), eContextK8s116, dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels)
+			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels, true)
 		})
 	})
 
@@ -401,7 +491,7 @@ var _ = Describe("Ensurer", func() {
 	})
 })
 
-func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string]string) {
+func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string]string, k8sVersionLessThan117 bool) {
 	// Check that the kube-apiserver container still exists and contains all needed command line args,
 	// env vars, and volume mounts
 	c := extensionswebhook.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-apiserver")
@@ -413,15 +503,18 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string
 	Expect(c.Env).To(ContainElement(accessKeyIDEnvVar))
 	Expect(c.Env).To(ContainElement(secretAccessKeyEnvVar))
 	Expect(c.VolumeMounts).To(ContainElement(cloudProviderConfigVolumeMount))
-
-	// Check that the Pod spec contains all needed volumes
 	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderConfigVolume))
+
+	if !k8sVersionLessThan117 {
+		Expect(c.VolumeMounts).To(ContainElement(etcSSLVolumeMount))
+		Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(etcSSLVolume))
+	}
 
 	// Check that the Pod template contains all needed checksum annotations
 	Expect(dep.Spec.Template.Annotations).To(Equal(annotations))
 }
 
-func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations, labels map[string]string) {
+func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations, labels map[string]string, k8sVersionLessThan117 bool) {
 	// Check that the kube-controller-manager container still exists and contains all needed command line args,
 	// env vars, and volume mounts
 	c := extensionswebhook.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-controller-manager")
@@ -432,9 +525,12 @@ func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations, l
 	Expect(c.Env).To(ContainElement(accessKeyIDEnvVar))
 	Expect(c.Env).To(ContainElement(secretAccessKeyEnvVar))
 	Expect(c.VolumeMounts).To(ContainElement(cloudProviderConfigVolumeMount))
-
-	// Check that the Pod spec contains all needed volumes
 	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderConfigVolume))
+
+	if !k8sVersionLessThan117 {
+		Expect(c.VolumeMounts).To(ContainElement(etcSSLVolumeMount))
+		Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(etcSSLVolume))
+	}
 
 	// Check that the Pod template contains all needed checksum annotations
 	Expect(dep.Spec.Template.Annotations).To(Equal(annotations))

--- a/controllers/provider-azure/README.md
+++ b/controllers/provider-azure/README.md
@@ -23,6 +23,7 @@ This extension controller supports the following Kubernetes versions:
 
 | Version         | Support     | Conformance test results |
 | --------------- | ----------- | ------------------------ |
+| Kubernetes 1.17 | 1.17.0+     | TBD |
 | Kubernetes 1.16 | 1.16.0+, except 1.16.2 | [![Gardener v1.16 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.16%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.16%20Azure) |
 | Kubernetes 1.15 | 1.15.0+, except 1.15.5 | [![Gardener v1.15 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.15%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.15%20Azure) |
 | Kubernetes 1.14 | 1.14.0+     | [![Gardener v1.14 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.14%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.14%20Azure) |

--- a/controllers/provider-azure/charts/images.yaml
+++ b/controllers/provider-azure/charts/images.yaml
@@ -3,9 +3,15 @@ images:
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
   tag: "0.17.0"
-- name: hyperkube
+- name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/kubernetes
   repository: k8s.gcr.io/hyperkube
+  targetVersion: "< 1.17"
+- name: cloud-controller-manager
+  sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
+  repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
+  tag: v0.4.1
+  targetVersion: ">= 1.17"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager

--- a/controllers/provider-azure/charts/internal/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/controllers/provider-azure/charts/internal/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -53,10 +53,12 @@ spec:
         operator: Exists
       containers:
       - name: azure-cloud-controller-manager
-        image: {{ index .Values.images "hyperkube" }}
+        image: {{ index .Values.images "cloud-controller-manager" }}
         imagePullPolicy: IfNotPresent
         command:
+        {{- if semverCompare "< 1.17" .Values.kubernetesVersion }}
         - /hyperkube
+        {{- end }}
         - cloud-controller-manager
         - --allocate-node-cidrs=true
         - --cloud-provider=azure
@@ -112,6 +114,9 @@ spec:
           mountPath: /var/lib/cloud-controller-manager-server
         - name: cloud-provider-config
           mountPath: /etc/kubernetes/cloudprovider
+        - name: etc-ssl
+          mountPath: /etc/ssl
+          readOnly: true
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -126,3 +131,6 @@ spec:
       - name: cloud-provider-config
         configMap:
           name: cloud-provider-config
+      - name: etc-ssl
+        hostPath:
+          path: /etc/ssl

--- a/controllers/provider-azure/charts/internal/cloud-controller-manager/values.yaml
+++ b/controllers/provider-azure/charts/internal/cloud-controller-manager/values.yaml
@@ -7,7 +7,7 @@ featureGates: {}
   # CustomResourceValidation: true
   # RotateKubeletServerCertificate: false
 images:
-  hyperkube: image-repository:image-tag
+  cloud-controller-manager: image-repository:image-tag
 resources:
   requests:
     cpu: 11m

--- a/controllers/provider-azure/pkg/azure/types.go
+++ b/controllers/provider-azure/pkg/azure/types.go
@@ -31,16 +31,16 @@ const (
 
 	// MachineControllerManagerName is a constant for the name of the machine-controller-manager.
 	MachineControllerManagerName = "machine-controller-manager"
-	// HyperkubeImageName is the name of the hyperkube image
-	HyperkubeImageName = "hyperkube"
+	// CloudControllerManagerImageName is the name of the cloud-controller-manager image.
+	CloudControllerManagerImageName = "cloud-controller-manager"
 
-	// SubscriptionIDKey is the key for the subscription ID
+	// SubscriptionIDKey is the key for the subscription ID.
 	SubscriptionIDKey = "subscriptionID"
-	// TenantIDKey is the key for the tenant id
+	// TenantIDKey is the key for the tenant ID.
 	TenantIDKey = "tenantID"
-	// ClientIDKey is the key for the client id
+	// ClientIDKey is the key for the client ID.
 	ClientIDKey = "clientID"
-	// ClientSecretKey is the key for the client secret
+	// ClientSecretKey is the key for the client secret.
 	ClientSecretKey = "clientSecret"
 
 	// StorageAccount is a constant for the key in a cloud provider secret and backup secret that holds the Azure account name.

--- a/controllers/provider-azure/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-azure/pkg/controller/controlplane/valuesprovider.go
@@ -99,7 +99,7 @@ var configChart = &chart.Chart{
 var ccmChart = &chart.Chart{
 	Name:   "cloud-controller-manager",
 	Path:   filepath.Join(internal.InternalChartsPath, "cloud-controller-manager"),
-	Images: []string{azure.HyperkubeImageName},
+	Images: []string{azure.CloudControllerManagerImageName},
 	Objects: []*chart.Object{
 		{Type: &corev1.Service{}, Name: "cloud-controller-manager"},
 		{Type: &appsv1.Deployment{}, Name: "cloud-controller-manager"},

--- a/controllers/provider-gcp/README.md
+++ b/controllers/provider-gcp/README.md
@@ -23,6 +23,7 @@ This extension controller supports the following Kubernetes versions:
 
 | Version         | Support     | Conformance test results |
 | --------------- | ----------- | ------------------------ |
+| Kubernetes 1.17 | 1.17.0+     | TBD |
 | Kubernetes 1.16 | 1.16.0+      | [![Gardener v1.16 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.16%20GCE/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.16%20GCE) |
 | Kubernetes 1.15 | 1.15.0+      | [![Gardener v1.15 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.15%20GCE/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.15%20GCE) |
 | Kubernetes 1.14 | 1.14.0+     | [![Gardener v1.14 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.14%20GCE/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.14%20GCE) |

--- a/controllers/provider-gcp/charts/images.yaml
+++ b/controllers/provider-gcp/charts/images.yaml
@@ -3,9 +3,15 @@ images:
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
   tag: "0.17.0"
-- name: hyperkube
+- name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/kubernetes
   repository: k8s.gcr.io/hyperkube
+  targetVersion: "< 1.17"
+- name: cloud-controller-manager
+  sourceRepository: github.com/gardener/cloud-provider-gcp
+  repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-gcp
+  tag: "v1.17.0"
+  targetVersion: ">= 1.17"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager

--- a/controllers/provider-gcp/charts/internal/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/controllers/provider-gcp/charts/internal/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -53,11 +53,15 @@ spec:
         operator: Exists
       containers:
       - name: gcp-cloud-controller-manager
-        image: {{ index .Values.images "hyperkube" }}
+        image: {{ index .Values.images "cloud-controller-manager" }}
         imagePullPolicy: IfNotPresent
         command:
+        {{- if semverCompare "< 1.17" .Values.kubernetesVersion }}
         - /hyperkube
         - cloud-controller-manager
+        {{- else }}
+        - /gcp-cloud-controller-manager
+        {{- end }}
         - --allocate-node-cidrs=true
         - --cloud-provider=gce
         - --cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf

--- a/controllers/provider-gcp/charts/internal/cloud-controller-manager/values.yaml
+++ b/controllers/provider-gcp/charts/internal/cloud-controller-manager/values.yaml
@@ -7,7 +7,7 @@ featureGates: {}
   # CustomResourceValidation: true
   # RotateKubeletServerCertificate: false
 images:
-  hyperkube: image-repository:image-tag
+  cloud-controller-manager: image-repository:image-tag
 resources:
   requests:
     cpu: 23m

--- a/controllers/provider-gcp/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-gcp/pkg/controller/controlplane/valuesprovider.go
@@ -95,7 +95,7 @@ var configChart = &chart.Chart{
 var ccmChart = &chart.Chart{
 	Name:   "cloud-controller-manager",
 	Path:   filepath.Join(internal.InternalChartsPath, "cloud-controller-manager"),
-	Images: []string{gcp.HyperkubeImageName},
+	Images: []string{gcp.CloudControllerManagerImageName},
 	Objects: []*chart.Object{
 		{Type: &corev1.Service{}, Name: "cloud-controller-manager"},
 		{Type: &appsv1.Deployment{}, Name: "cloud-controller-manager"},

--- a/controllers/provider-gcp/pkg/gcp/types.go
+++ b/controllers/provider-gcp/pkg/gcp/types.go
@@ -22,8 +22,8 @@ const (
 	// StorageProviderName is the name of the GCP storage provider.
 	StorageProviderName = "GCS"
 
-	// HyperkubeImageName is the name of the hyperkube image.
-	HyperkubeImageName = "hyperkube"
+	// CloudControllerManagerImageName is the name of the cloud-controller-manager image.
+	CloudControllerManagerImageName = "cloud-controller-manager"
 	// MachineControllerManagerImageName is the name of the MachineControllerManager image.
 	MachineControllerManagerImageName = "machine-controller-manager"
 	// ETCDBackupRestoreImageName is the name of the etcd backup and restore image.

--- a/controllers/provider-gcp/pkg/webhook/controlplane/ensurer_test.go
+++ b/controllers/provider-gcp/pkg/webhook/controlplane/ensurer_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/gardener/gardener-extensions/controllers/provider-gcp/pkg/internal"
+	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener-extensions/pkg/util"
 	extensionswebhook "github.com/gardener/gardener-extensions/pkg/webhook"
@@ -26,6 +27,7 @@ import (
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane/test"
 
 	"github.com/coreos/go-systemd/unit"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -52,7 +54,29 @@ var _ = Describe("Ensurer", func() {
 	var (
 		ctrl *gomock.Controller
 
-		dummyContext = genericmutator.NewEnsurerContext(nil, nil)
+		dummyContext   = genericmutator.NewEnsurerContext(nil, nil)
+		eContextK8s116 = genericmutator.NewInternalEnsurerContext(
+			&extensionscontroller.Cluster{
+				Shoot: &gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Kubernetes: gardencorev1beta1.Kubernetes{
+							Version: "1.16.0",
+						},
+					},
+				},
+			},
+		)
+		eContextK8s117 = genericmutator.NewInternalEnsurerContext(
+			&extensionscontroller.Cluster{
+				Shoot: &gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Kubernetes: gardencorev1beta1.Kubernetes{
+							Version: "1.17.0",
+						},
+					},
+				},
+			},
+		)
 
 		secretKey = client.ObjectKey{Namespace: namespace, Name: v1beta1constants.SecretNameCloudProvider}
 		secret    = &corev1.Secret{
@@ -87,7 +111,7 @@ var _ = Describe("Ensurer", func() {
 	})
 
 	Describe("#EnsureKubeAPIServerDeployment", func() {
-		It("should add missing elements to kube-apiserver deployment", func() {
+		It("should add missing elements to kube-apiserver deployment (k8s < 1.17)", func() {
 			var (
 				dep = &appsv1.Deployment{
 					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1beta1constants.DeploymentNameKubeAPIServer},
@@ -116,9 +140,43 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
-			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dummyContext, dep)
+			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), eContextK8s116, dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeAPIServerDeployment(dep, annotations)
+			checkKubeAPIServerDeployment(dep, annotations, true)
+		})
+
+		It("should add missing elements to kube-apiserver deployment (k8s >= 1.17)", func() {
+			var (
+				dep = &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1beta1constants.DeploymentNameKubeAPIServer},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "kube-apiserver",
+									},
+								},
+							},
+						},
+					},
+				}
+			)
+
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
+			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
+
+			// Create ensurer
+			ensurer := NewEnsurer(logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Call EnsureKubeAPIServerDeployment method and check the result
+			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), eContextK8s117, dep)
+			Expect(err).To(Not(HaveOccurred()))
+			checkKubeAPIServerDeployment(dep, annotations, false)
 		})
 
 		It("should modify existing elements of kube-apiserver deployment", func() {
@@ -167,14 +225,14 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
-			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dummyContext, dep)
+			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), eContextK8s116, dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeAPIServerDeployment(dep, annotations)
+			checkKubeAPIServerDeployment(dep, annotations, true)
 		})
 	})
 
 	Describe("#EnsureKubeControllerManagerDeployment", func() {
-		It("should add missing elements to kube-controller-manager deployment", func() {
+		It("should add missing elements to kube-controller-manager deployment (k8s < 1.17)", func() {
 			var (
 				dep = &appsv1.Deployment{
 					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1beta1constants.DeploymentNameKubeControllerManager},
@@ -203,9 +261,43 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeControllerManagerDeployment method and check the result
-			err = ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), dummyContext, dep)
+			err = ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), eContextK8s116, dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels)
+			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels, true)
+		})
+
+		It("should add missing elements to kube-controller-manager deployment (k8s >= 1.17)", func() {
+			var (
+				dep = &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1beta1constants.DeploymentNameKubeControllerManager},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "kube-controller-manager",
+									},
+								},
+							},
+						},
+					},
+				}
+			)
+
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
+			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
+
+			// Create ensurer
+			ensurer := NewEnsurer(logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Call EnsureKubeControllerManagerDeployment method and check the result
+			err = ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), eContextK8s117, dep)
+			Expect(err).To(Not(HaveOccurred()))
+			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels, false)
 		})
 
 		It("should modify existing elements of kube-controller-manager deployment", func() {
@@ -253,9 +345,9 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeControllerManagerDeployment method and check the result
-			err = ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), dummyContext, dep)
+			err = ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), eContextK8s116, dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels)
+			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels, true)
 		})
 	})
 
@@ -368,7 +460,7 @@ var _ = Describe("Ensurer", func() {
 	})
 })
 
-func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string]string) {
+func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string]string, k8sVersionLessThan117 bool) {
 	// Check that the kube-apiserver container still exists and contains all needed command line args,
 	// env vars, and volume mounts
 	c := extensionswebhook.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-apiserver")
@@ -380,16 +472,19 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string
 	Expect(c.Env).To(ContainElement(credentialsEnvVar))
 	Expect(c.VolumeMounts).To(ContainElement(cloudProviderConfigVolumeMount))
 	Expect(c.VolumeMounts).To(ContainElement(cloudProviderSecretVolumeMount))
-
-	// Check that the Pod spec contains all needed volumes
 	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderConfigVolume))
 	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderSecretVolume))
+
+	if !k8sVersionLessThan117 {
+		Expect(c.VolumeMounts).To(ContainElement(etcSSLVolumeMount))
+		Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(etcSSLVolume))
+	}
 
 	// Check that the Pod template contains all needed checksum annotations
 	Expect(dep.Spec.Template.Annotations).To(Equal(annotations))
 }
 
-func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations, labels map[string]string) {
+func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations, labels map[string]string, k8sVersionLessThan117 bool) {
 	// Check that the kube-controller-manager container still exists and contains all needed command line args,
 	// env vars, and volume mounts
 	c := extensionswebhook.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-controller-manager")
@@ -400,10 +495,13 @@ func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations, l
 	Expect(c.Env).To(ContainElement(credentialsEnvVar))
 	Expect(c.VolumeMounts).To(ContainElement(cloudProviderConfigVolumeMount))
 	Expect(c.VolumeMounts).To(ContainElement(cloudProviderSecretVolumeMount))
-
-	// Check that the Pod spec contains all needed volumes
 	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderConfigVolume))
 	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderSecretVolume))
+
+	if !k8sVersionLessThan117 {
+		Expect(c.VolumeMounts).To(ContainElement(etcSSLVolumeMount))
+		Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(etcSSLVolume))
+	}
 
 	// Check that the Pod template contains all needed checksum annotations
 	Expect(dep.Spec.Template.Annotations).To(Equal(annotations))

--- a/controllers/provider-openstack/README.md
+++ b/controllers/provider-openstack/README.md
@@ -23,6 +23,7 @@ This extension controller supports the following Kubernetes versions:
 
 | Version         | Support     | Conformance test results |
 | --------------- | ----------- | ------------------------ |
+| Kubernetes 1.17 | 1.17.0+     | TBD |
 | Kubernetes 1.16 | 1.16.0+     | [![Gardener v1.16 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.16%20OpenStack/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.16%20OpenStack) |
 | Kubernetes 1.15 | 1.15.0+     | [![Gardener v1.15 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.15%20OpenStack/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.15%20OpenStack) |
 | Kubernetes 1.14 | 1.14.0+     | [![Gardener v1.14 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.14%20OpenStack/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.14%20OpenStack) |

--- a/controllers/provider-openstack/charts/images.yaml
+++ b/controllers/provider-openstack/charts/images.yaml
@@ -11,12 +11,12 @@ images:
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
   tag: "0.7.3"
-- name: openstack-cloud-controller-manager
+- name: cloud-controller-manager
+  sourceRepository: github.com/kubernetes/cloud-provider-openstack
+  repository: k8s.gcr.io/hyperkube
+  targetVersion: "< 1.15"
+- name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager
   tag: "v1.17.0"
   targetVersion: ">= 1.15"
-- name: openstack-cloud-controller-manager
-  sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: k8s.gcr.io/hyperkube
-  targetVersion: "< 1.15"

--- a/controllers/provider-openstack/charts/internal/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/controllers/provider-openstack/charts/internal/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -54,7 +54,7 @@ spec:
         operator: Exists
       containers:
       - name: openstack-cloud-controller-manager
-        image: {{ index .Values.images "openstack-cloud-controller-manager" }}
+        image: {{ index .Values.images "cloud-controller-manager" }}
         imagePullPolicy: IfNotPresent
         command:
         {{- if semverCompare ">= 1.15" .Values.kubernetesVersion }}

--- a/controllers/provider-openstack/pkg/openstack/types.go
+++ b/controllers/provider-openstack/pkg/openstack/types.go
@@ -25,7 +25,7 @@ const (
 	// MachineControllerManagerImageName is the name of the MachineControllerManager image.
 	MachineControllerManagerImageName = "machine-controller-manager"
 	// CloudControllerImageName is the name of the external OpenStackCloudProvider image.
-	CloudControllerImageName = "openstack-cloud-controller-manager"
+	CloudControllerImageName = "cloud-controller-manager"
 	// ETCDBackupRestoreImageName is the name of the etcd backup and restore image.
 	ETCDBackupRestoreImageName = "etcd-backup-restore"
 

--- a/controllers/provider-openstack/pkg/webhook/controlplane/ensurer.go
+++ b/controllers/provider-openstack/pkg/webhook/controlplane/ensurer.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/coreos/go-systemd/unit"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -57,11 +58,17 @@ func (e *ensurer) InjectClient(client client.Client) error {
 func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, ectx genericmutator.EnsurerContext, dep *appsv1.Deployment) error {
 	template := &dep.Spec.Template
 	ps := &template.Spec
+
+	cluster, err := ectx.GetCluster(ctx)
+	if err != nil {
+		return err
+	}
+
 	if c := extensionswebhook.ContainerWithName(ps.Containers, "kube-apiserver"); c != nil {
 		ensureKubeAPIServerCommandLineArgs(c)
-		ensureVolumeMounts(c)
+		ensureVolumeMounts(c, cluster.Shoot.Spec.Kubernetes.Version)
 	}
-	ensureVolumes(ps)
+	ensureVolumes(ps, cluster.Shoot.Spec.Kubernetes.Version)
 	return e.ensureChecksumAnnotations(ctx, &dep.Spec.Template, dep.Namespace)
 }
 
@@ -69,12 +76,18 @@ func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, ectx generi
 func (e *ensurer) EnsureKubeControllerManagerDeployment(ctx context.Context, ectx genericmutator.EnsurerContext, dep *appsv1.Deployment) error {
 	template := &dep.Spec.Template
 	ps := &template.Spec
+
+	cluster, err := ectx.GetCluster(ctx)
+	if err != nil {
+		return err
+	}
+
 	if c := extensionswebhook.ContainerWithName(ps.Containers, "kube-controller-manager"); c != nil {
 		ensureKubeControllerManagerCommandLineArgs(c)
-		ensureVolumeMounts(c)
+		ensureVolumeMounts(c, cluster.Shoot.Spec.Kubernetes.Version)
 	}
 	ensureKubeControllerManagerAnnotations(template)
-	ensureVolumes(ps)
+	ensureVolumes(ps, cluster.Shoot.Spec.Kubernetes.Version)
 	return e.ensureChecksumAnnotations(ctx, &dep.Spec.Template, dep.Namespace)
 }
 
@@ -102,6 +115,21 @@ func ensureKubeControllerManagerAnnotations(t *corev1.PodTemplateSpec) {
 }
 
 var (
+	etcSSLName        = "etc-ssl"
+	etcSSLVolumeMount = corev1.VolumeMount{
+		Name:      etcSSLName,
+		MountPath: "/etc/ssl",
+		ReadOnly:  true,
+	}
+	etcSSLVolume = corev1.Volume{
+		Name: etcSSLName,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/etc/ssl",
+			},
+		},
+	}
+
 	cloudProviderConfigKubeControllerManagerVolumeMount = corev1.VolumeMount{
 		Name:      openstack.CloudProviderConfigKubeControllerManagerName,
 		MountPath: "/etc/kubernetes/cloudprovider",
@@ -116,12 +144,32 @@ var (
 	}
 )
 
-func ensureVolumeMounts(c *corev1.Container) {
+func ensureVolumeMounts(c *corev1.Container, version string) {
 	c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, cloudProviderConfigKubeControllerManagerVolumeMount)
+
+	if mustMountEtcSSLFolder(version) {
+		c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, etcSSLVolumeMount)
+	}
 }
 
-func ensureVolumes(ps *corev1.PodSpec) {
+func ensureVolumes(ps *corev1.PodSpec, version string) {
 	ps.Volumes = extensionswebhook.EnsureVolumeWithName(ps.Volumes, cloudProviderConfigKubeControllerManagerVolume)
+
+	if mustMountEtcSSLFolder(version) {
+		ps.Volumes = extensionswebhook.EnsureVolumeWithName(ps.Volumes, etcSSLVolume)
+	}
+}
+
+// Beginning with 1.17 Gardener no longer uses the hyperkube image for the Kubernetes control plane components.
+// The hyperkube image contained all the well-known root CAs, but the dedicated images don't. This is why we
+// mount the /etc/ssl folder from the host here.
+// TODO: This can be remove again once we have migrated to CSI.
+func mustMountEtcSSLFolder(version string) bool {
+	k8sVersionAtLeast117, err := versionutils.CompareVersions(version, ">=", "1.17")
+	if err != nil {
+		return false
+	}
+	return k8sVersionAtLeast117
 }
 
 func (e *ensurer) ensureChecksumAnnotations(ctx context.Context, template *corev1.PodTemplateSpec, namespace string) error {

--- a/controllers/provider-openstack/pkg/webhook/controlplane/ensurer_test.go
+++ b/controllers/provider-openstack/pkg/webhook/controlplane/ensurer_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/gardener/gardener-extensions/controllers/provider-openstack/pkg/openstack"
+	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener-extensions/pkg/util"
 	extensionswebhook "github.com/gardener/gardener-extensions/pkg/webhook"
@@ -26,6 +27,7 @@ import (
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane/test"
 
 	"github.com/coreos/go-systemd/unit"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -55,7 +57,29 @@ var _ = Describe("Ensurer", func() {
 	var (
 		ctrl *gomock.Controller
 
-		dummyContext = genericmutator.NewEnsurerContext(nil, nil)
+		dummyContext   = genericmutator.NewEnsurerContext(nil, nil)
+		eContextK8s116 = genericmutator.NewInternalEnsurerContext(
+			&extensionscontroller.Cluster{
+				Shoot: &gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Kubernetes: gardencorev1beta1.Kubernetes{
+							Version: "1.16.0",
+						},
+					},
+				},
+			},
+		)
+		eContextK8s117 = genericmutator.NewInternalEnsurerContext(
+			&extensionscontroller.Cluster{
+				Shoot: &gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Kubernetes: gardencorev1beta1.Kubernetes{
+							Version: "1.17.0",
+						},
+					},
+				},
+			},
+		)
 
 		cmKey    = client.ObjectKey{Namespace: namespace, Name: openstack.CloudProviderConfigCloudControllerManagerName}
 		cmKCMKey = client.ObjectKey{Namespace: namespace, Name: openstack.CloudProviderConfigKubeControllerManagerName}
@@ -84,7 +108,7 @@ var _ = Describe("Ensurer", func() {
 	})
 
 	Describe("#EnsureKubeAPIServerDeployment", func() {
-		It("should add missing elements to kube-apiserver deployment", func() {
+		It("should add missing elements to kube-apiserver deployment (k8s < 1.17)", func() {
 			var (
 				dep = &appsv1.Deployment{
 					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1beta1constants.DeploymentNameKubeAPIServer},
@@ -112,9 +136,42 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
-			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dummyContext, dep)
+			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), eContextK8s116, dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeAPIServerDeployment(dep, annotations)
+			checkKubeAPIServerDeployment(dep, annotations, true)
+		})
+
+		It("should add missing elements to kube-apiserver deployment (k8s >= 1.17)", func() {
+			var (
+				dep = &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1beta1constants.DeploymentNameKubeAPIServer},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "kube-apiserver",
+									},
+								},
+							},
+						},
+					},
+				}
+			)
+
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
+
+			// Create ensurer
+			ensurer := NewEnsurer(logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Call EnsureKubeAPIServerDeployment method and check the result
+			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), eContextK8s117, dep)
+			Expect(err).To(Not(HaveOccurred()))
+			checkKubeAPIServerDeployment(dep, annotations, false)
 		})
 
 		It("should modify existing elements of kube-apiserver deployment", func() {
@@ -151,14 +208,14 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
-			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dummyContext, dep)
+			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), eContextK8s116, dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeAPIServerDeployment(dep, annotations)
+			checkKubeAPIServerDeployment(dep, annotations, true)
 		})
 	})
 
 	Describe("#EnsureKubeControllerManagerDeployment", func() {
-		It("should add missing elements to kube-controller-manager deployment", func() {
+		It("should add missing elements to kube-controller-manager deployment (k8s < 1.17)", func() {
 			var (
 				dep = &appsv1.Deployment{
 					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1beta1constants.DeploymentNameKubeControllerManager},
@@ -186,9 +243,42 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeControllerManagerDeployment method and check the result
-			err = ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), dummyContext, dep)
+			err = ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), eContextK8s116, dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels)
+			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels, true)
+		})
+
+		It("should add missing elements to kube-controller-manager deployment (k8s >= 1.17)", func() {
+			var (
+				dep = &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1beta1constants.DeploymentNameKubeControllerManager},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "kube-controller-manager",
+									},
+								},
+							},
+						},
+					},
+				}
+			)
+
+			// Create mock client
+			client := mockclient.NewMockClient(ctrl)
+			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
+
+			// Create ensurer
+			ensurer := NewEnsurer(logger)
+			err := ensurer.(inject.Client).InjectClient(client)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Call EnsureKubeControllerManagerDeployment method and check the result
+			err = ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), eContextK8s117, dep)
+			Expect(err).To(Not(HaveOccurred()))
+			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels, false)
 		})
 
 		It("should modify existing elements of kube-controller-manager deployment", func() {
@@ -230,9 +320,9 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeControllerManagerDeployment method and check the result
-			err = ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), dummyContext, dep)
+			err = ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), eContextK8s116, dep)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels)
+			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels, true)
 		})
 	})
 
@@ -355,7 +445,7 @@ var _ = Describe("Ensurer", func() {
 	})
 })
 
-func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string]string) {
+func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string]string, k8sVersionLessThan117 bool) {
 	// Check that the kube-apiserver container still exists and contains all needed command line args,
 	// env vars, and volume mounts
 	c := extensionswebhook.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-apiserver")
@@ -365,15 +455,18 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string
 	Expect(c.Command).To(test.ContainElementWithPrefixContaining("--enable-admission-plugins=", "PersistentVolumeLabel", ","))
 	Expect(c.Command).To(Not(test.ContainElementWithPrefixContaining("--disable-admission-plugins=", "PersistentVolumeLabel", ",")))
 	Expect(c.VolumeMounts).To(ContainElement(cloudProviderConfigKubeControllerManagerVolumeMount))
-
-	// Check that the Pod spec contains all needed volumes
 	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderConfigKubeControllerManagerVolume))
+
+	if !k8sVersionLessThan117 {
+		Expect(c.VolumeMounts).To(ContainElement(etcSSLVolumeMount))
+		Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(etcSSLVolume))
+	}
 
 	// Check that the Pod template contains all needed checksum annotations
 	Expect(dep.Spec.Template.Annotations).To(Equal(annotations))
 }
 
-func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations, labels map[string]string) {
+func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations, labels map[string]string, k8sVersionLessThan117 bool) {
 	// Check that the kube-controller-manager container still exists and contains all needed command line args,
 	// env vars, and volume mounts
 	c := extensionswebhook.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-controller-manager")
@@ -382,9 +475,12 @@ func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations, l
 	Expect(c.Command).To(ContainElement("--cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf"))
 	Expect(c.Command).To(ContainElement("--external-cloud-volume-plugin=openstack"))
 	Expect(c.VolumeMounts).To(ContainElement(cloudProviderConfigKubeControllerManagerVolumeMount))
-
-	// Check that the Pod spec contains all needed volumes
 	Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderConfigKubeControllerManagerVolume))
+
+	if !k8sVersionLessThan117 {
+		Expect(c.VolumeMounts).To(ContainElement(etcSSLVolumeMount))
+		Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(etcSSLVolume))
+	}
 
 	// Check that the Pod template contains all needed checksum annotations
 	Expect(dep.Spec.Template.Annotations).To(Equal(annotations))

--- a/controllers/provider-packet/README.md
+++ b/controllers/provider-packet/README.md
@@ -23,6 +23,7 @@ This extension controller supports the following Kubernetes versions:
 
 | Version         | Support     | Conformance test results |
 | --------------- | ----------- | ------------------------ |
+| Kubernetes 1.17 | unknown     | N/A                      |
 | Kubernetes 1.16 | 1.16.0+     | N/A                      |
 | Kubernetes 1.15 | 1.15.0+     | N/A                      |
 | Kubernetes 1.14 | 1.14.0+     | N/A                      |

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,13 @@ github.com/gardener/gardener v0.0.0-20190830053951-194cf8abb797/go.mod h1:UjyQiG
 github.com/gardener/gardener v0.0.0-20190913144920-5b4adb9f114d/go.mod h1:8LOLWzproKzfww5LdDo0/7FyVQR7gR1QA5LQc5buDzQ=
 github.com/gardener/gardener v0.0.0-20191004085047-5707d498b40c/go.mod h1:zvajWsteDY43oECil7ADr4NNp88CMltFEutUp1jX+zA=
 github.com/gardener/gardener v0.0.0-20191028054636-32cb0027c126/go.mod h1:Ow7vOXQYgQeHTRFn2HdbEIptelrSB5NLmVFIt2rgNeY=
+github.com/gardener/gardener v0.33.1-0.20191217084546-948979065a54 h1:8qndSViHaSFr5sJ5AAMVc6hMWWnEFQTz9lcgDp+7A64=
+github.com/gardener/gardener v0.33.1-0.20191217084546-948979065a54/go.mod h1:ABQbMpOczmL52FWopbCpzDFpzOg01Jasslez5PAiAqs=
+github.com/gardener/gardener v0.33.1-0.20191218064725-9a32c273cb38 h1:I7e4i1BxaXCSlkopkh/tY5Ik+OTPSFLG0Co0sdYRXBk=
+github.com/gardener/gardener v0.33.1-0.20191218064725-9a32c273cb38/go.mod h1:OsrX8Fhrn6qYaHaFJhvZYsSQVpo6/pfX+5WpzWzniHY=
 github.com/gardener/gardener v0.33.1-0.20191230124716-a9eee9416e16 h1:jaa6GiBdHbJPmBK2WX8sMZ2XQauVko0vwX1PZ/DPYOE=
 github.com/gardener/gardener v0.33.1-0.20191230124716-a9eee9416e16/go.mod h1:OsrX8Fhrn6qYaHaFJhvZYsSQVpo6/pfX+5WpzWzniHY=
+github.com/gardener/gardener v0.33.6 h1:pb7T/zmMP4ZZqlvfzfvGQCweHwcLaMZv6S8WPJfuCpc=
 github.com/gardener/gardener-extensions v0.0.0-20190725050243-a80ef643c64b/go.mod h1:uXjtl3KeVdQXuGIP26+84wJY1Kwru67l0FXm7A5DiME=
 github.com/gardener/gardener-extensions v0.0.0-20190820050625-a15de8a82f6b/go.mod h1:q69+1cUGSfQ8gSMWzU7GFz/R8K8MpOLQBT2wJJcCjEA=
 github.com/gardener/gardener-extensions v0.0.0-20190906160200-5c329d46ae81/go.mod h1:OBUAbab8OMm8pvzr/1/cdwIQnQYuMoGDTNR2c+i9nYo=


### PR DESCRIPTION
**What this PR does / why we need it**:
Support for Kubernetes v1.17

**Which issue(s) this PR fixes**:
Part of gardener/gardener#1709 

**Special notes for your reviewer**:
* I didn't vendor the `kubernetes-1.17` sources yet because the controller-runtime is still using `kubernetes-1.16`.
* As the k/k community does no longer build a Docker image for the in-tree cloud-controller-managers (as of 1.16) and has deprecated the `hyperkube` image (as of 1.17) which also no longer contains the cloud-controller-manager binary, we
  * forked [k/cloud-provider-aws](https://github.com/kubernetes/cloud-provider-aws) to [g/cloud-provider-aws](https://github.com/gardener/cloud-provider-aws) and build the AWS CCM 1.17 image ourselves (for < 1.17 clusters the hyperkube cloud-controller-manager is still used)
  * use the [k-sigs/cloud-provider-azure](https://github.com/kubernetes-sigs/cloud-provider-azure) `v0.4.0` out-of-tree cloud-controller-manager for 1.17 Azure clusters (for < 1.17 clusters the hyperkube cloud-controller-manager is still used)
  * forked [k/cloud-provider-gcp](https://github.com/kubernetes/cloud-provider-gcp) to [g/cloud-provider-gcp](https://github.com/gardener/cloud-provider-gcp) and build the GCP CCM 1.17 image ourselves (for < 1.17 clusters the hyperkube cloud-controller-manager is still used)
  * still use the same versions as before of the CCMs for Alicloud and OpenStack

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy operator
The Alicloud, AWS, Azure, GCP, and OpenStack extension controllers do now support Kubernetes 1.17 clusters.
