### PR TITLE
[WIP]add worker state retention

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -10,7 +10,6 @@ contrib.go.opencensus.io/exporter/ocagent v0.4.10/go.mod h1:ueLzZcP7LPhPulEBukGn
 contrib.go.opencensus.io/exporter/ocagent v0.4.12/go.mod h1:450APlNTSR6FrvC3CTRqYosuDstRB9un7SOx2k/9ckA=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 git.apache.org/thrift.git v0.12.0/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
-github.com/Azure/azure-pipeline-go v0.2.1 h1:OLBdZJ3yvOn2MezlWvbrBMTEUQC72zAftRZOMdj5HYo=
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-pipeline-go v0.2.2 h1:6oiIS9yaG6XCCzhgAgKFfIWyo4LLCiDhZot6ltoThhY=
 github.com/Azure/azure-pipeline-go v0.2.2/go.mod h1:4rQ/NZncSvGqNkkOsNpOU1tgoNuIlp9AfUH5G1tvCHc=
@@ -276,14 +275,12 @@ github.com/gobuffalo/genny v0.0.0-20190403191548-3ca520ef0d9e/go.mod h1:80lIj3kV
 github.com/gobuffalo/gitgen v0.0.0-20190315122116-cc086187d211/go.mod h1:vEHJk/E9DmhejeLeNt7UVvlSGv3ziL+djtTr3yyzcOw=
 github.com/gobuffalo/gogen v0.0.0-20190315121717-8f38393713f5 h1:f3Fpd5AqsFuTHUEhUeEMIFJkX8FpVnzdW+GpYxIyXkA=
 github.com/gobuffalo/gogen v0.0.0-20190315121717-8f38393713f5/go.mod h1:V9QVDIxsgKNZs6L2IYiGR8datgMhB577vzTDqypH360=
-github.com/gobuffalo/logger v0.0.0-20190315122211-86e12af44bc2 h1:8thhT+kUJMTMy3HlX4+y9Da+BNJck+p109tqqKp7WDs=
 github.com/gobuffalo/logger v0.0.0-20190315122211-86e12af44bc2/go.mod h1:QdxcLw541hSGtBnhUc4gaNIXRjiDppFGaDqzbrBd3v8=
 github.com/gobuffalo/logger v1.0.1 h1:ZEgyRGgAm4ZAhAO45YXMs5Fp+bzGLESFewzAVBMKuTg=
 github.com/gobuffalo/logger v1.0.1/go.mod h1:2zbswyIUa45I+c+FLXuWl9zSWEiVuthsk8ze5s8JvPs=
 github.com/gobuffalo/mapi v1.0.1/go.mod h1:4VAGh89y6rVOvm5A8fKFxYG+wIW6LO1FMTG9hnKStFc=
 github.com/gobuffalo/mapi v1.0.2 h1:fq9WcL1BYrm36SzK6+aAnZ8hcp+SrmnDyAxhNx8dvJk=
 github.com/gobuffalo/mapi v1.0.2/go.mod h1:4VAGh89y6rVOvm5A8fKFxYG+wIW6LO1FMTG9hnKStFc=
-github.com/gobuffalo/packd v0.0.0-20190315124812-a385830c7fc0 h1:P6naWPiHm/7R3eYx/ub3VhaW9G+1xAMJ6vzACePaGPI=
 github.com/gobuffalo/packd v0.0.0-20190315124812-a385830c7fc0/go.mod h1:M2Juc+hhDXf/PnmBANFCqx4DM3wRbgDvnVWeG2RIxq4=
 github.com/gobuffalo/packd v0.3.0 h1:eMwymTkA1uXsqxS0Tpoop3Lc0u3kTfiMBE6nKtQU4g4=
 github.com/gobuffalo/packd v0.3.0/go.mod h1:zC7QkmNkYVGKPw4tHpBQ+ml7W/3tIebgeo1b36chA3Q=
@@ -292,7 +289,6 @@ github.com/gobuffalo/packr v1.25.0/go.mod h1:NqsGg8CSB2ZD+6RBIRs18G7aZqdYDlYNNvs
 github.com/gobuffalo/packr/v2 v2.0.9/go.mod h1:emmyGweYTm6Kdper+iywB6YK5YzuKchGtJQZ0Odn4pQ=
 github.com/gobuffalo/packr/v2 v2.1.0 h1:nWGTgGtZrR4yBQvmAKF4AthraObjRMzx6lJa9e+JbLQ=
 github.com/gobuffalo/packr/v2 v2.1.0/go.mod h1:n90ZuXIc2KN2vFAOQascnPItp9A2g9QYSvYvS3AjQEM=
-github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754 h1:tpom+2CJmpzAWj5/VEHync2rJGi+epHNIeRSWjzGA+4=
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
@@ -396,7 +392,6 @@ github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHh
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru v0.0.0-20180201235237-0fb14efe8c47/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3 h1:YPkqC67at8FYaadspW/6uE0COsBxS2656RLEr8Bppgk=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
@@ -433,7 +428,6 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/karrick/godirwalk v1.8.0 h1:ycpSqVon/QJJoaT1t8sae0tp1Stg21j+dyuS7OoagcA=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.12 h1:BqUm+LuJcXjGv1d2mj3gBiQyrQ57a0rYoAmhvJQ7RDU=
 github.com/karrick/godirwalk v1.10.12/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
@@ -442,7 +436,6 @@ github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQL
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
-github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -464,7 +457,6 @@ github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2 h1:JgVTCPf0uBVcUSW
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
 github.com/markbates/safe v1.0.1 h1:yjZkbvRM6IzKj9tlu/zMJLS0n/V351OZWRnF3QfaUxI=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
-github.com/mattn/go-ieproxy v0.0.0-20190610004146-91bb50d98149 h1:HfxbT6/JcvIljmERptWhwa8XzP7H3T+Z2N26gTsaDaA=
 github.com/mattn/go-ieproxy v0.0.0-20190610004146-91bb50d98149/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
 github.com/mattn/go-ieproxy v0.0.0-20190702010315-6dee0af9227d/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
 github.com/mattn/go-ieproxy v0.0.0-20190805055040-f9202b1cfdeb h1:hXqqXzQtJbENrsb+rsIqkVqcg4FUJL0SQFGw08Dgivw=
@@ -602,7 +594,6 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -822,7 +813,6 @@ google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
-google.golang.org/genproto v0.0.0-20190716160619-c506a9f90610 h1:Ygq9/SRJX9+dU0WCIICM8RkWvDw03lvB77hrhJnpxfU=
 google.golang.org/genproto v0.0.0-20190716160619-c506a9f90610/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2ElGhA4+qG2zF97qiUzTM+rQ0klBOcE=
@@ -854,7 +844,6 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/ini.v1 v1.42.0 h1:7N3gPTt50s8GuLortA00n8AqRTk75qOP98+mTPpgzRk=
 gopkg.in/ini.v1 v1.42.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.44.0 h1:YRJzTUp0kSYWUVFF5XAbDFfyiqwsl0Vb9R8TVP5eRi0=
 gopkg.in/ini.v1 v1.44.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
@@ -870,7 +859,6 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.0.0/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
@@ -928,9 +916,14 @@ k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/kube-aggregator v0.0.0-20190918161219-8c8f079fddc3 h1:Qscw8cxevIcxULoLXwNgcIPbGCGCaGHlh5HpTE8N8C8=
 k8s.io/kube-aggregator v0.0.0-20190918161219-8c8f079fddc3/go.mod h1:NJisPUqwlg1A99RhO1BTnNtwC4pKUyXJ2f3Xc4PxKQg=
 k8s.io/kube-openapi v0.0.0-20180216212618-50ae88d24ede/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
+k8s.io/kube-openapi v0.0.0-20180216212618-50ae88d24ede/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
+k8s.io/kube-openapi v0.0.0-20180731170545-e3762e86a74c/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/kube-openapi v0.0.0-20180731170545-e3762e86a74c/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/kube-openapi v0.0.0-20190320154901-5e45bb682580/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
+k8s.io/kube-openapi v0.0.0-20190320154901-5e45bb682580/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/kube-openapi v0.0.0-20190722073852-5e22f3d471e6 h1:s9IxTKe9GwDH0S/WaX62nFYr0or32DsTWex9AileL7U=
+k8s.io/kube-openapi v0.0.0-20190722073852-5e22f3d471e6 h1:s9IxTKe9GwDH0S/WaX62nFYr0or32DsTWex9AileL7U=
+k8s.io/kube-openapi v0.0.0-20190722073852-5e22f3d471e6/go.mod h1:RZvgC8MSN6DjiMV6oIfEE9pDL9CYXokkfaCKZeHm3nc=
 k8s.io/kube-openapi v0.0.0-20190722073852-5e22f3d471e6/go.mod h1:RZvgC8MSN6DjiMV6oIfEE9pDL9CYXokkfaCKZeHm3nc=
 k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf h1:EYm5AW/UUDbnmnI+gK0TJDVK9qPLhM+sRHYanNKw0EQ=
 k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=

--- a/pkg/controller/worker/actuator.go
+++ b/pkg/controller/worker/actuator.go
@@ -29,3 +29,9 @@ type Actuator interface {
 	// Delete deletes the Worker.
 	Delete(context.Context, *extensionsv1alpha1.Worker, *extensionscontroller.Cluster) error
 }
+
+// StateActuator acts upon Worker's State resources.
+type StateActuator interface {
+	// Reconcile reconciles the Worker State.
+	Reconcile(context.Context, *extensionsv1alpha1.Worker) error
+}

--- a/pkg/controller/worker/controller.go
+++ b/pkg/controller/worker/controller.go
@@ -17,10 +17,12 @@ package worker
 import (
 	extensionshandler "github.com/gardener/gardener-extensions/pkg/handler"
 	extensionspredicate "github.com/gardener/gardener-extensions/pkg/predicate"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -31,6 +33,8 @@ const (
 	FinalizerName = "extensions.gardener.cloud/worker"
 	// ControllerName is the name of the controller.
 	ControllerName = "worker_controller"
+	// StateUpdatingControllerName is the name of the controller responsible for updating the worker's state.
+	StateUpdatingControllerName = "worker_state_controller"
 )
 
 // AddArgs are arguments for adding an worker controller to a manager.
@@ -75,7 +79,11 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 func Add(mgr manager.Manager, args AddArgs) error {
 	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator)
 	predicates := extensionspredicate.AddTypePredicate(args.Type, args.Predicates)
-	return add(mgr, args.ControllerOptions, predicates)
+	if err := add(mgr, args.ControllerOptions, predicates); err != nil {
+		return err
+	}
+
+	return addStateUpdatingController(mgr, args.ControllerOptions)
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -92,4 +100,35 @@ func add(mgr manager.Manager, options controller.Options, predicates []predicate
 	return ctrl.Watch(&source.Kind{Type: &extensionsv1alpha1.Cluster{}}, &extensionshandler.EnqueueRequestsFromMapFunc{
 		ToRequests: extensionshandler.SimpleMapper(ClusterToWorkerMapper(predicates), extensionshandler.UpdateWithNew),
 	})
+}
+
+func addStateUpdatingController(mgr manager.Manager, options controller.Options) error {
+	stateActuator := NewStateActuator(log.Log.WithName("worker-state-actuator"))
+	stateReconciler := NewStateReconciler(mgr, stateActuator)
+	addStateUpdatingControllerOptions := controller.Options{
+		MaxConcurrentReconciles: options.MaxConcurrentReconciles,
+		Reconciler:              stateReconciler,
+	}
+	predicates := []predicate.Predicate{
+		extensionspredicate.Or(
+			extensionspredicate.IsDeleting(),
+			extensionspredicate.MachineStatusHasChanged(),
+			predicate.GenerationChangedPredicate{},
+		),
+	}
+
+	ctrl, err := controller.New(StateUpdatingControllerName, mgr, addStateUpdatingControllerOptions)
+	if err != nil {
+		return err
+	}
+
+	if err := ctrl.Watch(&source.Kind{Type: &machinev1alpha1.MachineSet{}}, &extensionshandler.EnqueueRequestsFromMapFunc{
+		ToRequests: extensionshandler.SimpleMapper(MachineSetToWorkerMapper(nil), extensionshandler.UpdateWithNew),
+	}, predicates...); err != nil {
+		return err
+	}
+
+	return ctrl.Watch(&source.Kind{Type: &machinev1alpha1.Machine{}}, &extensionshandler.EnqueueRequestsFromMapFunc{
+		ToRequests: extensionshandler.SimpleMapper(MachineToWorkerMapper(nil), extensionshandler.UpdateWithNew),
+	}, predicates...)
 }

--- a/pkg/controller/worker/genericactuator/actuator.go
+++ b/pkg/controller/worker/genericactuator/actuator.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -52,6 +53,7 @@ type genericActuator struct {
 
 	client               client.Client
 	clientset            kubernetes.Interface
+	decoder              runtime.Decoder
 	gardenerClientset    gardenerkubernetes.Interface
 	chartApplier         gardenerkubernetes.ChartApplier
 	chartRendererFactory extensionscontroller.ChartRendererFactory
@@ -79,6 +81,11 @@ func (a *genericActuator) InjectFunc(f inject.Func) error {
 
 func (a *genericActuator) InjectClient(client client.Client) error {
 	a.client = client
+	return nil
+}
+
+func (a *genericActuator) InjectScheme(scheme *runtime.Scheme) error {
+	a.decoder = serializer.NewCodecFactory(scheme).UniversalDecoder()
 	return nil
 }
 

--- a/pkg/controller/worker/genericactuator/actuator_resore.go
+++ b/pkg/controller/worker/genericactuator/actuator_resore.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package genericactuator
+
+import (
+	"context"
+	"encoding/json"
+
+	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
+	workercontroller "github.com/gardener/gardener-extensions/pkg/controller/worker"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (a *genericActuator) restore(ctx context.Context, worker *extensionsv1alpha1.Worker, existingMachineDeployments *machinev1alpha1.MachineDeploymentList, wantedMachineDeployments workercontroller.MachineDeployments) error {
+
+	if worker.Annotations[v1beta1constants.GardenerOperation] != v1beta1constants.GardenerOperationRestore {
+		return nil
+	}
+
+	// remove operation annotation 'restore'
+	withOpAnnotationRestore := worker.DeepCopyObject()
+	delete(worker.Annotations, v1beta1constants.GardenerOperation)
+	if err := a.client.Patch(ctx, worker, client.MergeFrom(withOpAnnotationRestore)); err != nil {
+		return err
+	}
+
+	// Parse the worker state to a separete machineDeployment states and attach them to
+	// the corresponding machineDeployments which are to be deployed later
+	if err := a.addStateToMachineDeployment(ctx, worker, wantedMachineDeployments); err != nil {
+		return err
+	}
+
+	// Do the actual restoration
+	return a.deployMachineSetsAndMachines(ctx, worker, existingMachineDeployments, wantedMachineDeployments)
+}
+
+func (a *genericActuator) addStateToMachineDeployment(ctx context.Context, worker *extensionsv1alpha1.Worker, wantedMachineDeployments workercontroller.MachineDeployments) error {
+	// Make a deep copy to ensure that no one will change the state during the restoration
+	workerCopy := worker.DeepCopy()
+
+	if workerCopy.Status.State == nil || len(workerCopy.Status.State.Raw) <= 0 {
+		return nil
+	}
+
+	// Parse the worker state to MachineDeploymentStates
+	workerState := make(map[string]*workercontroller.MachineDeploymentState)
+	if err := json.Unmarshal(workerCopy.Status.State.Raw, &workerState); err != nil {
+		return err
+	}
+
+	// Attach the parsed MachineDeploymentStates to the wanted MachineDeployments
+	for index, wantedMachineDeployment := range wantedMachineDeployments {
+		wantedMachineDeployments[index].State = workerState[wantedMachineDeployment.Name]
+	}
+
+	return nil
+}
+
+func (a *genericActuator) deployMachineSetsAndMachines(ctx context.Context, worker *extensionsv1alpha1.Worker, existingMachineDeployments *machinev1alpha1.MachineDeploymentList, wantedMachineDeployments workercontroller.MachineDeployments) error {
+	existingMachineDeploymentNameSet := make(map[string]struct{})
+
+	for _, existingMachineDeployment := range existingMachineDeployments.Items {
+		existingMachineDeploymentNameSet[existingMachineDeployment.Name] = struct{}{}
+	}
+
+	for _, wantedMachineDeployment := range wantedMachineDeployments {
+		// We restore machineSets and machines only for missing machineDeployments
+		if _, ok := existingMachineDeploymentNameSet[wantedMachineDeployment.Name]; ok ||
+			wantedMachineDeployment.State == nil || wantedMachineDeployment.State.MachineSet == nil {
+			continue
+		}
+
+		// Extract the MachineSet
+		machineSet := &machinev1alpha1.MachineSet{}
+		if _, _, err := a.decoder.Decode(wantedMachineDeployment.State.MachineSet.Raw, nil, machineSet); err != nil {
+			return err
+		}
+
+		// Create the MachineSet if not already exists. We do not care about the MachineSet status
+		// because the MCM will update it
+		if err := a.client.Create(ctx, machineSet); err != nil && !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+
+		// Deploy each machine owned by the MachineSet which was restored above
+		for _, rawMachine := range wantedMachineDeployment.State.Machines {
+			if rawMachine.Raw == nil {
+				continue
+			}
+			// Unmarshal the Machine
+			machine := &machinev1alpha1.Machine{}
+			if _, _, err := a.decoder.Decode(rawMachine.Raw, nil, machine); err != nil {
+				return err
+			}
+
+			// Create the machine if it not exists already
+			err := a.client.Create(ctx, machine)
+			if err != nil && !apierrors.IsAlreadyExists(err) {
+				return err
+			}
+
+			// Attach the Shoot node to the Machine status
+			node := machine.Status.Node
+			if err := a.updateStatus(ctx, machine, apierrors.IsAlreadyExists(err), func() error {
+				machine.Status.Node = node
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// isAlreadyExists must be returned from from apierrors.IsAlreadyExists(err) where err commes from client.Create.
+// This function is needed because wen you call client.Create and it successed if you immediately call TryUpdateStatus
+// it will return an error stating that the Object does not exists.
+// This bug comes form the fact that exponentialBackoff in TryUpdateStatus does not retry if client.Get returns error
+// so the function exits immediately with error
+func (a *genericActuator) updateStatus(ctx context.Context, obj runtime.Object, isAlreadyExists bool, transform func() error) error {
+	if isAlreadyExists {
+		return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, a.client, obj, transform)
+	}
+	return a.client.Status().Update(ctx, obj)
+}

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -26,6 +26,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
@@ -51,10 +52,18 @@ type MachineDeployment struct {
 	Labels         map[string]string
 	Annotations    map[string]string
 	Taints         []corev1.Taint
+	State          *MachineDeploymentState
 }
 
 // MachineDeployments is a list of machine deployments.
 type MachineDeployments []MachineDeployment
+
+// MachineDeploymentState stores the last versions of the machine sets and machine which
+// the machine deployment corresponds
+type MachineDeploymentState struct {
+	MachineSet *runtime.RawExtension  `json:"machineSet,omitempty"`
+	Machines   []runtime.RawExtension `json:"machines,omitempty"`
+}
 
 // HasDeployment checks whether the <name> is part of the <machineDeployments>
 // list, i.e. whether there is an entry whose 'Name' attribute matches <name>. It returns true or false.

--- a/pkg/controller/worker/mapper.go
+++ b/pkg/controller/worker/mapper.go
@@ -28,3 +28,15 @@ import (
 func ClusterToWorkerMapper(predicates []predicate.Predicate) handler.Mapper {
 	return extensionshandler.ClusterToObjectMapper(func() runtime.Object { return &extensionsv1alpha1.WorkerList{} }, predicates)
 }
+
+// MachineSetToWorkerMapper returns a mapper that returns requests for Worker whose
+// referenced MachineSets have been modified.
+func MachineSetToWorkerMapper(predicates []predicate.Predicate) handler.Mapper {
+	return extensionshandler.MachineSetToObjectMapper(func() runtime.Object { return &extensionsv1alpha1.WorkerList{} }, predicates)
+}
+
+// MachineToWorkerMapper returns a mapper that returns requests for Worker whose
+// referenced Machines have been modified.
+func MachineToWorkerMapper(predicates []predicate.Predicate) handler.Mapper {
+	return extensionshandler.MachineToObjectMapper(func() runtime.Object { return &extensionsv1alpha1.WorkerList{} }, predicates)
+}

--- a/pkg/controller/worker/state_actuator.go
+++ b/pkg/controller/worker/state_actuator.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"context"
+	"encoding/json"
+
+	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-logr/logr"
+)
+
+type genericStateActuator struct {
+	logger logr.Logger
+
+	client client.Client
+}
+
+// NewStateActuator creates a new Actuator that reconciles Worker's State subresource
+// It provides a default implementation that allows easier integration of providers.
+func NewStateActuator(logger logr.Logger) StateActuator {
+	return &genericStateActuator{logger: logger.WithName("worker-state-actuator")}
+}
+
+func (a *genericStateActuator) InjectClient(client client.Client) error {
+	a.client = client
+	return nil
+}
+
+// Reconcile update the Worker state with the latest.
+func (a *genericStateActuator) Reconcile(ctx context.Context, worker *extensionsv1alpha1.Worker) error {
+	copyOfWorker := worker.DeepCopy()
+	if err := a.updateWorkerState(ctx, copyOfWorker); err != nil {
+		return errors.Wrapf(err, "failed to update the state in worker status")
+	}
+
+	return nil
+}
+
+func (a *genericStateActuator) updateWorkerState(ctx context.Context, worker *extensionsv1alpha1.Worker) error {
+	state, err := a.getWorkerState(ctx, worker)
+	if err != nil {
+		return err
+	}
+
+	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, a.client, worker, func() error {
+		worker.Status.State = &runtime.RawExtension{Raw: state}
+		return nil
+	})
+}
+
+func (a *genericStateActuator) getWorkerState(ctx context.Context, worker *extensionsv1alpha1.Worker) ([]byte, error) {
+	machineDeploymentNames, err := a.getExistingMachineDeploymentNames(ctx, worker)
+	if err != nil {
+		return nil, err
+	}
+
+	machineSets, err := a.getExistingMachineSetsMap(ctx, worker)
+	if err != nil {
+		return nil, err
+	}
+
+	machines, err := a.getExistingMachinesMap(ctx, worker)
+	if err != nil {
+		return nil, err
+	}
+
+	workerState := make(map[string]*MachineDeploymentState)
+	for _, deploymentName := range machineDeploymentNames {
+		machineDeploymentState := &MachineDeploymentState{}
+
+		machineSet, ok := machineSets[deploymentName]
+		if !ok {
+			continue
+		}
+		addMachineSetToMachineDeploymentState(machineSet, machineDeploymentState)
+
+		currentMachines := machines[machineSet.Name]
+		if len(currentMachines) <= 0 {
+			continue
+		}
+
+		for index := range currentMachines {
+			addMachineToMachineDeploymentState(&currentMachines[index], machineDeploymentState)
+		}
+
+		workerState[deploymentName] = machineDeploymentState
+	}
+
+	return json.Marshal(workerState)
+}
+
+func (a *genericStateActuator) getExistingMachineDeploymentNames(ctx context.Context, worker *extensionsv1alpha1.Worker) ([]string, error) {
+	existingMachineDeployments := &machinev1alpha1.MachineDeploymentList{}
+	if err := a.client.List(ctx, existingMachineDeployments, client.InNamespace(worker.Namespace)); err != nil {
+		return nil, err
+	}
+
+	var machineDeploymentNames []string
+	for _, machineDeployment := range existingMachineDeployments.Items {
+		machineDeploymentNames = append(machineDeploymentNames, machineDeployment.Name)
+	}
+
+	return machineDeploymentNames, nil
+}
+
+func (a *genericStateActuator) getExistingMachineSetsMap(ctx context.Context, worker *extensionsv1alpha1.Worker) (map[string]*machinev1alpha1.MachineSet, error) {
+	existingMachineSets := &machinev1alpha1.MachineSetList{}
+	if err := a.client.List(ctx, existingMachineSets, client.InNamespace(worker.Namespace)); err != nil {
+		return nil, err
+	}
+
+	machineSets := make(map[string]*machinev1alpha1.MachineSet)
+	for index, machineSet := range existingMachineSets.Items {
+		for _, referant := range machineSet.OwnerReferences {
+			if referant.Kind == "MachineDeployment" {
+				machineSets[referant.Name] = &existingMachineSets.Items[index]
+			}
+		}
+	}
+	return machineSets, nil
+}
+
+func (a *genericStateActuator) getExistingMachinesMap(ctx context.Context, worker *extensionsv1alpha1.Worker) (map[string][]machinev1alpha1.Machine, error) {
+	existingMachines := &machinev1alpha1.MachineList{}
+	if err := a.client.List(ctx, existingMachines, client.InNamespace(worker.Namespace)); err != nil {
+		return nil, err
+	}
+
+	machines := make(map[string][]machinev1alpha1.Machine)
+	for index, machine := range existingMachines.Items {
+		for _, referant := range machine.OwnerReferences {
+			if referant.Kind == "MachineSet" {
+				machines[referant.Name] = append(machines[referant.Name], existingMachines.Items[index])
+			}
+		}
+	}
+	return machines, nil
+}
+
+func addMachineSetToMachineDeploymentState(machineSet *machinev1alpha1.MachineSet, machineDeploymentState *MachineDeploymentState) {
+	if machineSet == nil || machineDeploymentState == nil {
+		return
+	}
+
+	//remove redundant data from the machine set
+	machineSet.ObjectMeta = metav1.ObjectMeta{
+		Name:        machineSet.Name,
+		Namespace:   machineSet.Namespace,
+		Annotations: machineSet.Annotations,
+		Labels:      machineSet.Labels,
+	}
+	machineSet.OwnerReferences = nil
+	machineSet.Status = machinev1alpha1.MachineSetStatus{}
+
+	machineDeploymentState.MachineSet = &runtime.RawExtension{Object: machineSet}
+}
+
+func addMachineToMachineDeploymentState(machine *machinev1alpha1.Machine, machineDeploymentState *MachineDeploymentState) {
+	if machine == nil || machineDeploymentState == nil {
+		return
+	}
+
+	//remove redundant data from the machine
+	machine.ObjectMeta = metav1.ObjectMeta{
+		Name:        machine.Name,
+		Namespace:   machine.Namespace,
+		Annotations: machine.Annotations,
+		Labels:      machine.Labels,
+	}
+	machine.OwnerReferences = nil
+	machine.Status = machinev1alpha1.MachineStatus{
+		Node: machine.Status.Node,
+	}
+
+	machineDeploymentState.Machines = append(machineDeploymentState.Machines, runtime.RawExtension{Object: machine})
+}

--- a/pkg/controller/worker/state_reconciler.go
+++ b/pkg/controller/worker/state_reconciler.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gardener/gardener-extensions/pkg/controller"
+	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
+	"github.com/gardener/gardener-extensions/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+const (
+	// StartToSyncState is used as part of the Event 'reason' when a Worker state starts to synchronize
+	StartToSyncState = "SynchronizingState"
+	// SuccessSynced is used as part of the Event 'reason' when a Worker state is synced
+	SuccessSynced = "StateSynced"
+	// ErrorStateSync is used as part of the Event 'reason' when a Worker state fail to sync
+	ErrorStateSync = "ErrorSynchronizingState"
+	// StateSyncControllerName is the name of the controller which synchronize the Worker state
+	StateSyncControllerName = "worker-state-cotroller"
+)
+
+type stateReconciler struct {
+	logger   logr.Logger
+	actuator StateActuator
+
+	// Recorder is an event recorder for recording Event resources to the
+	// Kubernetes API.
+	recorder record.EventRecorder
+
+	ctx    context.Context
+	client client.Client
+}
+
+// NewStateReconciler creates a new reconcile.Reconciler that reconciles
+// Worker's State resources of Gardener's `extensions.gardener.cloud` API group.
+func NewStateReconciler(mgr manager.Manager, actuator StateActuator) reconcile.Reconciler {
+	return &stateReconciler{
+		logger:   log.Log.WithName(StateUpdatingControllerName),
+		actuator: actuator,
+		recorder: mgr.GetEventRecorderFor(StateSyncControllerName),
+	}
+}
+
+func (r *stateReconciler) InjectFunc(f inject.Func) error {
+	return f(r.actuator)
+}
+
+func (r *stateReconciler) InjectClient(client client.Client) error {
+	r.client = client
+	return nil
+}
+
+func (r *stateReconciler) InjectStopChannel(stopCh <-chan struct{}) error {
+	r.ctx = util.ContextFromStopChannel(stopCh)
+	return nil
+}
+
+func (r *stateReconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	worker := &extensionsv1alpha1.Worker{}
+	if err := r.client.Get(r.ctx, request.NamespacedName, worker); err != nil {
+		if errors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	// Deletion flow
+	if worker.DeletionTimestamp != nil {
+		//Nothing to do
+		return reconcile.Result{}, nil
+	}
+
+	// Reconcile flow
+	if err := controller.EnsureFinalizer(r.ctx, r.client, FinalizerName, worker); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	operationType := gardencorev1beta1helper.ComputeOperationType(worker.ObjectMeta, worker.Status.LastOperation)
+	if operationType != gardencorev1beta1.LastOperationTypeReconcile {
+		return reconcile.Result{Requeue: true}, nil
+	}
+
+	r.recorder.Event(worker, corev1.EventTypeNormal, StartToSyncState, "Updating the worker state")
+
+	if err := r.actuator.Reconcile(r.ctx, worker); err != nil {
+		msg := "Error updating worker state"
+		r.logger.Error(err, msg, "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
+		r.recorder.Event(worker, corev1.EventTypeWarning, ErrorStateSync, msg)
+		return extensionscontroller.ReconcileErr(err)
+	}
+
+	msg := "Successfully update worker state"
+	r.logger.Info(msg, "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
+	r.recorder.Event(worker, corev1.EventTypeNormal, SuccessSynced, msg)
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/handler/mapper.go
+++ b/pkg/handler/mapper.go
@@ -18,8 +18,8 @@ import (
 	"context"
 
 	extensionspredicate "github.com/gardener/gardener-extensions/pkg/predicate"
-
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -68,6 +68,108 @@ func (m *clusterToObjectMapper) Map(obj handler.MapObject) []reconcile.Request {
 		return nil
 	}
 
+	return getReconcileRequestsFromObjectList(objList, m.predicates)
+}
+
+// ClusterToObjectMapper returns a mapper that returns requests for objects whose
+// referenced clusters have been modified.
+func ClusterToObjectMapper(newObjListFunc func() runtime.Object, predicates []predicate.Predicate) handler.Mapper {
+	return &clusterToObjectMapper{newObjListFunc: newObjListFunc, predicates: predicates}
+}
+
+type machineSetToObjectMapper struct {
+	client         client.Client
+	newObjListFunc func() runtime.Object
+	predicates     []predicate.Predicate
+}
+
+func (m *machineSetToObjectMapper) InjectClient(c client.Client) error {
+	m.client = c
+	return nil
+}
+
+func (m *machineSetToObjectMapper) InjectFunc(f inject.Func) error {
+	for _, p := range m.predicates {
+		if err := f(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *machineSetToObjectMapper) Map(obj handler.MapObject) []reconcile.Request {
+	ctx := context.TODO()
+
+	if obj.Object == nil {
+		return nil
+	}
+
+	machineSet, ok := obj.Object.(*machinev1alpha1.MachineSet)
+	if !ok {
+		return nil
+	}
+
+	objList := m.newObjListFunc()
+	if err := m.client.List(ctx, objList, client.InNamespace(machineSet.Namespace)); err != nil {
+		return nil
+	}
+
+	return getReconcileRequestsFromObjectList(objList, m.predicates)
+}
+
+// MachineSetToObjectMapper returns a mapper that returns requests for objects whose
+// referenced MachineSets have been modified.
+func MachineSetToObjectMapper(newObjListFunc func() runtime.Object, predicates []predicate.Predicate) handler.Mapper {
+	return &machineSetToObjectMapper{newObjListFunc: newObjListFunc, predicates: predicates}
+}
+
+type machineToObjectMapper struct {
+	client         client.Client
+	newObjListFunc func() runtime.Object
+	predicates     []predicate.Predicate
+}
+
+func (m *machineToObjectMapper) InjectClient(c client.Client) error {
+	m.client = c
+	return nil
+}
+
+func (m *machineToObjectMapper) InjectFunc(f inject.Func) error {
+	for _, p := range m.predicates {
+		if err := f(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *machineToObjectMapper) Map(obj handler.MapObject) []reconcile.Request {
+	ctx := context.TODO()
+
+	if obj.Object == nil {
+		return nil
+	}
+
+	machine, ok := obj.Object.(*machinev1alpha1.Machine)
+	if !ok {
+		return nil
+	}
+
+	objList := m.newObjListFunc()
+	if err := m.client.List(ctx, objList, client.InNamespace(machine.Namespace)); err != nil {
+		return nil
+	}
+
+	return getReconcileRequestsFromObjectList(objList, m.predicates)
+}
+
+// MachineToObjectMapper returns a mapper that returns requests for objects whose
+// referenced Machines have been modified.
+func MachineToObjectMapper(newObjListFunc func() runtime.Object, predicates []predicate.Predicate) handler.Mapper {
+	return &machineToObjectMapper{newObjListFunc: newObjListFunc, predicates: predicates}
+}
+
+func getReconcileRequestsFromObjectList(objList runtime.Object, predicates []predicate.Predicate) []reconcile.Request {
 	var requests []reconcile.Request
 
 	utilruntime.HandleError(meta.EachListItem(objList, func(obj runtime.Object) error {
@@ -76,7 +178,7 @@ func (m *clusterToObjectMapper) Map(obj handler.MapObject) []reconcile.Request {
 			return err
 		}
 
-		if !extensionspredicate.EvalGeneric(obj, m.predicates...) {
+		if !extensionspredicate.EvalGeneric(obj, predicates...) {
 			return nil
 		}
 
@@ -89,10 +191,4 @@ func (m *clusterToObjectMapper) Map(obj handler.MapObject) []reconcile.Request {
 		return nil
 	}))
 	return requests
-}
-
-// ClusterToObjectMapper returns a mapper that returns requests for objects whose
-// referenced clusters have been modified.
-func ClusterToObjectMapper(newObjListFunc func() runtime.Object, predicates []predicate.Predicate) handler.Mapper {
-	return &clusterToObjectMapper{newObjListFunc: newObjListFunc, predicates: predicates}
 }

--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -17,6 +17,8 @@ package predicate
 import (
 	"errors"
 
+	machinesv1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+
 	"github.com/gardener/gardener-extensions/pkg/controller"
 	extensionsevent "github.com/gardener/gardener-extensions/pkg/event"
 	extensionsinject "github.com/gardener/gardener-extensions/pkg/inject"
@@ -158,7 +160,8 @@ func HasName(name string) predicate.Predicate {
 // HasOperationAnnotation is a predicate for the operation annotation.
 func HasOperationAnnotation() predicate.Predicate {
 	return FromMapper(MapperFunc(func(e event.GenericEvent) bool {
-		return e.Meta.GetAnnotations()[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationReconcile
+		return e.Meta.GetAnnotations()[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationReconcile ||
+			e.Meta.GetAnnotations()[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationRestore
 	}), CreateTrigger, UpdateNewTrigger, GenericTrigger)
 }
 
@@ -224,4 +227,40 @@ func HasPurpose(purpose extensionsv1alpha1.Purpose) predicate.Predicate {
 
 		return *controlPlane.Spec.Purpose == purpose
 	}), CreateTrigger, UpdateNewTrigger, DeleteTrigger, GenericTrigger)
+}
+
+// MachineStatusHasChanged is a predicate deciding wether the status of a MCM's Machine has been changed.
+func MachineStatusHasChanged() predicate.Predicate {
+	statusHasChanged := func(oldObj runtime.Object, newObj runtime.Object) bool {
+		oldMachine, ok := oldObj.(*machinesv1alpha1.Machine)
+		if !ok {
+			return false
+		}
+		newMachine, ok := newObj.(*machinesv1alpha1.Machine)
+		if !ok {
+			return false
+		}
+		oldStatus := oldMachine.Status
+		newStatus := newMachine.Status
+
+		//Check the Node
+		return oldStatus.Node != newStatus.Node
+
+	}
+
+	return predicate.Funcs{
+		CreateFunc: func(event event.CreateEvent) bool {
+			return true
+		},
+		UpdateFunc: func(event event.UpdateEvent) bool {
+			result := statusHasChanged(event.ObjectOld, event.ObjectNew)
+			return result
+		},
+		GenericFunc: func(event event.GenericEvent) bool {
+			return false
+		},
+		DeleteFunc: func(event event.DeleteEvent) bool {
+			return true
+		},
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR we add second controller which works side by side with the worker controller.|
This new controller watch for changes in the MachineSets and the Machines and update the state of the Worker state. The Worker State consist of the actual state of the MachineSets and the Machines.
In case of a control plane migration this resources will be extracted from the Worker State and deployed instead of letting MCM to create a new ones.
 
**Which issue(s) this PR fixes**:
Part of [#1631](https://github.com/gardener/gardener/issues/1631)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Add worker state updating controller
```
