### PR TITLE
Update golangci/golangci-lint to v1.20.1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@
 !VERSION
 !Makefile
 !.gitignore
+!.golangci.yaml
 !go.mod
 !go.sum
 !test/

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,6 @@
+run:
+  deadline: 7m
+
+linters:
+  disable:
+  - unused

--- a/hack/check.sh
+++ b/hack/check.sh
@@ -24,7 +24,7 @@ echo "Executing check-generate"
 "$DIRNAME"/check-generate.sh
 
 echo "Executing golangci-lint"
-golangci-lint run --deadline 7m "${SOURCE_TREES[@]}"
+golangci-lint run -c "$DIRNAME"/../.golangci.yaml "${SOURCE_TREES[@]}"
 
 echo "Checking for format issues with gofmt"
 unformatted_files="$(gofmt -l controllers pkg)"

--- a/hack/install-requirements.sh
+++ b/hack/install-requirements.sh
@@ -24,7 +24,7 @@ go install -mod=vendor ./vendor/github.com/gobuffalo/packr/v2/packr2
 go install -mod=vendor ./vendor/github.com/onsi/ginkgo/ginkgo
 go install -mod=vendor ./vendor/github.com/golang/mock/mockgen
 go install -mod=vendor ./vendor/github.com/ahmetb/gen-crd-api-reference-docs
-curl -sfL "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh" | sh -s -- -b $(go env GOPATH)/bin v1.18.0
+curl -sfL "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh" | sh -s -- -b $(go env GOPATH)/bin v1.20.1
 curl -s "https://raw.githubusercontent.com/helm/helm/v2.13.1/scripts/get" | bash -s -- --version 'v2.13.1'
 
 if [[ "$(uname -s)" == *"Darwin"* ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently we experience high memory usage for golangci-lint runs which most often breaks the ci/cd run.
With the current master branch and a local container with 5GB limit the `golangci-lint` is getting OOMKilled trying to consume almost all of the memory.

Several improvements:
- Update to golangci/golangci-lint to v1.20.1 which according to release notes has improved memory usage (ref https://github.com/golangci/golangci-lint/releases/tag/v1.20.0). (We don't update to the latest one because of the flakes we hit with it - ref #534).
- Disable the `unused` linter.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
