### PR TITLE
Handle hibernated cluster w/ missing API service

### DIFF
--- a/controllers/provider-alicloud/pkg/webhook/controlplaneexposure/ensurer.go
+++ b/controllers/provider-alicloud/pkg/webhook/controlplaneexposure/ensurer.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/gardener/gardener-extensions/controllers/provider-alicloud/pkg/apis/config"
+	"github.com/gardener/gardener-extensions/pkg/controller"
 	"github.com/gardener/gardener-extensions/pkg/util"
 	extensionswebhook "github.com/gardener/gardener-extensions/pkg/webhook"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
@@ -56,6 +57,15 @@ func (e *ensurer) InjectClient(client client.Client) error {
 
 // EnsureKubeAPIServerDeployment ensures that the kube-apiserver deployment conforms to the provider requirements.
 func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, ectx genericmutator.EnsurerContext, dep *appsv1.Deployment) error {
+	cluster, err := controller.GetCluster(ctx, e.client, dep.Namespace)
+	if err != nil {
+		return err
+	}
+
+	if controller.IsHibernated(cluster) {
+		return nil
+	}
+
 	// Get load balancer address of the kube-apiserver service
 	address, err := kutil.GetLoadBalancerIngress(ctx, e.client, dep.Namespace, v1beta1constants.DeploymentNameKubeAPIServer)
 	if err != nil {

--- a/controllers/provider-alicloud/pkg/webhook/controlplaneexposure/ensurer_test.go
+++ b/controllers/provider-alicloud/pkg/webhook/controlplaneexposure/ensurer_test.go
@@ -16,7 +16,10 @@ package controlplaneexposure
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 
 	"github.com/gardener/gardener-extensions/controllers/provider-alicloud/pkg/apis/config"
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
@@ -26,6 +29,7 @@ import (
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane/genericmutator"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -69,6 +73,13 @@ var _ = Describe("Ensurer", func() {
 				},
 			},
 		}
+		cluster = &extensionsv1alpha1.Cluster{
+			Spec: extensionsv1alpha1.ClusterSpec{
+				Shoot: runtime.RawExtension{
+					Raw: encode(&gardencorev1beta1.Shoot{}),
+				},
+			},
+		}
 	)
 
 	BeforeEach(func() {
@@ -99,12 +110,13 @@ var _ = Describe("Ensurer", func() {
 			)
 
 			// Create mock client
-			client := mockclient.NewMockClient(ctrl)
-			client.EXPECT().Get(context.TODO(), svcKey, &corev1.Service{}).DoAndReturn(clientGet(svc))
+			c := mockclient.NewMockClient(ctrl)
+			c.EXPECT().Get(context.TODO(), client.ObjectKey{Name: namespace}, &extensionsv1alpha1.Cluster{}).DoAndReturn(clientGet(cluster))
+			c.EXPECT().Get(context.TODO(), svcKey, &corev1.Service{}).DoAndReturn(clientGet(svc))
 
 			// Create ensurer
 			ensurer := NewEnsurer(etcdStorage, logger)
-			err := ensurer.(inject.Client).InjectClient(client)
+			err := ensurer.(inject.Client).InjectClient(c)
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
@@ -133,12 +145,13 @@ var _ = Describe("Ensurer", func() {
 			)
 
 			// Create mock client
-			client := mockclient.NewMockClient(ctrl)
-			client.EXPECT().Get(context.TODO(), svcKey, &corev1.Service{}).DoAndReturn(clientGet(svc))
+			c := mockclient.NewMockClient(ctrl)
+			c.EXPECT().Get(context.TODO(), client.ObjectKey{Name: namespace}, &extensionsv1alpha1.Cluster{}).DoAndReturn(clientGet(cluster))
+			c.EXPECT().Get(context.TODO(), svcKey, &corev1.Service{}).DoAndReturn(clientGet(svc))
 
 			// Create ensurer
 			ensurer := NewEnsurer(etcdStorage, logger)
-			err := ensurer.(inject.Client).InjectClient(client)
+			err := ensurer.(inject.Client).InjectClient(c)
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
@@ -269,7 +282,14 @@ func clientGet(result runtime.Object) interface{} {
 		switch obj.(type) {
 		case *corev1.Service:
 			*obj.(*corev1.Service) = *result.(*corev1.Service)
+		case *extensionsv1alpha1.Cluster:
+			*obj.(*extensionsv1alpha1.Cluster) = *result.(*extensionsv1alpha1.Cluster)
 		}
 		return nil
 	}
+}
+
+func encode(obj runtime.Object) []byte {
+	data, _ := json.Marshal(obj)
+	return data
 }

--- a/controllers/provider-aws/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-aws/pkg/controller/controlplane/valuesprovider.go
@@ -16,13 +16,14 @@ package controlplane
 
 import (
 	"context"
-	"github.com/gardener/gardener-extensions/pkg/controller/common"
 	"path/filepath"
 
 	apisaws "github.com/gardener/gardener-extensions/controllers/provider-aws/pkg/apis/aws"
 	"github.com/gardener/gardener-extensions/controllers/provider-aws/pkg/apis/aws/helper"
 	"github.com/gardener/gardener-extensions/controllers/provider-aws/pkg/aws"
+	"github.com/gardener/gardener-extensions/pkg/controller"
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
+	"github.com/gardener/gardener-extensions/pkg/controller/common"
 	"github.com/gardener/gardener-extensions/pkg/controller/controlplane"
 	"github.com/gardener/gardener-extensions/pkg/controller/controlplane/genericactuator"
 	"github.com/gardener/gardener-extensions/pkg/util"
@@ -216,11 +217,15 @@ func (vp *valuesProvider) GetControlPlaneExposureChartValues(
 	cluster *extensionscontroller.Cluster,
 	checksums map[string]string,
 ) (map[string]interface{}, error) {
+	var address string
 
-	// Get load balancer address of the kube-apiserver service
-	address, err := kutil.GetLoadBalancerIngress(ctx, vp.Client(), cp.Namespace, v1beta1constants.DeploymentNameKubeAPIServer)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get kube-apiserver service load balancer address")
+	if !controller.IsHibernated(cluster) {
+		// Get load balancer address of the kube-apiserver service
+		var err error
+		address, err = kutil.GetLoadBalancerIngress(ctx, vp.Client(), cp.Namespace, v1beta1constants.DeploymentNameKubeAPIServer)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get kube-apiserver service load balancer address")
+		}
 	}
 
 	return map[string]interface{}{

--- a/controllers/provider-azure/pkg/webhook/controlplaneexposure/ensurer.go
+++ b/controllers/provider-azure/pkg/webhook/controlplaneexposure/ensurer.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/apis/config"
+	"github.com/gardener/gardener-extensions/pkg/controller"
 	extensionswebhook "github.com/gardener/gardener-extensions/pkg/webhook"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane/genericmutator"
@@ -64,6 +65,15 @@ func (e *ensurer) EnsureKubeAPIServerService(ctx context.Context, ectx genericmu
 
 // EnsureKubeAPIServerDeployment ensures that the kube-apiserver deployment conforms to the provider requirements.
 func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, ectx genericmutator.EnsurerContext, dep *appsv1.Deployment) error {
+	cluster, err := controller.GetCluster(ctx, e.client, dep.Namespace)
+	if err != nil {
+		return err
+	}
+
+	if controller.IsHibernated(cluster) {
+		return nil
+	}
+
 	// Get load balancer address of the kube-apiserver service
 	address, err := kutil.GetLoadBalancerIngress(ctx, e.client, dep.Namespace, v1beta1constants.DeploymentNameKubeAPIServer)
 	if err != nil {

--- a/controllers/provider-azure/pkg/webhook/controlplaneexposure/ensurer_test.go
+++ b/controllers/provider-azure/pkg/webhook/controlplaneexposure/ensurer_test.go
@@ -16,7 +16,11 @@ package controlplaneexposure
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 
 	"github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/apis/config"
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
@@ -69,6 +73,13 @@ var _ = Describe("Ensurer", func() {
 				},
 			},
 		}
+		cluster = &extensionsv1alpha1.Cluster{
+			Spec: extensionsv1alpha1.ClusterSpec{
+				Shoot: runtime.RawExtension{
+					Raw: encode(&gardencorev1beta1.Shoot{}),
+				},
+			},
+		}
 	)
 
 	BeforeEach(func() {
@@ -99,12 +110,13 @@ var _ = Describe("Ensurer", func() {
 			)
 
 			// Create mock client
-			client := mockclient.NewMockClient(ctrl)
-			client.EXPECT().Get(context.TODO(), svcKey, &corev1.Service{}).DoAndReturn(clientGet(svc))
+			c := mockclient.NewMockClient(ctrl)
+			c.EXPECT().Get(context.TODO(), client.ObjectKey{Name: namespace}, &extensionsv1alpha1.Cluster{}).DoAndReturn(clientGet(cluster))
+			c.EXPECT().Get(context.TODO(), svcKey, &corev1.Service{}).DoAndReturn(clientGet(svc))
 
 			// Create ensurer
 			ensurer := NewEnsurer(etcdStorage, logger)
-			err := ensurer.(inject.Client).InjectClient(client)
+			err := ensurer.(inject.Client).InjectClient(c)
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
@@ -133,12 +145,13 @@ var _ = Describe("Ensurer", func() {
 			)
 
 			// Create mock client
-			client := mockclient.NewMockClient(ctrl)
-			client.EXPECT().Get(context.TODO(), svcKey, &corev1.Service{}).DoAndReturn(clientGet(svc))
+			c := mockclient.NewMockClient(ctrl)
+			c.EXPECT().Get(context.TODO(), client.ObjectKey{Name: namespace}, &extensionsv1alpha1.Cluster{}).DoAndReturn(clientGet(cluster))
+			c.EXPECT().Get(context.TODO(), svcKey, &corev1.Service{}).DoAndReturn(clientGet(svc))
 
 			// Create ensurer
 			ensurer := NewEnsurer(etcdStorage, logger)
-			err := ensurer.(inject.Client).InjectClient(client)
+			err := ensurer.(inject.Client).InjectClient(c)
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
@@ -269,7 +282,14 @@ func clientGet(result runtime.Object) interface{} {
 		switch obj.(type) {
 		case *corev1.Service:
 			*obj.(*corev1.Service) = *result.(*corev1.Service)
+		case *extensionsv1alpha1.Cluster:
+			*obj.(*extensionsv1alpha1.Cluster) = *result.(*extensionsv1alpha1.Cluster)
 		}
 		return nil
 	}
+}
+
+func encode(obj runtime.Object) []byte {
+	data, _ := json.Marshal(obj)
+	return data
 }

--- a/controllers/provider-gcp/pkg/webhook/controlplaneexposure/ensurer_test.go
+++ b/controllers/provider-gcp/pkg/webhook/controlplaneexposure/ensurer_test.go
@@ -16,7 +16,12 @@ package controlplaneexposure
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 
 	"github.com/gardener/gardener-extensions/controllers/provider-gcp/pkg/apis/config"
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
@@ -69,6 +74,13 @@ var _ = Describe("Ensurer", func() {
 				},
 			},
 		}
+		cluster = &extensionsv1alpha1.Cluster{
+			Spec: extensionsv1alpha1.ClusterSpec{
+				Shoot: runtime.RawExtension{
+					Raw: encode(&gardencorev1beta1.Shoot{}),
+				},
+			},
+		}
 	)
 
 	BeforeEach(func() {
@@ -99,12 +111,13 @@ var _ = Describe("Ensurer", func() {
 			)
 
 			// Create mock client
-			client := mockclient.NewMockClient(ctrl)
-			client.EXPECT().Get(context.TODO(), svcKey, &corev1.Service{}).DoAndReturn(clientGet(svc))
+			c := mockclient.NewMockClient(ctrl)
+			c.EXPECT().Get(context.TODO(), client.ObjectKey{Name: namespace}, &extensionsv1alpha1.Cluster{}).DoAndReturn(clientGet(cluster))
+			c.EXPECT().Get(context.TODO(), svcKey, &corev1.Service{}).DoAndReturn(clientGet(svc))
 
 			// Create ensurer
 			ensurer := NewEnsurer(etcdStorage, logger)
-			err := ensurer.(inject.Client).InjectClient(client)
+			err := ensurer.(inject.Client).InjectClient(c)
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
@@ -133,12 +146,13 @@ var _ = Describe("Ensurer", func() {
 			)
 
 			// Create mock client
-			client := mockclient.NewMockClient(ctrl)
-			client.EXPECT().Get(context.TODO(), svcKey, &corev1.Service{}).DoAndReturn(clientGet(svc))
+			c := mockclient.NewMockClient(ctrl)
+			c.EXPECT().Get(context.TODO(), client.ObjectKey{Name: namespace}, &extensionsv1alpha1.Cluster{}).DoAndReturn(clientGet(cluster))
+			c.EXPECT().Get(context.TODO(), svcKey, &corev1.Service{}).DoAndReturn(clientGet(svc))
 
 			// Create ensurer
 			ensurer := NewEnsurer(etcdStorage, logger)
-			err := ensurer.(inject.Client).InjectClient(client)
+			err := ensurer.(inject.Client).InjectClient(c)
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
@@ -268,7 +282,14 @@ func clientGet(result runtime.Object) interface{} {
 		switch obj.(type) {
 		case *corev1.Service:
 			*obj.(*corev1.Service) = *result.(*corev1.Service)
+		case *extensionsv1alpha1.Cluster:
+			*obj.(*extensionsv1alpha1.Cluster) = *result.(*extensionsv1alpha1.Cluster)
 		}
 		return nil
 	}
+}
+
+func encode(obj runtime.Object) []byte {
+	data, _ := json.Marshal(obj)
+	return data
 }

--- a/controllers/provider-openstack/pkg/webhook/controlplaneexposure/ensurer.go
+++ b/controllers/provider-openstack/pkg/webhook/controlplaneexposure/ensurer.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/gardener/gardener-extensions/controllers/provider-openstack/pkg/apis/config"
+	"github.com/gardener/gardener-extensions/pkg/controller"
 	extensionswebhook "github.com/gardener/gardener-extensions/pkg/webhook"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane/genericmutator"
@@ -54,6 +55,15 @@ func (e *ensurer) InjectClient(client client.Client) error {
 
 // EnsureKubeAPIServerDeployment ensures that the kube-apiserver deployment conforms to the provider requirements.
 func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, ectx genericmutator.EnsurerContext, dep *appsv1.Deployment) error {
+	cluster, err := controller.GetCluster(ctx, e.client, dep.Namespace)
+	if err != nil {
+		return err
+	}
+
+	if controller.IsHibernated(cluster) {
+		return nil
+	}
+
 	// Get load balancer address of the kube-apiserver service
 	address, err := kutil.GetLoadBalancerIngress(ctx, e.client, dep.Namespace, v1beta1constants.DeploymentNameKubeAPIServer)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is needed to reconcile clusters whose `Kube-Apiserver` service was deleted when they were entering hibernation.

PR is still WIP for testing purposes.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`Alicloud`, `AWS`, `Azure`, `GCP` and `OpenStack` providers are now capable of managing hibernated shoots which don't have a `Kube-Apiserver` service. 
```
