### PR TITLE
Fix issue in cp ctrl that sometimes preserved last error

### DIFF
--- a/pkg/controller/controlplane/reconciler.go
+++ b/pkg/controller/controlplane/reconciler.go
@@ -178,28 +178,24 @@ func (r *reconciler) delete(ctx context.Context, cp *extensionsv1alpha1.ControlP
 }
 
 func (r *reconciler) updateStatusProcessing(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	lastOperation := extensionscontroller.LastOperation(lastOperationType, gardencorev1beta1.LastOperationStateProcessing, 1, description)
-	return r.updateStatus(ctx, cp, lastOperation, nil, nil)
+	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, cp, func() error {
+		cp.Status.LastOperation = extensionscontroller.LastOperation(lastOperationType, gardencorev1beta1.LastOperationStateProcessing, 1, description)
+		return nil
+	})
 }
 
 func (r *reconciler) updateStatusError(ctx context.Context, err error, cp *extensionsv1alpha1.ControlPlane, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	cp.Status.ObservedGeneration = cp.Generation
-	lastOperation, lastError := extensionscontroller.ReconcileError(lastOperationType, gardencorev1beta1helper.FormatLastErrDescription(fmt.Errorf("%s: %v", description, err)), 50, gardencorev1beta1helper.ExtractErrorCodes(err)...)
-	return r.updateStatus(ctx, cp, lastOperation, lastError, &cp.Generation)
+	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, cp, func() error {
+		cp.Status.ObservedGeneration = cp.Generation
+		cp.Status.LastOperation, cp.Status.LastError = extensionscontroller.ReconcileError(lastOperationType, gardencorev1beta1helper.FormatLastErrDescription(fmt.Errorf("%s: %v", description, err)), 50, gardencorev1beta1helper.ExtractErrorCodes(err)...)
+		return nil
+	})
 }
 
 func (r *reconciler) updateStatusSuccess(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	lastOperation, lastError := extensionscontroller.ReconcileSucceeded(lastOperationType, description)
-	return r.updateStatus(ctx, cp, lastOperation, lastError, &cp.Generation)
-}
-
-func (r *reconciler) updateStatus(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, lastOperation *gardencorev1beta1.LastOperation, lastError *gardencorev1beta1.LastError, observedGen *int64) error {
 	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, cp, func() error {
-		cp.Status.LastOperation = lastOperation
-		if lastError != nil {
-			cp.Status.ObservedGeneration = *observedGen
-			cp.Status.LastError = lastError
-		}
+		cp.Status.ObservedGeneration = cp.Generation
+		cp.Status.LastOperation, cp.Status.LastError = extensionscontroller.ReconcileSucceeded(lastOperationType, description)
 		return nil
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a bug that was introduced with #472. The control plane controller sometimes preserves the `.status.lastError` in the `ControlPlane` resource although the reconciliation succeeded. This is undesired behaviour and is fixed now.

**Special notes for your reviewer**:
What #472 tried to introduce was a retry mechanism for status update (like done in all other controllers). Though, the semantics of the functions was changed, leading to the bug.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
