### PR TITLE
Revert golangci/golangci-lint to v1.18.0

### DIFF
--- a/hack/check.sh
+++ b/hack/check.sh
@@ -24,7 +24,7 @@ echo "Executing check-generate"
 "$DIRNAME"/check-generate.sh
 
 echo "Executing golangci-lint"
-golangci-lint run --timeout 5m "${SOURCE_TREES[@]}"
+golangci-lint run --deadline 5m "${SOURCE_TREES[@]}"
 
 echo "Checking for format issues with gofmt"
 unformatted_files="$(gofmt -l controllers pkg)"

--- a/hack/install-requirements.sh
+++ b/hack/install-requirements.sh
@@ -24,7 +24,7 @@ go install -mod=vendor ./vendor/github.com/gobuffalo/packr/v2/packr2
 go install -mod=vendor ./vendor/github.com/onsi/ginkgo/ginkgo
 go install -mod=vendor ./vendor/github.com/golang/mock/mockgen
 go install -mod=vendor ./vendor/github.com/ahmetb/gen-crd-api-reference-docs
-curl -sfL "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh" | sh -s -- -b $(go env GOPATH)/bin v1.22.2
+curl -sfL "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh" | sh -s -- -b $(go env GOPATH)/bin v1.18.0
 curl -s "https://raw.githubusercontent.com/helm/helm/v2.13.1/scripts/get" | bash -s -- --version 'v2.13.1'
 
 if [[ "$(uname -s)" == *"Darwin"* ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
Revert golangci/golangci-lint to v1.18.0 as we face a lot of flakes with the new version.
See https://github.com/golangci/golangci-lint/issues/827.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
