### PR TITLE
Consistent naming for worker CIDRs

### DIFF
--- a/controllers/provider-alicloud/charts/internal/alicloud-infra/templates/main.tf
+++ b/controllers/provider-alicloud/charts/internal/alicloud-infra/templates/main.tf
@@ -29,7 +29,7 @@ resource "alicloud_nat_gateway" "nat_gateway" {
 resource "alicloud_vswitch" "vsw_z{{ $index }}" {
   name              = "{{ required "clusterName is required" $.Values.clusterName }}-{{ required "zone.name is required" $zone.name }}-vsw"
   vpc_id            = "{{ required "vpc.id is required" $.Values.vpc.id }}"
-  cidr_block        = "{{ required "zone.cidr.worker is required" $zone.cidr.worker }}"
+  cidr_block        = "{{ required "zone.cidr.workers is required" $zone.cidr.workers }}"
   availability_zone = "{{ required "zone.name is required" $zone.name }}"
 }
 

--- a/controllers/provider-alicloud/charts/internal/alicloud-infra/values.yaml
+++ b/controllers/provider-alicloud/charts/internal/alicloud-infra/values.yaml
@@ -18,10 +18,10 @@ vpc:
 zones:
 - name: cn-beijing-a
   cidr:
-    worker: 10.250.0.0/19
+    workers: 10.250.0.0/19
 - name: cn-beijing-b
   cidr:
-    worker: 10.250.32.0/19
+    workers: 10.250.32.0/19
 
 names:
   configuration: shoot.tf-config

--- a/controllers/provider-alicloud/docs/usage-as-end-user.md
+++ b/controllers/provider-alicloud/docs/usage-as-end-user.md
@@ -38,7 +38,7 @@ networks:
     cidr: 10.250.0.0/16
   zones:
   - name: eu-central-1a
-    worker: 10.250.1.0/24
+    workers: 10.250.1.0/24
 ```
 
 The `networks.vpc` section describes whether you want to create the shoot cluster in an already existing VPC or whether to create a new one:
@@ -51,7 +51,7 @@ You can freely choose a private CIDR range.
 The `networks.zones` section describes which subnets you want to create in availability zones.
 For every zone, the Alicloud extension creates one subnet:
 
-* The `worker` subnet is used for all shoot worker nodes, i.e., VMs which later run your applications.
+* The `workers` subnet is used for all shoot worker nodes, i.e., VMs which later run your applications.
 
 For every subnet, you have to specify a CIDR range contained in the VPC CIDR specified above, or the VPC CIDR of your already existing VPC.
 You can freely choose these CIDR and it is your responsibility to properly design the network layout to suit your needs.
@@ -108,7 +108,7 @@ spec:
           cidr: 10.250.0.0/16
         zones:
         - name: eu-central-1a
-          worker: 10.250.0.0/19
+          workers: 10.250.0.0/19
     controlPlaneConfig:
       apiVersion: alicloud.provider.extensions.gardener.cloud/v1alpha1
       kind: ControlPlaneConfig
@@ -164,9 +164,9 @@ spec:
           cidr: 10.250.0.0/16
         zones:
         - name: eu-central-1a
-          worker: 10.250.0.0/26
+          workers: 10.250.0.0/26
         - name: eu-central-1b
-          worker: 10.250.0.64/26
+          workers: 10.250.0.64/26
     controlPlaneConfig:
       apiVersion: alicloud.provider.extensions.gardener.cloud/v1alpha1
       kind: ControlPlaneConfig

--- a/controllers/provider-alicloud/example/30-infrastructure.yaml
+++ b/controllers/provider-alicloud/example/30-infrastructure.yaml
@@ -59,4 +59,4 @@ spec:
         cidr: 10.250.0.0/16
       zones:
       - name: eu-central-1a
-        worker: 10.250.1.0/24
+        workers: 10.250.1.0/24

--- a/controllers/provider-alicloud/hack/api-reference/api.md
+++ b/controllers/provider-alicloud/hack/api-reference/api.md
@@ -727,7 +727,19 @@ string
 </em>
 </td>
 <td>
-<p>Worker specifies the worker CIDR to use.</p>
+<p>Worker specifies the worker CIDR to use.
+Deprecated - use <code>workers</code> instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workers</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Workers specifies the worker CIDR to use.</p>
 </td>
 </tr>
 </tbody>

--- a/controllers/provider-alicloud/pkg/apis/alicloud/types_infrastructure.go
+++ b/controllers/provider-alicloud/pkg/apis/alicloud/types_infrastructure.go
@@ -90,7 +90,10 @@ type Zone struct {
 	// Name is the name of a zone.
 	Name string
 	// Worker specifies the worker CIDR to use.
+	// Deprecated - use `workers` instead.
 	Worker string
+	// Workers specifies the worker CIDR to use.
+	Workers string
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/controllers/provider-alicloud/pkg/apis/alicloud/v1alpha1/types_infrastructure.go
+++ b/controllers/provider-alicloud/pkg/apis/alicloud/v1alpha1/types_infrastructure.go
@@ -91,7 +91,10 @@ type Zone struct {
 	// Name is the name of a zone.
 	Name string `json:"name"`
 	// Worker specifies the worker CIDR to use.
+	// Deprecated - use `workers` instead.
 	Worker string `json:"worker"`
+	// Workers specifies the worker CIDR to use.
+	Workers string `json:"workers"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/controllers/provider-alicloud/pkg/apis/alicloud/v1alpha1/zz_generated.conversion.go
+++ b/controllers/provider-alicloud/pkg/apis/alicloud/v1alpha1/zz_generated.conversion.go
@@ -511,6 +511,7 @@ func Convert_alicloud_WorkerStatus_To_v1alpha1_WorkerStatus(in *alicloud.WorkerS
 func autoConvert_v1alpha1_Zone_To_alicloud_Zone(in *Zone, out *alicloud.Zone, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Worker = in.Worker
+	out.Workers = in.Workers
 	return nil
 }
 
@@ -522,6 +523,7 @@ func Convert_v1alpha1_Zone_To_alicloud_Zone(in *Zone, out *alicloud.Zone, s conv
 func autoConvert_alicloud_Zone_To_v1alpha1_Zone(in *alicloud.Zone, out *Zone, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Worker = in.Worker
+	out.Workers = in.Workers
 	return nil
 }
 

--- a/controllers/provider-alicloud/pkg/apis/alicloud/validation/infrastructure.go
+++ b/controllers/provider-alicloud/pkg/apis/alicloud/validation/infrastructure.go
@@ -53,10 +53,19 @@ func ValidateInfrastructureConfig(infra *apisalicloud.InfrastructureConfig, node
 	)
 
 	for i, zone := range infra.Networks.Zones {
-		workerPath := networksPath.Child("zones").Index(i).Child("workers")
-		cidrs = append(cidrs, cidrvalidation.NewCIDR(zone.Worker, workerPath))
-		allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(workerPath, zone.Worker)...)
-		workerCIDRs = append(workerCIDRs, cidrvalidation.NewCIDR(zone.Worker, workerPath))
+		if zone.Worker != "" {
+			workerPath := networksPath.Child("zones").Index(i).Child("worker")
+			cidrs = append(cidrs, cidrvalidation.NewCIDR(zone.Worker, workerPath))
+			allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(workerPath, zone.Worker)...)
+			workerCIDRs = append(workerCIDRs, cidrvalidation.NewCIDR(zone.Worker, workerPath))
+		}
+
+		if zone.Workers != "" {
+			workerPath := networksPath.Child("zones").Index(i).Child("workers")
+			cidrs = append(cidrs, cidrvalidation.NewCIDR(zone.Workers, workerPath))
+			allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(workerPath, zone.Workers)...)
+			workerCIDRs = append(workerCIDRs, cidrvalidation.NewCIDR(zone.Workers, workerPath))
+		}
 	}
 
 	allErrs = append(allErrs, cidrvalidation.ValidateCIDRParse(cidrs...)...)

--- a/controllers/provider-alicloud/pkg/apis/alicloud/validation/infrastructure_test.go
+++ b/controllers/provider-alicloud/pkg/apis/alicloud/validation/infrastructure_test.go
@@ -44,8 +44,8 @@ var _ = Describe("InfrastructureConfig validation", func() {
 				},
 				Zones: []apisalicloud.Zone{
 					{
-						Name:   "zone1",
-						Worker: "10.250.3.0/24",
+						Name:    "zone1",
+						Workers: "10.250.3.0/24",
 					},
 				},
 			},
@@ -67,7 +67,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			})
 
 			It("should forbid invalid workers CIDR", func() {
-				infrastructureConfig.Networks.Zones[0].Worker = invalidCIDR
+				infrastructureConfig.Networks.Zones[0].Workers = invalidCIDR
 
 				errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, &pods, &services)
 
@@ -79,7 +79,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			})
 
 			It("should forbid workers CIDR which are not in Nodes CIDR", func() {
-				infrastructureConfig.Networks.Zones[0].Worker = "1.1.1.1/32"
+				infrastructureConfig.Networks.Zones[0].Workers = "1.1.1.1/32"
 
 				errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, &pods, &services)
 
@@ -96,7 +96,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 
 			It("should forbid Node which are not in VPC CIDR", func() {
 				notOverlappingCIDR := "1.1.1.1/32"
-				infrastructureConfig.Networks.Zones[0].Worker = notOverlappingCIDR
+				infrastructureConfig.Networks.Zones[0].Workers = notOverlappingCIDR
 
 				errorList := ValidateInfrastructureConfig(infrastructureConfig, &notOverlappingCIDR, &pods, &services)
 
@@ -143,7 +143,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 					serviceCIDR = "100.64.0.5/13"
 				)
 
-				infrastructureConfig.Networks.Zones[0].Worker = "10.250.3.8/24"
+				infrastructureConfig.Networks.Zones[0].Workers = "10.250.3.8/24"
 				infrastructureConfig.Networks.VPC = apisalicloud.VPC{CIDR: &vpcCIDR}
 
 				errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodeCIDR, &podCIDR, &serviceCIDR)

--- a/controllers/provider-alicloud/pkg/controller/infrastructure/terraform.go
+++ b/controllers/provider-alicloud/pkg/controller/infrastructure/terraform.go
@@ -58,10 +58,15 @@ func (terraformOps) ComputeChartValues(
 ) map[string]interface{} {
 	zones := make([]map[string]interface{}, 0, len(config.Networks.Zones))
 	for _, zone := range config.Networks.Zones {
+		workersCIDR := zone.Workers
+		// Backwards compatibility - remove this code in a future version.
+		if workersCIDR == "" {
+			workersCIDR = zone.Worker
+		}
 		zones = append(zones, map[string]interface{}{
 			"name": zone.Name,
 			"cidr": map[string]interface{}{
-				"worker": string(zone.Worker),
+				"workers": string(workersCIDR),
 			},
 		})
 	}

--- a/controllers/provider-alicloud/pkg/controller/infrastructure/terraform_test.go
+++ b/controllers/provider-alicloud/pkg/controller/infrastructure/terraform_test.go
@@ -119,12 +119,12 @@ var _ = Describe("TerraformChartOps", func() {
 					Networks: v1alpha1.Networks{
 						Zones: []v1alpha1.Zone{
 							{
-								Name:   zone1Name,
-								Worker: zone1Worker,
+								Name:    zone1Name,
+								Workers: zone1Worker,
 							},
 							{
-								Name:   zone2Name,
-								Worker: zone2Worker,
+								Name:    zone2Name,
+								Workers: zone2Worker,
 							},
 						},
 					},
@@ -165,13 +165,13 @@ var _ = Describe("TerraformChartOps", func() {
 					{
 						"name": zone1Name,
 						"cidr": map[string]interface{}{
-							"worker": zone1Worker,
+							"workers": zone1Worker,
 						},
 					},
 					{
 						"name": zone2Name,
 						"cidr": map[string]interface{}{
-							"worker": zone2Worker,
+							"workers": zone2Worker,
 						},
 					},
 				},

--- a/controllers/provider-alicloud/test/tm/generator.go
+++ b/controllers/provider-alicloud/test/tm/generator.go
@@ -17,10 +17,11 @@ package main
 
 import (
 	"flag"
-	"github.com/pkg/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"reflect"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gardener/gardener-extensions/controllers/provider-alicloud/pkg/apis/alicloud/v1alpha1"
 	"github.com/gardener/gardener-extensions/test/tm/generator"
@@ -58,8 +59,8 @@ func main() {
 			},
 			Zones: []v1alpha1.Zone{
 				{
-					Name:   *zone,
-					Worker: *networkWorkerCidr,
+					Name:    *zone,
+					Workers: *networkWorkerCidr,
 				},
 			},
 		},

--- a/controllers/provider-gcp/charts/internal/gcp-infra/templates/main.tf
+++ b/controllers/provider-gcp/charts/internal/gcp-infra/templates/main.tf
@@ -26,7 +26,7 @@ resource "google_compute_network" "network" {
 
 resource "google_compute_subnetwork" "subnetwork-nodes" {
   name          = "{{ required "clusterName is required" .Values.clusterName }}-nodes"
-  ip_cidr_range = "{{ required "networks.worker is required" .Values.networks.worker }}"
+  ip_cidr_range = "{{ required "networks.workers is required" .Values.networks.workers }}"
   network       = "{{ required "vpc.name is required" .Values.vpc.name }}"
   region        = "{{ required "google.region is required" .Values.google.region }}"
 }

--- a/controllers/provider-gcp/charts/internal/gcp-infra/values.yaml
+++ b/controllers/provider-gcp/charts/internal/gcp-infra/values.yaml
@@ -18,8 +18,8 @@ networks:
     minPortsPerVM: 2048
   services: 100.64.0.0/13
   pods: 100.96.0.0/11
-  worker: 10.250.0.0/19
-#  internal: 10.250.112.0/22
+  workers: 10.250.0.0/19
+# internal: 10.250.112.0/22
 
 outputKeys:
   vpcName: vpc_name

--- a/controllers/provider-gcp/docs/usage-as-end-user.md
+++ b/controllers/provider-gcp/docs/usage-as-end-user.md
@@ -36,7 +36,7 @@ networks:
 #   name: my-vpc
 #   cloudRouter:
 #     name: my-cloudrouter
-  worker: 10.250.0.0/16
+  workers: 10.250.0.0/16
 # internal: 10.251.0.0/16
 # cloudNAT:
 #   minPortsPerVM: 2048
@@ -108,7 +108,7 @@ spec:
       apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
       kind: InfrastructureConfig
       networks:
-        worker: 10.250.0.0/16
+        workers: 10.250.0.0/16
     controlPlaneConfig:
       apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
       kind: ControlPlaneConfig

--- a/controllers/provider-gcp/example/30-infrastructure.yaml
+++ b/controllers/provider-gcp/example/30-infrastructure.yaml
@@ -55,7 +55,7 @@ spec:
     #   name: my-vpc
     #   cloudRouter:
     #     name: my-cloudrouter
-      worker: 10.242.0.0/19
+      workers: 10.242.0.0/19
     # internal: 10.243.0.0/19
     # cloudNAT:
     #   minPortsPerVM: 2048

--- a/controllers/provider-gcp/hack/api-reference/api.md
+++ b/controllers/provider-gcp/hack/api-reference/api.md
@@ -498,6 +498,18 @@ string
 </em>
 </td>
 <td>
+<p>Worker is the worker subnet range to create (used for the VMs).
+Deprecated - use <code>workers</code> instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workers</code></br>
+<em>
+string
+</em>
+</td>
+<td>
 <p>Workers is the worker subnet range to create (used for the VMs).</p>
 </td>
 </tr>

--- a/controllers/provider-gcp/pkg/apis/gcp/types_infrastructure.go
+++ b/controllers/provider-gcp/pkg/apis/gcp/types_infrastructure.go
@@ -37,8 +37,11 @@ type NetworkConfig struct {
 	CloudNAT *CloudNAT
 	// Internal is a private subnet (used for internal load balancers).
 	Internal *string
-	// Workers is the worker subnet range to create (used for the VMs).
+	// Worker is the worker subnet range to create (used for the VMs).
+	// Deprecated - use `workers` instead.
 	Worker string
+	// Workers is the worker subnet range to create (used for the VMs).
+	Workers string
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/controllers/provider-gcp/pkg/apis/gcp/v1alpha1/types_infrastructure.go
+++ b/controllers/provider-gcp/pkg/apis/gcp/v1alpha1/types_infrastructure.go
@@ -40,8 +40,11 @@ type NetworkConfig struct {
 	// Internal is a private subnet (used for internal load balancers).
 	// +optional
 	Internal *string `json:"internal,omitempty"`
-	// Workers is the worker subnet range to create (used for the VMs).
+	// Worker is the worker subnet range to create (used for the VMs).
+	// Deprecated - use `workers` instead.
 	Worker string `json:"worker"`
+	// Workers is the worker subnet range to create (used for the VMs).
+	Workers string `json:"workers"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/controllers/provider-gcp/pkg/apis/gcp/v1alpha1/zz_generated.conversion.go
+++ b/controllers/provider-gcp/pkg/apis/gcp/v1alpha1/zz_generated.conversion.go
@@ -413,6 +413,7 @@ func autoConvert_v1alpha1_NetworkConfig_To_gcp_NetworkConfig(in *NetworkConfig, 
 	out.CloudNAT = (*gcp.CloudNAT)(unsafe.Pointer(in.CloudNAT))
 	out.Internal = (*string)(unsafe.Pointer(in.Internal))
 	out.Worker = in.Worker
+	out.Workers = in.Workers
 	return nil
 }
 
@@ -426,6 +427,7 @@ func autoConvert_gcp_NetworkConfig_To_v1alpha1_NetworkConfig(in *gcp.NetworkConf
 	out.CloudNAT = (*CloudNAT)(unsafe.Pointer(in.CloudNAT))
 	out.Internal = (*string)(unsafe.Pointer(in.Internal))
 	out.Worker = in.Worker
+	out.Workers = in.Workers
 	return nil
 }
 

--- a/controllers/provider-gcp/pkg/apis/gcp/validation/infrastructure.go
+++ b/controllers/provider-gcp/pkg/apis/gcp/validation/infrastructure.go
@@ -43,13 +43,21 @@ func ValidateInfrastructureConfig(infra *apisgcp.InfrastructureConfig, nodesCIDR
 	}
 
 	networksPath := field.NewPath("networks")
-	if len(infra.Networks.Worker) == 0 {
-		allErrs = append(allErrs, field.Required(networksPath.Child("worker"), "must specify the network range for the worker network"))
+	if len(infra.Networks.Worker) == 0 && len(infra.Networks.Workers) == 0 {
+		allErrs = append(allErrs, field.Required(networksPath.Child("workers"), "must specify the network range for the worker network"))
 	}
 
-	workerCIDR := cidrvalidation.NewCIDR(infra.Networks.Worker, networksPath.Child("worker"))
-	allErrs = append(allErrs, cidrvalidation.ValidateCIDRParse(workerCIDR)...)
-	allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(networksPath.Child("worker"), infra.Networks.Worker)...)
+	var workerCIDR cidrvalidation.CIDR
+	if infra.Networks.Worker != "" {
+		workerCIDR = cidrvalidation.NewCIDR(infra.Networks.Worker, networksPath.Child("worker"))
+		allErrs = append(allErrs, cidrvalidation.ValidateCIDRParse(workerCIDR)...)
+		allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(networksPath.Child("worker"), infra.Networks.Worker)...)
+	}
+	if infra.Networks.Workers != "" {
+		workerCIDR = cidrvalidation.NewCIDR(infra.Networks.Workers, networksPath.Child("workers"))
+		allErrs = append(allErrs, cidrvalidation.ValidateCIDRParse(workerCIDR)...)
+		allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(networksPath.Child("workers"), infra.Networks.Workers)...)
+	}
 
 	if infra.Networks.Internal != nil {
 		internalCIDR := cidrvalidation.NewCIDR(*infra.Networks.Internal, networksPath.Child("internal"))

--- a/controllers/provider-gcp/pkg/apis/gcp/validation/infrastructure_test.go
+++ b/controllers/provider-gcp/pkg/apis/gcp/validation/infrastructure_test.go
@@ -43,7 +43,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 					Name: "hugo",
 				},
 				Internal: &internal,
-				Worker:   "10.250.0.0/16",
+				Workers:  "10.250.0.0/16",
 			},
 		}
 	})
@@ -51,13 +51,13 @@ var _ = Describe("InfrastructureConfig validation", func() {
 	Describe("#ValidateInfrastructureConfig", func() {
 		Context("CIDR", func() {
 			It("should forbid invalid worker CIDRs", func() {
-				infrastructureConfig.Networks.Worker = invalidCIDR
+				infrastructureConfig.Networks.Workers = invalidCIDR
 
 				errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, &pods, &services)
 
 				Expect(errorList).To(ConsistOfFields(Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
-					"Field":  Equal("networks.worker"),
+					"Field":  Equal("networks.workers"),
 					"Detail": Equal("invalid CIDR address: invalid-cidr"),
 				}))
 			})
@@ -76,13 +76,13 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			})
 
 			It("should forbid workers CIDR which are not in Nodes CIDR", func() {
-				infrastructureConfig.Networks.Worker = "1.1.1.1/32"
+				infrastructureConfig.Networks.Workers = "1.1.1.1/32"
 
 				errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, &pods, &services)
 
 				Expect(errorList).To(ConsistOfFields(Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
-					"Field":  Equal("networks.worker"),
+					"Field":  Equal("networks.workers"),
 					"Detail": Equal(`must be a subset of "" ("10.250.0.0/16")`),
 				}))
 			})
@@ -90,7 +90,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			It("should forbid Internal CIDR to overlap with Node - and Worker CIDR", func() {
 				overlappingCIDR := "10.250.1.0/30"
 				infrastructureConfig.Networks.Internal = &overlappingCIDR
-				infrastructureConfig.Networks.Worker = overlappingCIDR
+				infrastructureConfig.Networks.Workers = overlappingCIDR
 
 				errorList := ValidateInfrastructureConfig(infrastructureConfig, &overlappingCIDR, &pods, &services)
 
@@ -101,7 +101,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 				}, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("networks.internal"),
-					"Detail": Equal(`must not be a subset of "networks.worker" ("10.250.1.0/30")`),
+					"Detail": Equal(`must not be a subset of "networks.workers" ("10.250.1.0/30")`),
 				}))
 			})
 
@@ -111,7 +111,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 				serviceCIDR := "100.64.0.5/13"
 				internal := "10.10.0.4/24"
 				infrastructureConfig.Networks.Internal = &internal
-				infrastructureConfig.Networks.Worker = "10.250.3.8/24"
+				infrastructureConfig.Networks.Workers = "10.250.3.8/24"
 
 				errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodeCIDR, &podCIDR, &serviceCIDR)
 
@@ -122,7 +122,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 					"Detail": Equal("must be valid canonical CIDR"),
 				}, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
-					"Field":  Equal("networks.worker"),
+					"Field":  Equal("networks.workers"),
 					"Detail": Equal("must be valid canonical CIDR"),
 				}))
 			})

--- a/controllers/provider-gcp/pkg/internal/infrastructure/terraform.go
+++ b/controllers/provider-gcp/pkg/internal/infrastructure/terraform.go
@@ -99,6 +99,12 @@ func ComputeTerraformerChartValues(
 		}
 	}
 
+	workersCIDR := config.Networks.Workers
+	// Backwards compatibility - remove this code in a future version.
+	if workersCIDR == "" {
+		workersCIDR = config.Networks.Worker
+	}
+
 	return map[string]interface{}{
 		"google": map[string]interface{}{
 			"region":  infra.Spec.Region,
@@ -113,7 +119,7 @@ func ComputeTerraformerChartValues(
 		"networks": map[string]interface{}{
 			"pods":     extensionscontroller.GetPodNetwork(cluster),
 			"services": extensionscontroller.GetServiceNetwork(cluster),
-			"worker":   config.Networks.Worker,
+			"workers":  workersCIDR,
 			"internal": config.Networks.Internal,
 			"cloudNAT": map[string]interface{}{
 				"minPortsPerVM": minPortsPerVM,

--- a/controllers/provider-gcp/pkg/internal/infrastructure/terraform_test.go
+++ b/controllers/provider-gcp/pkg/internal/infrastructure/terraform_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Terraform", func() {
 					},
 				},
 				Internal: &internalCIDR,
-				Worker:   "10.1.0.0/16",
+				Workers:  "10.1.0.0/16",
 			},
 		}
 
@@ -79,7 +79,7 @@ var _ = Describe("Terraform", func() {
 					},
 				},
 				Internal: &internalCIDR,
-				Worker:   "10.1.0.0/16",
+				Workers:  "10.1.0.0/16",
 			},
 		}
 
@@ -127,7 +127,7 @@ var _ = Describe("Terraform", func() {
 							Name:        "vpc",
 							CloudRouter: &api.CloudRouter{Name: cloudRouterName},
 						},
-						Worker: "10.1.0.0/16",
+						Workers: "10.1.0.0/16",
 					},
 				}
 
@@ -174,7 +174,7 @@ var _ = Describe("Terraform", func() {
 						VPC: &api.VPC{
 							Name: "vpc",
 						},
-						Worker: "10.1.0.0/16",
+						Workers: "10.1.0.0/16",
 					},
 				}
 
@@ -232,7 +232,7 @@ var _ = Describe("Terraform", func() {
 				"networks": map[string]interface{}{
 					"pods":     podsCIDR,
 					"services": servicesCIDR,
-					"worker":   config.Networks.Worker,
+					"workers":  config.Networks.Workers,
 					"internal": config.Networks.Internal,
 					"cloudNAT": map[string]interface{}{
 						"minPortsPerVM": minPortsPerVM,
@@ -269,7 +269,7 @@ var _ = Describe("Terraform", func() {
 				"networks": map[string]interface{}{
 					"pods":     podsCIDR,
 					"services": servicesCIDR,
-					"worker":   config.Networks.Worker,
+					"workers":  config.Networks.Workers,
 					"internal": config.Networks.Internal,
 					"cloudNAT": map[string]interface{}{
 						"minPortsPerVM": minPortsPerVM,

--- a/controllers/provider-gcp/test/tm/generator.go
+++ b/controllers/provider-gcp/test/tm/generator.go
@@ -17,10 +17,11 @@ package main
 
 import (
 	"flag"
-	"github.com/pkg/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"reflect"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gardener/gardener-extensions/controllers/provider-gcp/pkg/apis/gcp/v1alpha1"
 	"github.com/gardener/gardener-extensions/test/tm/generator"
@@ -52,7 +53,7 @@ func main() {
 			Kind:       reflect.TypeOf(v1alpha1.InfrastructureConfig{}).Name(),
 		},
 		Networks: v1alpha1.NetworkConfig{
-			Worker: *networkWorkerCidr,
+			Workers: *networkWorkerCidr,
 		},
 	}
 

--- a/controllers/provider-openstack/charts/internal/openstack-infra/templates/main.tf
+++ b/controllers/provider-openstack/charts/internal/openstack-infra/templates/main.tf
@@ -31,7 +31,7 @@ resource "openstack_networking_network_v2" "cluster" {
 
 resource "openstack_networking_subnet_v2" "cluster" {
   name            = "{{ required "clusterName is required" .Values.clusterName }}"
-  cidr            = "{{ required "networks.worker is required" .Values.networks.worker }}"
+  cidr            = "{{ required "networks.workers is required" .Values.networks.workers }}"
   network_id      = "${openstack_networking_network_v2.cluster.id}"
   ip_version      = 4
   {{- if .Values.dnsServers }}

--- a/controllers/provider-openstack/charts/internal/openstack-infra/values.yaml
+++ b/controllers/provider-openstack/charts/internal/openstack-infra/values.yaml
@@ -19,7 +19,7 @@ dnsServers:
 clusterName: test-namespace
 
 networks:
-  worker: 10.250.0.0/19
+  workers: 10.250.0.0/19
 
 outputKeys:
   routerID: router_id

--- a/controllers/provider-openstack/docs/usage-as-end-user.md
+++ b/controllers/provider-openstack/docs/usage-as-end-user.md
@@ -38,7 +38,7 @@ floatingPoolName: MY-FLOATING-POOL
 networks:
 # router:
 #   id: 1234
-  worker: 10.250.0.0/19
+  workers: 10.250.0.0/19
 ```
 
 The `floatingPoolName` is the name of the floating pool you want to use for your shoot.
@@ -104,7 +104,7 @@ spec:
       kind: InfrastructureConfig
       floatingPoolName: MY-FLOATING-POOL
       networks:
-        worker: 10.250.0.0/19
+        workers: 10.250.0.0/19
     controlPlaneConfig:
       apiVersion: openstack.provider.extensions.gardener.cloud/v1alpha1
       kind: ControlPlaneConfig

--- a/controllers/provider-openstack/example/30-infrastructure.yaml
+++ b/controllers/provider-openstack/example/30-infrastructure.yaml
@@ -62,5 +62,5 @@ spec:
     networks:
     # router:
     #   id: 1234
-      worker: 10.250.0.0/19
+      workers: 10.250.0.0/19
   sshPublicKey: AAAA

--- a/controllers/provider-openstack/hack/api-reference/api.md
+++ b/controllers/provider-openstack/hack/api-reference/api.md
@@ -975,7 +975,19 @@ string
 </em>
 </td>
 <td>
-<p>Worker is a CIDRs of a worker subnet (private) to create (used for the VMs).</p>
+<p>Worker is a CIDRs of a worker subnet (private) to create (used for the VMs).
+Deprecated - use <code>workers</code> instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workers</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Workers is a CIDRs of a worker subnet (private) to create (used for the VMs).</p>
 </td>
 </tr>
 </tbody>

--- a/controllers/provider-openstack/pkg/apis/openstack/types_infrastructure.go
+++ b/controllers/provider-openstack/pkg/apis/openstack/types_infrastructure.go
@@ -34,7 +34,10 @@ type Networks struct {
 	// Router indicates whether to use an existing router or create a new one.
 	Router *Router
 	// Worker is a CIDRs of a worker subnet (private) to create (used for the VMs).
+	// Deprecated - use `workers` instead.
 	Worker string
+	// Workers is a CIDRs of a worker subnet (private) to create (used for the VMs).
+	Workers string
 }
 
 // Router indicates whether to use an existing router or create a new one.

--- a/controllers/provider-openstack/pkg/apis/openstack/v1alpha1/types_infrastructure.go
+++ b/controllers/provider-openstack/pkg/apis/openstack/v1alpha1/types_infrastructure.go
@@ -36,7 +36,10 @@ type Networks struct {
 	// +optional
 	Router *Router `json:"router,omitempty"`
 	// Worker is a CIDRs of a worker subnet (private) to create (used for the VMs).
+	// Deprecated - use `workers` instead.
 	Worker string `json:"worker"`
+	// Workers is a CIDRs of a worker subnet (private) to create (used for the VMs).
+	Workers string `json:"workers"`
 }
 
 // Router indicates whether to use an existing router or create a new one.

--- a/controllers/provider-openstack/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
+++ b/controllers/provider-openstack/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
@@ -655,6 +655,7 @@ func Convert_openstack_NetworkStatus_To_v1alpha1_NetworkStatus(in *openstack.Net
 func autoConvert_v1alpha1_Networks_To_openstack_Networks(in *Networks, out *openstack.Networks, s conversion.Scope) error {
 	out.Router = (*openstack.Router)(unsafe.Pointer(in.Router))
 	out.Worker = in.Worker
+	out.Workers = in.Workers
 	return nil
 }
 
@@ -666,6 +667,7 @@ func Convert_v1alpha1_Networks_To_openstack_Networks(in *Networks, out *openstac
 func autoConvert_openstack_Networks_To_v1alpha1_Networks(in *openstack.Networks, out *Networks, s conversion.Scope) error {
 	out.Router = (*Router)(unsafe.Pointer(in.Router))
 	out.Worker = in.Worker
+	out.Workers = in.Workers
 	return nil
 }
 

--- a/controllers/provider-openstack/pkg/apis/openstack/validation/infrastructure.go
+++ b/controllers/provider-openstack/pkg/apis/openstack/validation/infrastructure.go
@@ -38,13 +38,21 @@ func ValidateInfrastructureConfig(infra *api.InfrastructureConfig, constraints a
 	}
 
 	networksPath := field.NewPath("networks")
-	if len(infra.Networks.Worker) == 0 {
-		allErrs = append(allErrs, field.Required(networksPath.Child("worker"), "must specify the network range for the worker network"))
+	if len(infra.Networks.Worker) == 0 && len(infra.Networks.Workers) == 0 {
+		allErrs = append(allErrs, field.Required(networksPath.Child("workers"), "must specify the network range for the worker network"))
 	}
 
-	workerCIDR := cidrvalidation.NewCIDR(infra.Networks.Worker, networksPath.Child("worker"))
-	allErrs = append(allErrs, cidrvalidation.ValidateCIDRParse(workerCIDR)...)
-	allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(networksPath.Child("worker"), infra.Networks.Worker)...)
+	var workerCIDR cidrvalidation.CIDR
+	if infra.Networks.Worker != "" {
+		workerCIDR = cidrvalidation.NewCIDR(infra.Networks.Worker, networksPath.Child("worker"))
+		allErrs = append(allErrs, cidrvalidation.ValidateCIDRParse(workerCIDR)...)
+		allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(networksPath.Child("worker"), infra.Networks.Worker)...)
+	}
+	if infra.Networks.Workers != "" {
+		workerCIDR = cidrvalidation.NewCIDR(infra.Networks.Workers, networksPath.Child("workers"))
+		allErrs = append(allErrs, cidrvalidation.ValidateCIDRParse(workerCIDR)...)
+		allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(networksPath.Child("workers"), infra.Networks.Workers)...)
+	}
 
 	if nodes != nil {
 		allErrs = append(allErrs, nodes.ValidateSubset(workerCIDR)...)

--- a/controllers/provider-openstack/pkg/apis/openstack/validation/infrastructure_test.go
+++ b/controllers/provider-openstack/pkg/apis/openstack/validation/infrastructure_test.go
@@ -49,7 +49,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 				Router: &api.Router{
 					ID: "hugo",
 				},
-				Worker: "10.250.0.0/16",
+				Workers: "10.250.0.0/16",
 			},
 		}
 	})
@@ -138,25 +138,25 @@ var _ = Describe("InfrastructureConfig validation", func() {
 
 		Context("CIDR", func() {
 			It("should forbid invalid workers CIDR", func() {
-				infrastructureConfig.Networks.Worker = invalidCIDR
+				infrastructureConfig.Networks.Workers = invalidCIDR
 
 				errorList := ValidateInfrastructureConfig(infrastructureConfig, constraints, region, &nodes)
 
 				Expect(errorList).To(ConsistOfFields(Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
-					"Field":  Equal("networks.worker"),
+					"Field":  Equal("networks.workers"),
 					"Detail": Equal("invalid CIDR address: invalid-cidr"),
 				}))
 			})
 
 			It("should forbid workers CIDR which are not in Nodes CIDR", func() {
-				infrastructureConfig.Networks.Worker = "1.1.1.1/32"
+				infrastructureConfig.Networks.Workers = "1.1.1.1/32"
 
 				errorList := ValidateInfrastructureConfig(infrastructureConfig, constraints, region, &nodes)
 
 				Expect(errorList).To(ConsistOfFields(Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
-					"Field":  Equal("networks.worker"),
+					"Field":  Equal("networks.workers"),
 					"Detail": Equal(`must be a subset of "" ("10.250.0.0/16")`),
 				}))
 			})
@@ -164,14 +164,14 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			It("should forbid non canonical CIDRs", func() {
 				nodeCIDR := "10.250.0.3/16"
 
-				infrastructureConfig.Networks.Worker = "10.250.3.8/24"
+				infrastructureConfig.Networks.Workers = "10.250.3.8/24"
 
 				errorList := ValidateInfrastructureConfig(infrastructureConfig, constraints, region, &nodeCIDR)
 				Expect(errorList).To(HaveLen(1))
 
 				Expect(errorList).To(ConsistOfFields(Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
-					"Field":  Equal("networks.worker"),
+					"Field":  Equal("networks.workers"),
 					"Detail": Equal("must be valid canonical CIDR"),
 				}))
 			})

--- a/controllers/provider-openstack/pkg/internal/infrastructure/terraform.go
+++ b/controllers/provider-openstack/pkg/internal/infrastructure/terraform.go
@@ -89,6 +89,12 @@ func ComputeTerraformerChartValues(
 		return nil, err
 	}
 
+	workersCIDR := config.Networks.Workers
+	// Backwards compatibility - remove this code in a future version.
+	if workersCIDR == "" {
+		workersCIDR = config.Networks.Worker
+	}
+
 	return map[string]interface{}{
 		"openstack": map[string]interface{}{
 			"authURL":          keyStoneURL,
@@ -107,7 +113,7 @@ func ComputeTerraformerChartValues(
 		},
 		"clusterName": infra.Namespace,
 		"networks": map[string]interface{}{
-			"worker": config.Networks.Worker,
+			"workers": workersCIDR,
 		},
 		"outputKeys": map[string]interface{}{
 			"routerID":          TerraformOutputKeyRouterID,

--- a/controllers/provider-openstack/pkg/internal/infrastructure/terraform_test.go
+++ b/controllers/provider-openstack/pkg/internal/infrastructure/terraform_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Terraform", func() {
 				Router: &api.Router{
 					ID: "1",
 				},
-				Worker: "10.1.0.0/16",
+				Workers: "10.1.0.0/16",
 			},
 		}
 
@@ -130,7 +130,7 @@ var _ = Describe("Terraform", func() {
 				},
 				"clusterName": infra.Namespace,
 				"networks": map[string]interface{}{
-					"worker": config.Networks.Worker,
+					"workers": config.Networks.Workers,
 				},
 				"outputKeys": map[string]interface{}{
 					"routerID":          TerraformOutputKeyRouterID,
@@ -168,7 +168,7 @@ var _ = Describe("Terraform", func() {
 				},
 				"clusterName": infra.Namespace,
 				"networks": map[string]interface{}{
-					"worker": config.Networks.Worker,
+					"workers": config.Networks.Workers,
 				},
 				"outputKeys": map[string]interface{}{
 					"routerID":          TerraformOutputKeyRouterID,

--- a/controllers/provider-openstack/test/tm/generator.go
+++ b/controllers/provider-openstack/test/tm/generator.go
@@ -17,10 +17,11 @@ package main
 
 import (
 	"flag"
-	"github.com/pkg/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"reflect"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gardener/gardener-extensions/controllers/provider-openstack/pkg/apis/openstack/v1alpha1"
 	"github.com/gardener/gardener-extensions/test/tm/generator"
@@ -55,7 +56,7 @@ func main() {
 		},
 		FloatingPoolName: *floatingPoolName,
 		Networks: v1alpha1.Networks{
-			Worker: *networkWorkerCidr,
+			Workers: *networkWorkerCidr,
 		},
 	}
 

--- a/go.sum
+++ b/go.sum
@@ -192,6 +192,7 @@ github.com/gardener/gardener v0.0.0-20191004085047-5707d498b40c/go.mod h1:zvajWs
 github.com/gardener/gardener v0.0.0-20191028054636-32cb0027c126/go.mod h1:Ow7vOXQYgQeHTRFn2HdbEIptelrSB5NLmVFIt2rgNeY=
 github.com/gardener/gardener v0.33.1-0.20191230124716-a9eee9416e16 h1:jaa6GiBdHbJPmBK2WX8sMZ2XQauVko0vwX1PZ/DPYOE=
 github.com/gardener/gardener v0.33.1-0.20191230124716-a9eee9416e16/go.mod h1:OsrX8Fhrn6qYaHaFJhvZYsSQVpo6/pfX+5WpzWzniHY=
+github.com/gardener/gardener v0.33.6 h1:pb7T/zmMP4ZZqlvfzfvGQCweHwcLaMZv6S8WPJfuCpc=
 github.com/gardener/gardener-extensions v0.0.0-20190725050243-a80ef643c64b/go.mod h1:uXjtl3KeVdQXuGIP26+84wJY1Kwru67l0FXm7A5DiME=
 github.com/gardener/gardener-extensions v0.0.0-20190820050625-a15de8a82f6b/go.mod h1:q69+1cUGSfQ8gSMWzU7GFz/R8K8MpOLQBT2wJJcCjEA=
 github.com/gardener/gardener-extensions v0.0.0-20190906160200-5c329d46ae81/go.mod h1:OBUAbab8OMm8pvzr/1/cdwIQnQYuMoGDTNR2c+i9nYo=


### PR DESCRIPTION
**What this PR does / why we need it**:
* Rename `networks.zones[].worker` to `workers` for Alicloud's `InfrastructureConfig`
* Rename `networks.worker` to `workers` for GCP `InfrastructureConfig`
* Rename `networks.worker` to `workers` for OpenStack `InfrastructureConfig`

**Which issue(s) this PR fixes**:
Fixes #412

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action user
The `networks.zones[].worker` field in the `alicloud.provider.extensions.gardener.cloud/v1alpha1.InfrastructureConfig` resource is deprecated in favour of the new `networks.zones[].workers` field. Please switch to the new field as the old one will be removed in a future version. Also, please note that this field is exclusively usable with Gardener's `core.gardener.cloud` API group.
```

```action user
The `networks.worker` field in the `gcp.provider.extensions.gardener.cloud/v1alpha1.InfrastructureConfig` resource is deprecated in favour of the new `networks.workers` field. Please switch to the new field as the old one will be removed in a future version. Also, please note that this field is exclusively usable with Gardener's `core.gardener.cloud` API group.
```

```action user
The `networks.worker` field in the `openstack.provider.extensions.gardener.cloud/v1alpha1.InfrastructureConfig` resource is deprecated in favour of the new `networks.workers` field. Please switch to the new field as the old one will be removed in a future version. Also, please note that this field is exclusively usable with Gardener's `core.gardener.cloud` API group.
```