### PR TITLE
Add v1beta1 shoots to AWS webhook chart

### DIFF
--- a/controllers/provider-aws/charts/validator-aws/charts/application/templates/validatingwebhook-validator.yaml
+++ b/controllers/provider-aws/charts/validator-aws/charts/application/templates/validatingwebhook-validator.yaml
@@ -9,6 +9,7 @@ webhooks:
     - "core.gardener.cloud"
     apiVersions:
     - v1alpha1
+    - v1beta1
     operations:
     - CREATE
     - UPDATE


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds v1beta1 shoots to the AWS webhook chart.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The AWS validating webhook chart now also includes `v1beta1` shoots in group `core.gardener.cloud`.
```
