### PR TITLE
Rename introduced labels to resourceLabels as labels is already taken

### DIFF
--- a/controllers/provider-gcp/charts/internal/machineclass/templates/machineclass.yaml
+++ b/controllers/provider-gcp/charts/internal/machineclass/templates/machineclass.yaml
@@ -5,9 +5,9 @@ kind: Secret
 metadata:
   name: {{ $machineClass.name }}
   namespace: {{ $.Release.Namespace }}
-{{- if $machineClass.labels }}
+{{- if $machineClass.resourceLabels }}
   labels:
-{{ toYaml $machineClass.labels | indent 4 }}
+{{ toYaml $machineClass.resourceLabels | indent 4 }}
 {{- end }}
 type: Opaque
 data:

--- a/controllers/provider-gcp/charts/internal/machineclass/values.yaml
+++ b/controllers/provider-gcp/charts/internal/machineclass/values.yaml
@@ -1,6 +1,6 @@
 machineClasses:
 - name: class-1
-# labels:
+# resourceLabels:
 #   foo: bar
   region: europe-west1
   zone: europe-west1-b

--- a/controllers/provider-gcp/pkg/controller/worker/machines.go
+++ b/controllers/provider-gcp/pkg/controller/worker/machines.go
@@ -196,7 +196,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			})
 
 			machineClassSpec["name"] = className
-			machineClassSpec["labels"] = map[string]string{
+			machineClassSpec["resourceLabels"] = map[string]string{
 				v1beta1constants.GardenPurpose: genericworkeractuator.GardenPurposeMachineClass,
 			}
 			machineClassSpec["secret"].(map[string]interface{})[gcp.ServiceAccountJSONMCM] = string(machineClassSecretData[machinev1alpha1.GCPServiceAccountJSON])

--- a/controllers/provider-gcp/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-gcp/pkg/controller/worker/machines_test.go
@@ -633,7 +633,7 @@ func useDefaultMachineClass(def map[string]interface{}, key string, value interf
 
 func addNameAndSecretToMachineClass(class map[string]interface{}, serviceAccountJSON, name string) {
 	class["name"] = name
-	class["labels"] = map[string]string{
+	class["resourceLabels"] = map[string]string{
 		v1beta1constants.GardenPurpose: genericworkeractuator.GardenPurposeMachineClass,
 	}
 	class["secret"].(map[string]interface{})[gcp.ServiceAccountJSONMCM] = serviceAccountJSON


### PR DESCRIPTION
**What this PR does / why we need it**:
The `labels` field in the GCP machine class was already taken, but then we introduced `labels` again with https://github.com/gardener/gardener-extensions/pull/548 with led to conflicts. This PR fixes this.

**Special notes for your reviewer**:
/cc @hardikdr 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
