### PR TITLE
Remove support for public IPs in GCP

### DIFF
--- a/controllers/provider-gcp/pkg/controller/worker/machines.go
+++ b/controllers/provider-gcp/pkg/controller/worker/machines.go
@@ -133,10 +133,6 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 		}
 
 		for zoneIndex, zone := range pool.Zones {
-			var disableExternalIP = false
-			if infrastructureStatus.Networks.VPC.CloudRouter != nil {
-				disableExternalIP = true
-			}
 			machineClassSpec := map[string]interface{}{
 				"region":             w.worker.Spec.Region,
 				"zone":               zone,
@@ -151,7 +147,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				"networkInterfaces": []map[string]interface{}{
 					{
 						"subnetwork":        nodesSubnet.Name,
-						"disableExternalIP": disableExternalIP,
+						"disableExternalIP": true,
 					},
 				},
 				"scheduling": map[string]interface{}{

--- a/controllers/provider-gcp/pkg/controller/worker/machines_test.go
+++ b/controllers/provider-gcp/pkg/controller/worker/machines_test.go
@@ -417,55 +417,6 @@ var _ = Describe("Machines", func() {
 						},
 					}
 				}
-
-				It("should return the expected machine deployments when disableExternal IP is false for profile image types", func() {
-
-					workerDelegate, _ = NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster)
-
-					expectGetSecretCallToWork(c, serviceAccountJSON)
-
-					// Test workerDelegate.DeployMachineClasses()
-					setup(false)
-
-					chartApplier.
-						EXPECT().
-						ApplyChart(
-							context.TODO(),
-							filepath.Join(gcp.InternalChartsPath, "machineclass"),
-							namespace,
-							"machineclass",
-							machineClasses,
-							nil,
-						).
-						Return(nil)
-
-					err := workerDelegate.DeployMachineClasses(context.TODO())
-					Expect(err).NotTo(HaveOccurred())
-
-					// Test workerDelegate.GetMachineImages()
-					machineImages, err := workerDelegate.GetMachineImages(context.TODO())
-					Expect(machineImages).To(Equal(&apiv1alpha1.WorkerStatus{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
-							Kind:       "WorkerStatus",
-						},
-						MachineImages: []apiv1alpha1.MachineImage{
-							{
-								Name:    machineImageName,
-								Version: machineImageVersion,
-								Image:   machineImage,
-							},
-						},
-					}))
-					Expect(err).NotTo(HaveOccurred())
-
-					// Test workerDelegate.GenerateMachineDeployments()
-
-					result, err := workerDelegate.GenerateMachineDeployments(context.TODO())
-					Expect(err).NotTo(HaveOccurred())
-					Expect(result).To(Equal(machineDeployments))
-				})
-
 				It("should return the expected machine deployments when disableExternal IP is true with profile image types", func() {
 					expectGetSecretCallToWork(c, serviceAccountJSON)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR completely removes support for public IPs in GCP. All egress traffic should be routed via CloudNAT. 

**Which issue(s) this PR fixes**:
Fixes #408 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Support for public IPs is now completely removed and new machines will get no public IPs.
```
```action user
It is now mandatory to specify a CloudRouter configuration for GCP shoots (i.e., name) if a VPC is re-used. The Gardener landscape operator should ensure that this is done for all GCP shoots before updating to this version.
```
