### PR TITLE
Azure-CCM: Bundle cloudProviderRateLimitQPS[Write] to the maxNodes

### DIFF
--- a/controllers/provider-azure/charts/internal/cloud-provider-config/templates/cloud-provider-config.tpl
+++ b/controllers/provider-azure/charts/internal/cloud-provider-config/templates/cloud-provider-config.tpl
@@ -21,9 +21,9 @@ cloudProviderBackoffExponent: 1.5
 cloudProviderBackoffDuration: 5
 cloudProviderBackoffJitter: 1.0
 cloudProviderRateLimit: true
-cloudProviderRateLimitQPS: 10.0
+cloudProviderRateLimitQPS: {{ ( max .Values.maxNodes 10 ) }}
 cloudProviderRateLimitBucket: 100
-cloudProviderRateLimitQPSWrite: 10.0
+cloudProviderRateLimitQPSWrite: {{ ( max .Values.maxNodes 10 ) }}
 cloudProviderRateLimitBucketWrite: 100
 {{- if semverCompare ">= 1.14" .Values.kubernetesVersion }}
 cloudProviderBackoffMode: v2

--- a/controllers/provider-azure/charts/internal/cloud-provider-config/values.yaml
+++ b/controllers/provider-azure/charts/internal/cloud-provider-config/values.yaml
@@ -10,3 +10,4 @@ subnetName: sname
 routeTableName: rtname
 securityGroupName: sgname
 region: location
+maxNodes: 0

--- a/controllers/provider-azure/pkg/controller/controlplane/valuesprovider.go
+++ b/controllers/provider-azure/pkg/controller/controlplane/valuesprovider.go
@@ -196,6 +196,11 @@ func getConfigChartValues(
 		return nil, errors.Wrapf(err, "could not determine subnet, availability set, route table or security group name from infrastructureStatus of controlplane '%s'", util.ObjectName(cp))
 	}
 
+	var maxNodes int32
+	for _, worker := range cluster.Shoot.Spec.Provider.Workers {
+		maxNodes = maxNodes + worker.Maximum
+	}
+
 	// Collect config chart values.
 	values := map[string]interface{}{
 		"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
@@ -209,6 +214,7 @@ func getConfigChartValues(
 		"routeTableName":    routeTableName,
 		"securityGroupName": securityGroupName,
 		"region":            cp.Spec.Region,
+		"maxNodes":          maxNodes,
 	}
 
 	if infraStatus.Networks.VNet.ResourceGroup != nil {

--- a/controllers/provider-azure/pkg/controller/controlplane/valuesprovider_test.go
+++ b/controllers/provider-azure/pkg/controller/controlplane/valuesprovider_test.go
@@ -38,7 +38,8 @@ import (
 )
 
 const (
-	namespace = "test"
+	namespace       = "test"
+	maxNodes  int32 = 0
 )
 
 var _ = Describe("ValuesProvider", func() {
@@ -450,6 +451,7 @@ var _ = Describe("ValuesProvider", func() {
 			"routeTableName":      "route-table-name",
 			"securityGroupName":   "security-group-name-workers",
 			"kubernetesVersion":   "1.13.4",
+			"maxNodes":            maxNodes,
 		}
 
 		configZonedClusterChartValues = map[string]interface{}{
@@ -464,6 +466,7 @@ var _ = Describe("ValuesProvider", func() {
 			"routeTableName":    "route-table-name",
 			"securityGroupName": "security-group-name-workers",
 			"kubernetesVersion": "1.13.4",
+			"maxNodes":          maxNodes,
 		}
 
 		ccmChartValues = map[string]interface{}{


### PR DESCRIPTION
**What this PR does / why we need it**:
Azure-CCM: Bundle cloudProviderRateLimitQPS[Write] to the maxNodes

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
https://github.com/kubernetes-sigs/cloud-provider-azure/issues/155#issuecomment-488523167

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue where cloud controller manager was self-rate-limited for azure shoot clusters with more than 10 nodes has been fixed.  
```
