### PR TITLE
Increase log level for successful health checks

### DIFF
--- a/pkg/controller/healthcheck/reconciler.go
+++ b/pkg/controller/healthcheck/reconciler.go
@@ -147,7 +147,7 @@ func (r *reconciler) performHealthCheck(ctx context.Context, request reconcile.R
 			continue
 		}
 
-		r.logger.Info("Health check for extension resource successful.", "kind", r.registeredExtension.groupVersionKind.Kind, "health condition type", healthCheckResult.HealthConditionType, "name", request.Name, "Namespace", request.Namespace)
+		r.logger.V(6).Info("Health check for extension resource successful.", "kind", r.registeredExtension.groupVersionKind.Kind, "health condition type", healthCheckResult.HealthConditionType, "name", request.Name, "Namespace", request.Namespace)
 		if err := r.updateExtensionConditionToSuccessful(ctx, r.registeredExtension.extension, &rawExtension, healthCondition, healthCheckResult); err != nil {
 			return r.resultWithRequeue(), err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
We don't need to log if the health checks were successful. Only errors are relevant.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
