### PR TITLE
Use  instead of  until old API group is removed

### DIFF
--- a/controllers/provider-alicloud/test/tm/generator.go
+++ b/controllers/provider-alicloud/test/tm/generator.go
@@ -59,8 +59,9 @@ func main() {
 			},
 			Zones: []v1alpha1.Zone{
 				{
-					Name:    *zone,
-					Workers: *networkWorkerCidr,
+					Name: *zone,
+					// TODO: change this to `Workers` once garden.sapcloud.io API group is removed
+					Worker: *networkWorkerCidr,
 				},
 			},
 		},

--- a/controllers/provider-gcp/test/tm/generator.go
+++ b/controllers/provider-gcp/test/tm/generator.go
@@ -53,7 +53,8 @@ func main() {
 			Kind:       reflect.TypeOf(v1alpha1.InfrastructureConfig{}).Name(),
 		},
 		Networks: v1alpha1.NetworkConfig{
-			Workers: *networkWorkerCidr,
+			// TODO: change this to `Workers` once garden.sapcloud.io API group is removed
+			Worker: *networkWorkerCidr,
 		},
 	}
 

--- a/controllers/provider-openstack/test/tm/generator.go
+++ b/controllers/provider-openstack/test/tm/generator.go
@@ -56,7 +56,8 @@ func main() {
 		},
 		FloatingPoolName: *floatingPoolName,
 		Networks: v1alpha1.Networks{
-			Workers: *networkWorkerCidr,
+			// TODO: change this to `Workers` once garden.sapcloud.io API group is removed
+			Worker: *networkWorkerCidr,
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Until the deprecated `garden.sapcloud.io` API group is removed we have to keep using the old `worker` field instead of `workers`, otherwise Gardener API server will reject:

```
time="2020-01-14T16:18:16Z" level=debug msg="unable to create shoot tm-v39-ujw: Shoot.core.gardener.cloud \"tm-v39-ujw\" is invalid: spec.cloud.alicloud.networks.workers[0]: Invalid value: \"\": invalid CIDR address: "
```

/cc @schrodit 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
