### PR TITLE
Use machineclass constant from generic worker actuator

### DIFF
--- a/controllers/provider-alicloud/charts/internal/machineclass/templates/machineclass.yaml
+++ b/controllers/provider-alicloud/charts/internal/machineclass/templates/machineclass.yaml
@@ -5,8 +5,10 @@ kind: Secret
 metadata:
   name: {{ $machineClass.name }}
   namespace: {{ $.Release.Namespace }}
+{{- if $machineClass.labels }}
   labels:
-    garden.sapcloud.io/purpose: machineclass
+{{ toYaml $machineClass.labels | indent 4 }}
+{{- end }}
 type: Opaque
 data:
   userData: {{ $machineClass.secret.userData | b64enc }}

--- a/controllers/provider-alicloud/charts/internal/machineclass/values.yaml
+++ b/controllers/provider-alicloud/charts/internal/machineclass/values.yaml
@@ -1,5 +1,7 @@
 # machineClasses:
 # - name: class-1
+#   labels:
+#     foo: bar
 #   imageID: coreos_1745_7_0_64_30G_alibase_20180705.vhd
 #   instanceType: ecs.n1.medium
 #   region: cn-hangzhou

--- a/controllers/provider-alicloud/pkg/controller/worker/machines.go
+++ b/controllers/provider-alicloud/pkg/controller/worker/machines.go
@@ -24,7 +24,9 @@ import (
 	apisalicloud "github.com/gardener/gardener-extensions/controllers/provider-alicloud/pkg/apis/alicloud"
 	alicloudapihelper "github.com/gardener/gardener-extensions/controllers/provider-alicloud/pkg/apis/alicloud/helper"
 	"github.com/gardener/gardener-extensions/pkg/controller/worker"
+	genericworkeractuator "github.com/gardener/gardener-extensions/pkg/controller/worker/genericactuator"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -172,6 +174,9 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			})
 
 			machineClassSpec["name"] = className
+			machineClassSpec["labels"] = map[string]string{
+				v1beta1constants.GardenPurpose: genericworkeractuator.GardenPurposeMachineClass,
+			}
 			machineClassSpec["secret"].(map[string]interface{})[alicloud.AccessKeyID] = string(machineClassSecretData[machinev1alpha1.AlicloudAccessKeyID])
 			machineClassSpec["secret"].(map[string]interface{})[alicloud.AccessKeySecret] = string(machineClassSecretData[machinev1alpha1.AlicloudAccessKeySecret])
 

--- a/controllers/provider-alicloud/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-alicloud/pkg/controller/worker/machines_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/gardener/gardener-extensions/pkg/controller/common"
 	"path/filepath"
 
 	"github.com/gardener/gardener-extensions/controllers/provider-alicloud/pkg/alicloud"
@@ -26,11 +25,14 @@ import (
 	apiv1alpha1 "github.com/gardener/gardener-extensions/controllers/provider-alicloud/pkg/apis/alicloud/v1alpha1"
 	. "github.com/gardener/gardener-extensions/controllers/provider-alicloud/pkg/controller/worker"
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
+	"github.com/gardener/gardener-extensions/pkg/controller/common"
 	"github.com/gardener/gardener-extensions/pkg/controller/worker"
+	genericworkeractuator "github.com/gardener/gardener-extensions/pkg/controller/worker/genericactuator"
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	mockkubernetes "github.com/gardener/gardener-extensions/pkg/mock/gardener/client/kubernetes"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/golang/mock/gomock"
@@ -601,6 +603,9 @@ func useDefaultMachineClass(def map[string]interface{}, keyValues ...interface{}
 
 func addNameAndSecretToMachineClass(class map[string]interface{}, alicloudAccessKeyID, alicloudAccessKeySecret, name string) {
 	class["name"] = name
+	class["labels"] = map[string]string{
+		v1beta1constants.GardenPurpose: genericworkeractuator.GardenPurposeMachineClass,
+	}
 	class["secret"].(map[string]interface{})[alicloud.AccessKeyID] = alicloudAccessKeyID
 	class["secret"].(map[string]interface{})[alicloud.AccessKeySecret] = alicloudAccessKeySecret
 }

--- a/controllers/provider-aws/charts/internal/machineclass/templates/machineclass.yaml
+++ b/controllers/provider-aws/charts/internal/machineclass/templates/machineclass.yaml
@@ -5,8 +5,10 @@ kind: Secret
 metadata:
   name: {{ $machineClass.name }}
   namespace: {{ $.Release.Namespace }}
+{{- if $machineClass.labels }}
   labels:
 {{ toYaml $machineClass.labels | indent 4 }}
+{{- end }}
 type: Opaque
 data:
   userData: {{ $machineClass.secret.cloudConfig | b64enc }}

--- a/controllers/provider-aws/charts/internal/machineclass/values.yaml
+++ b/controllers/provider-aws/charts/internal/machineclass/values.yaml
@@ -1,5 +1,7 @@
 machineClasses:
 - name: class-1
+# labels:
+#   foo: bar
   ami: ami-123456
   region: eu-west-1
   machineType: m4.xlarge

--- a/controllers/provider-aws/pkg/controller/worker/machines.go
+++ b/controllers/provider-aws/pkg/controller/worker/machines.go
@@ -25,8 +25,9 @@ import (
 	"github.com/gardener/gardener-extensions/controllers/provider-aws/pkg/aws"
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	"github.com/gardener/gardener-extensions/pkg/controller/worker"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	genericworkeractuator "github.com/gardener/gardener-extensions/pkg/controller/worker/genericactuator"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -195,7 +196,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 
 			machineClassSpec["name"] = className
 			machineClassSpec["labels"] = map[string]string{
-				v1beta1constants.GardenPurpose: v1beta1constants.GardenPurposeMachineClass,
+				v1beta1constants.GardenPurpose: genericworkeractuator.GardenPurposeMachineClass,
 			}
 			machineClassSpec["secret"].(map[string]interface{})[aws.AccessKeyID] = string(machineClassSecretData[machinev1alpha1.AWSAccessKeyID])
 			machineClassSpec["secret"].(map[string]interface{})[aws.SecretAccessKey] = string(machineClassSecretData[machinev1alpha1.AWSSecretAccessKey])

--- a/controllers/provider-aws/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-aws/pkg/controller/worker/machines_test.go
@@ -18,21 +18,21 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/gardener/gardener-extensions/pkg/controller/common"
 	"path/filepath"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	api "github.com/gardener/gardener-extensions/controllers/provider-aws/pkg/apis/aws"
 	apiv1alpha1 "github.com/gardener/gardener-extensions/controllers/provider-aws/pkg/apis/aws/v1alpha1"
 	"github.com/gardener/gardener-extensions/controllers/provider-aws/pkg/aws"
 	. "github.com/gardener/gardener-extensions/controllers/provider-aws/pkg/controller/worker"
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
+	"github.com/gardener/gardener-extensions/pkg/controller/common"
 	"github.com/gardener/gardener-extensions/pkg/controller/worker"
+	genericworkeractuator "github.com/gardener/gardener-extensions/pkg/controller/worker/genericactuator"
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	mockkubernetes "github.com/gardener/gardener-extensions/pkg/mock/gardener/client/kubernetes"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/golang/mock/gomock"
@@ -43,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Machines", func() {
@@ -678,7 +679,7 @@ func useDefaultMachineClass(def map[string]interface{}, key string, value interf
 func addNameAndSecretToMachineClass(class map[string]interface{}, awsAccessKeyID, awsSecretAccessKey, name string) {
 	class["name"] = name
 	class["labels"] = map[string]string{
-		v1beta1constants.GardenPurpose: v1beta1constants.GardenPurposeMachineClass,
+		v1beta1constants.GardenPurpose: genericworkeractuator.GardenPurposeMachineClass,
 	}
 	class["secret"].(map[string]interface{})[aws.AccessKeyID] = awsAccessKeyID
 	class["secret"].(map[string]interface{})[aws.SecretAccessKey] = awsSecretAccessKey

--- a/controllers/provider-azure/charts/internal/machineclass/templates/machineclass.yaml
+++ b/controllers/provider-azure/charts/internal/machineclass/templates/machineclass.yaml
@@ -5,8 +5,10 @@ kind: Secret
 metadata:
   name: {{ $machineClass.name }}
   namespace: {{ $.Release.Namespace }}
+{{- if $machineClass.labels }}
   labels:
-    garden.sapcloud.io/purpose: machineclass
+{{ toYaml $machineClass.labels | indent 4 }}
+{{- end }}
 type: Opaque
 data:
   userData: {{ $machineClass.secret.cloudConfig | b64enc }}

--- a/controllers/provider-azure/charts/internal/machineclass/values.yaml
+++ b/controllers/provider-azure/charts/internal/machineclass/values.yaml
@@ -1,5 +1,7 @@
 machineClasses:
 - name: class-1-zone
+# labels:
+#   foo: bar
   region: westeurope
   resourceGroup: my-resource-group
   vnetName: my-vnet

--- a/controllers/provider-azure/pkg/controller/worker/machines.go
+++ b/controllers/provider-azure/pkg/controller/worker/machines.go
@@ -25,7 +25,9 @@ import (
 	"github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/azure"
 	"github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/internal"
 	"github.com/gardener/gardener-extensions/pkg/controller/worker"
+	genericworkeractuator "github.com/gardener/gardener-extensions/pkg/controller/worker/genericactuator"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -213,6 +215,9 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			machineDeployment.SecretName = className
 
 			machineClassSpec["name"] = className
+			machineClassSpec["labels"] = map[string]string{
+				v1beta1constants.GardenPurpose: genericworkeractuator.GardenPurposeMachineClass,
+			}
 			machineClassSpec["secret"].(map[string]interface{})[azure.ClientIDKey] = string(machineClassSecretData[machinev1alpha1.AzureClientID])
 			machineClassSpec["secret"].(map[string]interface{})[azure.ClientSecretKey] = string(machineClassSecretData[machinev1alpha1.AzureClientSecret])
 			machineClassSpec["secret"].(map[string]interface{})[azure.SubscriptionIDKey] = string(machineClassSecretData[machinev1alpha1.AzureSubscriptionID])

--- a/controllers/provider-azure/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-azure/pkg/controller/worker/machines_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/gardener/gardener-extensions/pkg/controller/common"
 	"path/filepath"
 
 	apisazure "github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/apis/azure"
@@ -26,11 +25,14 @@ import (
 	"github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/azure"
 	. "github.com/gardener/gardener-extensions/controllers/provider-azure/pkg/controller/worker"
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
+	"github.com/gardener/gardener-extensions/pkg/controller/common"
 	"github.com/gardener/gardener-extensions/pkg/controller/worker"
+	genericworkeractuator "github.com/gardener/gardener-extensions/pkg/controller/worker/genericactuator"
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	mockkubernetes "github.com/gardener/gardener-extensions/pkg/mock/gardener/client/kubernetes"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/golang/mock/gomock"
@@ -536,6 +538,9 @@ func expectGetSecretCallToWork(c *mockclient.MockClient, azureClientID, azureCli
 
 func addNameAndSecretsToMachineClass(class map[string]interface{}, azureClientID, azureClientSecret, azureSubscriptionID, azureTenantID, name string) {
 	class["name"] = name
+	class["labels"] = map[string]string{
+		v1beta1constants.GardenPurpose: genericworkeractuator.GardenPurposeMachineClass,
+	}
 	class["secret"].(map[string]interface{})[azure.ClientIDKey] = azureClientID
 	class["secret"].(map[string]interface{})[azure.ClientSecretKey] = azureClientSecret
 	class["secret"].(map[string]interface{})[azure.SubscriptionIDKey] = azureSubscriptionID

--- a/controllers/provider-gcp/charts/internal/machineclass/templates/machineclass.yaml
+++ b/controllers/provider-gcp/charts/internal/machineclass/templates/machineclass.yaml
@@ -5,8 +5,10 @@ kind: Secret
 metadata:
   name: {{ $machineClass.name }}
   namespace: {{ $.Release.Namespace }}
+{{- if $machineClass.labels }}
   labels:
-    garden.sapcloud.io/purpose: machineclass
+{{ toYaml $machineClass.labels | indent 4 }}
+{{- end }}
 type: Opaque
 data:
   userData: {{ $machineClass.secret.cloudConfig | b64enc }}

--- a/controllers/provider-gcp/charts/internal/machineclass/values.yaml
+++ b/controllers/provider-gcp/charts/internal/machineclass/values.yaml
@@ -1,5 +1,7 @@
 machineClasses:
 - name: class-1
+# labels:
+#   foo: bar
   region: europe-west1
   zone: europe-west1-b
   canIpForward: true

--- a/controllers/provider-gcp/pkg/controller/worker/machines.go
+++ b/controllers/provider-gcp/pkg/controller/worker/machines.go
@@ -25,7 +25,9 @@ import (
 	"github.com/gardener/gardener-extensions/controllers/provider-gcp/pkg/gcp"
 	"github.com/gardener/gardener-extensions/controllers/provider-gcp/pkg/internal"
 	"github.com/gardener/gardener-extensions/pkg/controller/worker"
+	genericworkeractuator "github.com/gardener/gardener-extensions/pkg/controller/worker/genericactuator"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -194,6 +196,9 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			})
 
 			machineClassSpec["name"] = className
+			machineClassSpec["labels"] = map[string]string{
+				v1beta1constants.GardenPurpose: genericworkeractuator.GardenPurposeMachineClass,
+			}
 			machineClassSpec["secret"].(map[string]interface{})[gcp.ServiceAccountJSONMCM] = string(machineClassSecretData[machinev1alpha1.GCPServiceAccountJSON])
 
 			machineClasses = append(machineClasses, machineClassSpec)

--- a/controllers/provider-gcp/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-gcp/pkg/controller/worker/machines_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/gardener/gardener-extensions/pkg/controller/common"
 	"path/filepath"
 
 	api "github.com/gardener/gardener-extensions/controllers/provider-gcp/pkg/apis/gcp"
@@ -26,11 +25,14 @@ import (
 	. "github.com/gardener/gardener-extensions/controllers/provider-gcp/pkg/controller/worker"
 	"github.com/gardener/gardener-extensions/controllers/provider-gcp/pkg/gcp"
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
+	"github.com/gardener/gardener-extensions/pkg/controller/common"
 	"github.com/gardener/gardener-extensions/pkg/controller/worker"
+	genericworkeractuator "github.com/gardener/gardener-extensions/pkg/controller/worker/genericactuator"
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	mockkubernetes "github.com/gardener/gardener-extensions/pkg/mock/gardener/client/kubernetes"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/golang/mock/gomock"
@@ -631,5 +633,8 @@ func useDefaultMachineClass(def map[string]interface{}, key string, value interf
 
 func addNameAndSecretToMachineClass(class map[string]interface{}, serviceAccountJSON, name string) {
 	class["name"] = name
+	class["labels"] = map[string]string{
+		v1beta1constants.GardenPurpose: genericworkeractuator.GardenPurposeMachineClass,
+	}
 	class["secret"].(map[string]interface{})[gcp.ServiceAccountJSONMCM] = serviceAccountJSON
 }

--- a/controllers/provider-openstack/charts/internal/machineclass/templates/machineclass.yaml
+++ b/controllers/provider-openstack/charts/internal/machineclass/templates/machineclass.yaml
@@ -5,8 +5,10 @@ kind: Secret
 metadata:
   name: {{ $machineClass.name }}
   namespace: {{ $.Release.Namespace }}
+{{- if $machineClass.labels }}
   labels:
-    garden.sapcloud.io/purpose: machineclass
+{{ toYaml $machineClass.labels | indent 4 }}
+{{- end }}
 type: Opaque
 data:
   userData: {{ $machineClass.secret.cloudConfig | b64enc }}

--- a/controllers/provider-openstack/charts/internal/machineclass/values.yaml
+++ b/controllers/provider-openstack/charts/internal/machineclass/values.yaml
@@ -1,5 +1,7 @@
 machineClasses:
 - name: class-1
+# labels:
+#   foo: bar
   region: europe-1
   availabilityZone: europe-1a
   machineType: medium_2_4

--- a/controllers/provider-openstack/pkg/controller/worker/machines.go
+++ b/controllers/provider-openstack/pkg/controller/worker/machines.go
@@ -25,7 +25,9 @@ import (
 	"github.com/gardener/gardener-extensions/controllers/provider-openstack/pkg/openstack"
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	"github.com/gardener/gardener-extensions/pkg/controller/worker"
+	genericworkeractuator "github.com/gardener/gardener-extensions/pkg/controller/worker/genericactuator"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -165,6 +167,9 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			})
 
 			machineClassSpec["name"] = className
+			machineClassSpec["labels"] = map[string]string{
+				v1beta1constants.GardenPurpose: genericworkeractuator.GardenPurposeMachineClass,
+			}
 			machineClassSpec["secret"].(map[string]interface{})[openstack.AuthURL] = string(machineClassSecretData[machinev1alpha1.OpenStackAuthURL])
 			machineClassSpec["secret"].(map[string]interface{})[openstack.DomainName] = string(machineClassSecretData[machinev1alpha1.OpenStackDomainName])
 			machineClassSpec["secret"].(map[string]interface{})[openstack.TenantName] = string(machineClassSecretData[machinev1alpha1.OpenStackTenantName])

--- a/controllers/provider-openstack/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-openstack/pkg/controller/worker/machines_test.go
@@ -27,10 +27,12 @@ import (
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	"github.com/gardener/gardener-extensions/pkg/controller/common"
 	"github.com/gardener/gardener-extensions/pkg/controller/worker"
+	genericworkeractuator "github.com/gardener/gardener-extensions/pkg/controller/worker/genericactuator"
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	mockkubernetes "github.com/gardener/gardener-extensions/pkg/mock/gardener/client/kubernetes"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/golang/mock/gomock"
@@ -617,6 +619,9 @@ func useDefaultMachineClass(def map[string]interface{}, key string, value interf
 
 func addNameAndSecretToMachineClass(class map[string]interface{}, openstackAuthURL, openstackDomainName, openstackTenantName, openstackUserName, openstackPassword, name string) {
 	class["name"] = name
+	class["labels"] = map[string]string{
+		v1beta1constants.GardenPurpose: genericworkeractuator.GardenPurposeMachineClass,
+	}
 	class["secret"].(map[string]interface{})[openstack.AuthURL] = openstackAuthURL
 	class["secret"].(map[string]interface{})[openstack.DomainName] = openstackDomainName
 	class["secret"].(map[string]interface{})[openstack.TenantName] = openstackTenantName

--- a/controllers/provider-packet/charts/internal/machineclass/templates/machineclass.yaml
+++ b/controllers/provider-packet/charts/internal/machineclass/templates/machineclass.yaml
@@ -5,8 +5,10 @@ kind: Secret
 metadata:
   name: {{ $machineClass.name }}
   namespace: {{ $.Release.Namespace }}
+{{- if $machineClass.labels }}
   labels:
-    garden.sapcloud.io/purpose: machineclass
+{{ toYaml $machineClass.labels | indent 4 }}
+{{- end }}
 type: Opaque
 data:
   userData: {{ $machineClass.secret.cloudConfig | b64enc }}

--- a/controllers/provider-packet/charts/internal/machineclass/values.yaml
+++ b/controllers/provider-packet/charts/internal/machineclass/values.yaml
@@ -1,5 +1,7 @@
 machineClasses:
 - name: class-1
+# labels:
+#   foo: bar
   projectID: abcd-1234-fff
   OS: alpine_3
   billingCycle: hourly

--- a/controllers/provider-packet/pkg/controller/worker/machines.go
+++ b/controllers/provider-packet/pkg/controller/worker/machines.go
@@ -24,7 +24,9 @@ import (
 	"github.com/gardener/gardener-extensions/controllers/provider-packet/pkg/packet"
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	"github.com/gardener/gardener-extensions/pkg/controller/worker"
+	genericworkeractuator "github.com/gardener/gardener-extensions/pkg/controller/worker/genericactuator"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -144,6 +146,9 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 		})
 
 		machineClassSpec["name"] = className
+		machineClassSpec["labels"] = map[string]string{
+			v1beta1constants.GardenPurpose: genericworkeractuator.GardenPurposeMachineClass,
+		}
 		machineClassSpec["secret"].(map[string]interface{})[packet.APIToken] = string(machineClassSecretData[machinev1alpha1.PacketAPIKey])
 
 		machineClasses = append(machineClasses, machineClassSpec)

--- a/controllers/provider-packet/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-packet/pkg/controller/worker/machines_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	api "github.com/gardener/gardener-extensions/controllers/provider-packet/pkg/apis/packet"
 	apiv1alpha1 "github.com/gardener/gardener-extensions/controllers/provider-packet/pkg/apis/packet/v1alpha1"
 	. "github.com/gardener/gardener-extensions/controllers/provider-packet/pkg/controller/worker"
@@ -25,13 +26,14 @@ import (
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	"github.com/gardener/gardener-extensions/pkg/controller/common"
 	"github.com/gardener/gardener-extensions/pkg/controller/worker"
+	genericworkeractuator "github.com/gardener/gardener-extensions/pkg/controller/worker/genericactuator"
 	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
 	mockkubernetes "github.com/gardener/gardener-extensions/pkg/mock/gardener/client/kubernetes"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
+
 	"path/filepath"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/golang/mock/gomock"
@@ -40,7 +42,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Machines", func() {
@@ -453,5 +457,8 @@ func copyMachineClass(def map[string]interface{}) map[string]interface{} {
 
 func addNameAndSecretToMachineClass(class map[string]interface{}, packetAPIToken, name string) {
 	class["name"] = name
+	class["labels"] = map[string]string{
+		v1beta1constants.GardenPurpose: genericworkeractuator.GardenPurposeMachineClass,
+	}
 	class["secret"].(map[string]interface{})[packet.APIToken] = packetAPIToken
 }

--- a/pkg/controller/worker/genericactuator/actuator.go
+++ b/pkg/controller/worker/genericactuator/actuator.go
@@ -38,6 +38,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 )
 
+// GardenPurposeMachineClass is a constant for the 'machineclass' value in a label.
+const GardenPurposeMachineClass = "machineclass"
+
 type genericActuator struct {
 	logger logr.Logger
 
@@ -158,7 +161,7 @@ func (a *genericActuator) listMachineClassSecrets(ctx context.Context, namespace
 	var (
 		secretList = &corev1.SecretList{}
 		labels     = map[string]string{
-			v1beta1constants.GardenPurpose: v1beta1constants.GardenPurposeMachineClass,
+			v1beta1constants.GardenPurpose: GardenPurposeMachineClass,
 		}
 	)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The machine class constant is now stored in the generic worker actuator package. The extensions now use it from there and expose the machine class labels as Helm chart values so that they can be properly injected.

**Special notes for your reviewer**:
Follow-up of https://github.com/gardener/gardener/pull/1804

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
