### PR TITLE
React on operation annotation when value is "restore" and delete it before reconciliation

### DIFF
--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -158,7 +158,8 @@ func HasName(name string) predicate.Predicate {
 // HasOperationAnnotation is a predicate for the operation annotation.
 func HasOperationAnnotation() predicate.Predicate {
 	return FromMapper(MapperFunc(func(e event.GenericEvent) bool {
-		return e.Meta.GetAnnotations()[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationReconcile
+		return e.Meta.GetAnnotations()[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationReconcile ||
+			e.Meta.GetAnnotations()[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationRestore
 	}), CreateTrigger, UpdateNewTrigger, GenericTrigger)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Whit this PR the predicate HasOperationAnnotation will return true when the operation is "restore" and the OperationAnnotationWrapper will remove the annotation before reconciliation.
The Wrapper will react on the "restore" the same way as on "reconcile". 

**Which issue(s) this PR fixes**:
Part of [#1631](https://github.com/gardener/gardener/issues/1631)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
 The predicate HasOperationAnnotation will react on "resore" value returning true.
 The OperationAnnotationWrapper will remove operation annotation with value "restore" before reconciliation.
```
