### PR TITLE
Fix networking-calico local dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,8 @@ start-networking-calico:
 		-ldflags $(LD_FLAGS) \
 		./controllers/networking-calico/cmd/gardener-extension-networking-calico \
 		--ignore-operation-annotation=$(IGNORE_OPERATION_ANNOTATION) \
-		--leader-election=$(LEADER_ELECTION)
+		--leader-election=$(LEADER_ELECTION) \
+		--config-file=./controllers/networking-calico/example/00-componentconfig.yaml
 
 .PHONY: start-shoot-dns-service
 start-shoot-dns-service:


### PR DESCRIPTION
**What this PR does / why we need it**:
The networking-calico extension is missing the config flag after https://github.com/gardener/gardener-extensions/pull/541 in its `Makefile`. This PR adds the missing flag. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
