### PR TITLE
Added custom OpenStack root disk size

### DIFF
--- a/controllers/provider-openstack/charts/internal/machineclass/templates/machineclass.yaml
+++ b/controllers/provider-openstack/charts/internal/machineclass/templates/machineclass.yaml
@@ -36,6 +36,9 @@ spec:
 {{- end }}
   networkID: {{ $machineClass.networkID }}
   podNetworkCidr: {{ $machineClass.podNetworkCidr }}
+{{- if $machienClass.rootDiskSize }}
+  rootDiskSize: {{ $machineClass.rootDiskSize }}
+{{- end}}
   securityGroups:
 {{ toYaml $machineClass.securityGroups | indent 2 }}
   secretRef:

--- a/controllers/provider-openstack/charts/internal/machineclass/values.yaml
+++ b/controllers/provider-openstack/charts/internal/machineclass/values.yaml
@@ -10,6 +10,7 @@ machineClasses:
   #imageID: 836428cd-5f98-1305-af9d-9825d4dfd0ec
   networkID: 426428cd-5e88-4005-9fad-9555d4dfd0fb
   podNetworkCidr: 100.96.0.0/11
+  # rootDiskSize: 100 # 100GB
   securityGroups:
   - my-security-group
   tags:

--- a/controllers/provider-openstack/example/30-worker.yaml
+++ b/controllers/provider-openstack/example/30-worker.yaml
@@ -89,6 +89,9 @@ spec:
     maximum: 1
     maxSurge: 1
     maxUnavailable: 0
+  #  volume: # overrides the default flavor root disk size and uses a cinder backed block device instead
+  #    type: default
+  #    size: 20Gi
   # labels:
   #   key: value
   # annotations:

--- a/controllers/provider-openstack/pkg/controller/worker/machines.go
+++ b/controllers/provider-openstack/pkg/controller/worker/machines.go
@@ -124,6 +124,14 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 		}
 		machineImages = appendMachineImage(machineImages, *machineImage)
 
+		var volumeSize int
+		if pool.Volume != nil {
+			volumeSize, err = worker.DiskSize(pool.Volume.Size)
+			if err != nil {
+				return err
+			}
+		}
+
 		for zoneIndex, zone := range pool.Zones {
 			machineClassSpec := map[string]interface{}{
 				"region":           w.worker.Spec.Region,
@@ -140,6 +148,10 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				"secret": map[string]interface{}{
 					"cloudConfig": string(pool.UserData),
 				},
+			}
+
+			if volumeSize > 0 {
+				machineClassSpec["rootDiskSize"] = volumeSize
 			}
 
 			if machineImage.ID != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
Added support for custom root disk size in OpenStack. 

/ref https://github.com/gardener/machine-controller-manager/pull/388

**Release note**:
```improvement operator
Added support for custom root disk size in OpenStack
```
