### PR TITLE
Allow Azure cloud-controller to create service events

### DIFF
--- a/controllers/provider-azure/charts/internal/cloud-controller-manager-shoot/templates/rbac-cloud-controller.yaml
+++ b/controllers/provider-azure/charts/internal/cloud-controller-manager-shoot/templates/rbac-cloud-controller.yaml
@@ -1,0 +1,27 @@
+{{- if semverCompare ">= 1.12" .Capabilities.KubeVersion.GitVersion }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:azure-cloud-provider
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs:
+  - create
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:azure-cloud-provider
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:azure-cloud-provider
+subjects:
+- kind: ServiceAccount
+  name: azure-cloud-provider
+  namespace: kube-system
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow Azure cloud-controller to create Service events.
Azure Services can now have Events also from source `azure-cloud-provider` (in addition to the existing source `service-controller`).
For example:
```
$ k describe svc -n kube-system vpn-shoot
# ...
Events:
  Type     Reason                    Age                  From                  Message
  ----     ------                    ----                 ----                  -------
  Normal   EnsuringLoadBalancer      53m (x5 over 54m)    service-controller    Ensuring load balancer
  Warning  SyncLoadBalancerFailed    53m (x5 over 54m)    service-controller    Error syncing load balancer: failed to ensure load balancer: autorest/azure: Service returned an error. Status=<nil> Code="ScopeLocked" Message="The scope 'foo' cannot perform write operation because following scope(s) are locked: 'bar'. Please remove the lock and try again."
  Warning  CreateOrUpdateInterface   11m                  azure-cloud-provider  network.InterfacesClient#CreateOrUpdate: Failure sending request: StatusCode=429 -- Original Error: Code="RetryableError" Message="A retryable error occurred." Details=[{"code":"ReferencedResourceNotProvisioned","message":"Cannot proceed with operation because resource foo is not in Succeeded state. Resource is in Updating state and the last operation that updated/is updating the resource is InternalOperation."}]
  Warning  CreateOrUpdateInterface   11m                  azure-cloud-provider  network.InterfacesClient#CreateOrUpdate: Failure sending request: StatusCode=429 -- Original Error: Code="RetryableError" Message="A retryable error occurred." Details=[{"code":"ReferencedResourceNotProvisioned","message":"Cannot proceed with operation because resource foo is not in Succeeded state. Resource is in Updating state and the last operation that updated/is updating the resource is InternalOperation."}]
```

**Which issue(s) this PR fixes**:
Fixes #531

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Azure cloud-controller-manager is now able to create Service events which are helpful to easily identify the underground errors of Azure API.
```
