### PR TITLE
[ci:component:github.com/gardener/external-dns-management:v0.7.4->v0.7.5]

### DIFF
--- a/controllers/extension-shoot-dns-service/charts/images.yaml
+++ b/controllers/extension-shoot-dns-service/charts/images.yaml
@@ -2,4 +2,4 @@ images:
 - name: dns-controller-manager
   sourceRepository: github.com/gardener/external-dns-management
   repository: eu.gcr.io/gardener-project/dns-controller-manager
-  tag: "v0.7.4"
+  tag: "v0.7.5"


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/external-dns-management #53 @MartinWeindel
fixing TXT record creation for bug introduced with v0.7.4
```