### PR TITLE
Upgrade Calico to v3.11.2

### DIFF
--- a/controllers/networking-calico/charts/images.yaml
+++ b/controllers/networking-calico/charts/images.yaml
@@ -2,23 +2,23 @@ images:
 - name: calico-node
   sourceRepository: github.com/projectcalico/calico
   repository: quay.io/calico/node
-  tag: v3.8.2
+  tag: v3.11.2
 - name: calico-cni
   sourceRepository: github.com/projectcalico/cni-plugin
   repository: quay.io/calico/cni
-  tag: v3.8.2
+  tag: v3.11.2
 - name: calico-typha
   sourceRepository: github.com/projectcalico/typha
   repository: quay.io/calico/typha
-  tag: v3.8.2
+  tag: v3.11.2
 - name: calico-kube-controllers
   sourceRepository: github.com/projectcalico/kube-controllers
   repository: quay.io/calico/kube-controllers
-  tag: v3.8.2
+  tag: v3.11.2
 - name: calico-podtodaemon-flex
   sourceRepository: github.com/projectcalico/pod2daemon
   repository: quay.io/calico/pod2daemon-flexvol
-  tag: v3.8.2
+  tag: v3.11.2
 - name: typha-cpa
   sourceRepository: github.com/kubernetes-incubator/cluster-proportional-autoscaler
   repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64

--- a/controllers/networking-calico/charts/internal/calico/templates/node/clusterrole-calico-node.yaml
+++ b/controllers/networking-calico/charts/internal/calico/templates/node/clusterrole-calico-node.yaml
@@ -70,6 +70,7 @@ rules:
       - networksets
       - clusterinformations
       - hostendpoints
+      - blockaffinities
     verbs:
       - get
       - list

--- a/controllers/networking-calico/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
+++ b/controllers/networking-calico/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
@@ -99,6 +99,9 @@ spec:
             host: localhost
           periodSeconds: 30
           initialDelaySeconds: 30
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
         readinessProbe:
           httpGet:
             path: /readiness


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade Calico to v3.11.2

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Calico now runs on version 3.11.2.
```
