### PR TITLE
Allow to disable AWS ECR access via infrastructure config

### DIFF
--- a/controllers/provider-aws/charts/internal/aws-infra/templates/main.tf
+++ b/controllers/provider-aws/charts/internal/aws-infra/templates/main.tf
@@ -312,7 +312,7 @@ resource "aws_iam_role_policy" "nodes" {
       "Resource": [
         "*"
       ]
-    },
+    }{{ if .Values.enableECRAccess }},
     {
       "Effect": "Allow",
       "Action": [
@@ -327,7 +327,7 @@ resource "aws_iam_role_policy" "nodes" {
       "Resource": [
         "*"
       ]
-    }
+    }{{ end }}
   ]
 }
 EOF

--- a/controllers/provider-aws/charts/internal/aws-infra/values.yaml
+++ b/controllers/provider-aws/charts/internal/aws-infra/values.yaml
@@ -7,6 +7,7 @@ create:
 sshPublicKey: sshkey-12345
 
 clusterName: test-namespace
+enableECRAccess: true
 
 vpc:
   id: ${aws_vpc.vpc.id}

--- a/controllers/provider-aws/docs/usage-as-end-user.md
+++ b/controllers/provider-aws/docs/usage-as-end-user.md
@@ -32,6 +32,7 @@ An example `InfrastructureConfig` for the AWS extension looks as follows:
 ```yaml
 apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
 kind: InfrastructureConfig
+enableECRAccess: true
 networks:
   vpc: # specify either 'id' or 'cidr'
   # id: vpc-123456
@@ -42,6 +43,9 @@ networks:
     public: 10.250.96.0/22
     workers: 10.250.0.0/19
 ```
+
+The `enableECRAccess` flag specifies whether the AWS IAM role policy attached to all worker nodes of the cluster shall contain permissions to access the Elastic Container Registry of the respective AWS account.
+If the flag is not provided it is defaulted to `true`.
 
 The `networks.vpc` section describes whether you want to create the shoot cluster in an already existing VPC or whether to create a new one:
 

--- a/controllers/provider-aws/example/30-infrastructure.yaml
+++ b/controllers/provider-aws/example/30-infrastructure.yaml
@@ -42,6 +42,7 @@ spec:
   providerConfig:
     apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
     kind: InfrastructureConfig
+    enableECRAccess: true
     networks:
       vpc: # specify either 'id' or 'cidr'
       # id: vpc-123456

--- a/controllers/provider-aws/hack/api-reference/api.md
+++ b/controllers/provider-aws/hack/api-reference/api.md
@@ -145,6 +145,20 @@ string
 </tr>
 <tr>
 <td>
+<code>enableECRAccess</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>EnableECRAccess specifies whether the IAM role policy for the worker nodes shall contain
+permissions to access the ECR.
+default: true</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>networks</code></br>
 <em>
 <a href="#aws.provider.extensions.gardener.cloud/v1alpha1.Networks">

--- a/controllers/provider-aws/pkg/apis/aws/types_infrastructure.go
+++ b/controllers/provider-aws/pkg/apis/aws/types_infrastructure.go
@@ -24,6 +24,11 @@ import (
 type InfrastructureConfig struct {
 	metav1.TypeMeta
 
+	// EnableECRAccess specifies whether the IAM role policy for the worker nodes shall contain
+	// permissions to access the ECR.
+	// default: true
+	EnableECRAccess *bool
+
 	// Networks is the AWS specific network configuration (VPC, subnets, etc.)
 	Networks Networks
 }

--- a/controllers/provider-aws/pkg/apis/aws/v1alpha1/types_infrastructure.go
+++ b/controllers/provider-aws/pkg/apis/aws/v1alpha1/types_infrastructure.go
@@ -25,6 +25,12 @@ import (
 type InfrastructureConfig struct {
 	metav1.TypeMeta `json:",inline"`
 
+	// EnableECRAccess specifies whether the IAM role policy for the worker nodes shall contain
+	// permissions to access the ECR.
+	// default: true
+	// +optional
+	EnableECRAccess *bool `json:"enableECRAccess,omitempty"`
+
 	// Networks is the AWS specific network configuration (VPC, subnets, etc.)
 	Networks Networks `json:"networks"`
 }

--- a/controllers/provider-aws/pkg/apis/aws/v1alpha1/zz_generated.conversion.go
+++ b/controllers/provider-aws/pkg/apis/aws/v1alpha1/zz_generated.conversion.go
@@ -361,6 +361,7 @@ func Convert_aws_IAM_To_v1alpha1_IAM(in *aws.IAM, out *IAM, s conversion.Scope) 
 }
 
 func autoConvert_v1alpha1_InfrastructureConfig_To_aws_InfrastructureConfig(in *InfrastructureConfig, out *aws.InfrastructureConfig, s conversion.Scope) error {
+	out.EnableECRAccess = (*bool)(unsafe.Pointer(in.EnableECRAccess))
 	if err := Convert_v1alpha1_Networks_To_aws_Networks(&in.Networks, &out.Networks, s); err != nil {
 		return err
 	}
@@ -373,6 +374,7 @@ func Convert_v1alpha1_InfrastructureConfig_To_aws_InfrastructureConfig(in *Infra
 }
 
 func autoConvert_aws_InfrastructureConfig_To_v1alpha1_InfrastructureConfig(in *aws.InfrastructureConfig, out *InfrastructureConfig, s conversion.Scope) error {
+	out.EnableECRAccess = (*bool)(unsafe.Pointer(in.EnableECRAccess))
 	if err := Convert_aws_Networks_To_v1alpha1_Networks(&in.Networks, &out.Networks, s); err != nil {
 		return err
 	}

--- a/controllers/provider-aws/pkg/apis/aws/v1alpha1/zz_generated.deepcopy.go
+++ b/controllers/provider-aws/pkg/apis/aws/v1alpha1/zz_generated.deepcopy.go
@@ -155,6 +155,11 @@ func (in *IAM) DeepCopy() *IAM {
 func (in *InfrastructureConfig) DeepCopyInto(out *InfrastructureConfig) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.EnableECRAccess != nil {
+		in, out := &in.EnableECRAccess, &out.EnableECRAccess
+		*out = new(bool)
+		**out = **in
+	}
 	in.Networks.DeepCopyInto(&out.Networks)
 	return
 }

--- a/controllers/provider-aws/pkg/apis/aws/zz_generated.deepcopy.go
+++ b/controllers/provider-aws/pkg/apis/aws/zz_generated.deepcopy.go
@@ -155,6 +155,11 @@ func (in *IAM) DeepCopy() *IAM {
 func (in *InfrastructureConfig) DeepCopyInto(out *InfrastructureConfig) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.EnableECRAccess != nil {
+		in, out := &in.EnableECRAccess, &out.EnableECRAccess
+		*out = new(bool)
+		**out = **in
+	}
 	in.Networks.DeepCopyInto(&out.Networks)
 	return
 }

--- a/controllers/provider-aws/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/controllers/provider-aws/pkg/controller/infrastructure/actuator_reconcile.go
@@ -137,6 +137,11 @@ func generateTerraformInfraConfig(ctx context.Context, infrastructure *extension
 		})
 	}
 
+	enableECRAccess := true
+	if v := infrastructureConfig.EnableECRAccess; v != nil {
+		enableECRAccess = *v
+	}
+
 	return map[string]interface{}{
 		"aws": map[string]interface{}{
 			"region": infrastructure.Spec.Region,
@@ -144,7 +149,8 @@ func generateTerraformInfraConfig(ctx context.Context, infrastructure *extension
 		"create": map[string]interface{}{
 			"vpc": createVPC,
 		},
-		"sshPublicKey": string(infrastructure.Spec.SSHPublicKey),
+		"enableECRAccess": enableECRAccess,
+		"sshPublicKey":    string(infrastructure.Spec.SSHPublicKey),
 		"vpc": map[string]interface{}{
 			"id":                vpcID,
 			"cidr":              vpcCIDR,


### PR DESCRIPTION
**What this PR does / why we need it**:
Added a new `enableECRAccess` flag to `aws.provider.extensions.gardener.cloud/v1alpha1.InfrastructureConfig` that allows to control whether the permissions shall be added to the AWS IAM role policy attached to all worker nodes.

**Which issue(s) this PR fixes**:
Fixes #238

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
It is now possible to remove the ECR permission that is part of the AWS IAM role policy attached to all shoot worker nodes by specifying `aws.provider.extensions.gardener.cloud/v1alpha1.InfrastructureConfig.enableECRAccess=false`. If the field is not provided then it is defaulted to `true`, preserving the old behaviour where ECR access is always granted.
```
