### PR TITLE
Support for slice of similar type of operatingsystemconfigs

### DIFF
--- a/controllers/os-coreos-alicloud/pkg/coreos-alicloud/add.go
+++ b/controllers/os-coreos-alicloud/pkg/coreos-alicloud/add.go
@@ -21,12 +21,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-// Type is the type of operating system configs the CoreOS Alicloud controller monitors.
-const Type = "coreos-alicloud"
-
 var (
 	// DefaultAddOptions are the default controller.Options for AddToManager.
 	DefaultAddOptions = AddOptions{}
+	// Types is the type of operating system configs the CoreOS Alicloud controller monitors.
+	Types = []string{"coreos-alicloud"}
 )
 
 // AddOptions are the options for adding the controller to the manager.
@@ -44,7 +43,7 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 		Actuator:          NewActuator(),
 		ControllerOptions: opts.Controller,
 		Predicates:        operatingsystemconfig.DefaultPredicates(opts.IgnoreOperationAnnotation),
-		Type:              Type,
+		Types:             Types,
 	})
 }
 

--- a/controllers/os-coreos/pkg/coreos/add.go
+++ b/controllers/os-coreos/pkg/coreos/add.go
@@ -21,12 +21,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-// Type is the type of OperatingSystemConfigs the coreos actuator / predicate are built for.
-const Type = "coreos"
-
 var (
 	// DefaultAddOptions are the default controller.Options for AddToManager.
 	DefaultAddOptions = AddOptions{}
+	// Types is the type of OperatingSystemConfigs the coreos actuator / predicate are built for.
+	Types = []string{"coreos"}
 )
 
 // AddOptions are the options for adding the controller to the manager.
@@ -44,7 +43,7 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 		Actuator:          NewActuator(),
 		ControllerOptions: opts.Controller,
 		Predicates:        operatingsystemconfig.DefaultPredicates(opts.IgnoreOperationAnnotation),
-		Type:              Type,
+		Types:             Types,
 	})
 }
 

--- a/pkg/controller/backupbucket/controller.go
+++ b/pkg/controller/backupbucket/controller.go
@@ -74,7 +74,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, args AddArgs) error {
 	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator)
-	predicates := extensionspredicate.AddTypePredicate(args.Type, args.Predicates)
+	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
 	return add(mgr, args.ControllerOptions, predicates)
 }
 

--- a/pkg/controller/backupentry/controller.go
+++ b/pkg/controller/backupentry/controller.go
@@ -74,7 +74,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, args AddArgs) error {
 	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator)
-	predicates := extensionspredicate.AddTypePredicate(args.Type, args.Predicates)
+	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
 	return add(mgr, args.ControllerOptions, predicates)
 }
 

--- a/pkg/controller/controlplane/controller.go
+++ b/pkg/controller/controlplane/controller.go
@@ -80,7 +80,7 @@ func Add(mgr manager.Manager, args AddArgs) error {
 		return err
 	}
 
-	predicates := extensionspredicate.AddTypePredicate(args.Type, args.Predicates)
+	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
 
 	if err := ctrl.Watch(&source.Kind{Type: &extensionsv1alpha1.ControlPlane{}}, &handler.EnqueueRequestForObject{}, predicates...); err != nil {
 		return err

--- a/pkg/controller/extension/reconciler.go
+++ b/pkg/controller/extension/reconciler.go
@@ -99,7 +99,7 @@ func add(mgr manager.Manager, args AddArgs) error {
 		return err
 	}
 
-	predicates := extensionspredicate.AddTypePredicate(args.Type, args.Predicates)
+	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
 
 	if err := ctrl.Watch(&source.Kind{Type: &extensionsv1alpha1.Extension{}}, &handler.EnqueueRequestForObject{}, predicates...); err != nil {
 		return err

--- a/pkg/controller/healthcheck/controller.go
+++ b/pkg/controller/healthcheck/controller.go
@@ -160,7 +160,7 @@ func add(mgr manager.Manager, args AddArgs) error {
 	if err != nil {
 		return err
 	}
-	predicates := extensionspredicate.AddTypePredicate(args.Type, args.Predicates)
+	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
 
 	log.Log.Info("Registered health check controller", "Kind", args.registeredExtension.groupVersionKind.Kind, "type", args.Type, "health check type", args.registeredExtension.healthConditionType, "sync period", args.SyncPeriod.Duration.String())
 

--- a/pkg/controller/infrastructure/controller.go
+++ b/pkg/controller/infrastructure/controller.go
@@ -88,7 +88,7 @@ func add(mgr manager.Manager, args AddArgs) error {
 		return err
 	}
 
-	predicates := extensionspredicate.AddTypePredicate(args.Type, args.Predicates)
+	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
 
 	if err := ctrl.Watch(&source.Kind{Type: &extensionsv1alpha1.Infrastructure{}}, &handler.EnqueueRequestForObject{}, predicates...); err != nil {
 		return err

--- a/pkg/controller/network/controller.go
+++ b/pkg/controller/network/controller.go
@@ -84,7 +84,7 @@ func add(mgr manager.Manager, args AddArgs) error {
 		return err
 	}
 
-	predicates := extensionspredicate.AddTypePredicate(args.Type, args.Predicates)
+	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
 
 	if err := ctrl.Watch(&source.Kind{Type: &extensionsv1alpha1.Network{}}, &handler.EnqueueRequestForObject{}, predicates...); err != nil {
 		return err

--- a/pkg/controller/operatingsystemconfig/controller.go
+++ b/pkg/controller/operatingsystemconfig/controller.go
@@ -46,14 +46,15 @@ type AddArgs struct {
 	// Predicates are the predicates to use.
 	// If unset, GenerationChangedPredicate will be used.
 	Predicates []predicate.Predicate
-	// Type is the type of the resource considered for reconciliation.
-	Type string
+	// Types are the similar types which can be combined with a logic or,
+	// of the resource considered for reconciliation.
+	Types []string
 }
 
 // Add adds an operatingsystemconfig controller to the given manager using the given AddArgs.
 func Add(mgr manager.Manager, args AddArgs) error {
 	args.ControllerOptions.Reconciler = NewReconciler(args.Actuator)
-	predicates := extensionspredicate.AddTypePredicate(args.Type, args.Predicates)
+	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Types...)
 	return add(mgr, args.ControllerOptions, predicates)
 }
 

--- a/pkg/controller/operatingsystemconfig/oscommon/add.go
+++ b/pkg/controller/operatingsystemconfig/oscommon/add.go
@@ -40,7 +40,7 @@ func AddToManagerWithOptions(mgr manager.Manager, os string, generator generator
 	return operatingsystemconfig.Add(mgr, operatingsystemconfig.AddArgs{
 		Actuator:          actuator.NewActuator(os, generator),
 		Predicates:        operatingsystemconfig.DefaultPredicates(opts.IgnoreOperationAnnotation),
-		Type:              os,
+		Types:             []string{os},
 		ControllerOptions: opts.Controller,
 	})
 }

--- a/pkg/controller/worker/controller.go
+++ b/pkg/controller/worker/controller.go
@@ -74,7 +74,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, args AddArgs) error {
 	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator)
-	predicates := extensionspredicate.AddTypePredicate(args.Type, args.Predicates)
+	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
 	return add(mgr, args.ControllerOptions, predicates)
 }
 

--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -199,10 +199,23 @@ func IsDeleting() predicate.Predicate {
 }
 
 // AddTypePredicate returns a new slice which contains a type predicate and the given `predicates`.
-func AddTypePredicate(extensionType string, predicates []predicate.Predicate) []predicate.Predicate {
-	preds := make([]predicate.Predicate, 0, len(predicates)+1)
-	preds = append(preds, HasType(extensionType))
-	return append(preds, predicates...)
+// if more than one extensionTypes is given all given types are or combined
+func AddTypePredicate(predicates []predicate.Predicate, extensionTypes ...string) []predicate.Predicate {
+	resultPredicates := make([]predicate.Predicate, 0, len(predicates)+1)
+	resultPredicates = append(resultPredicates, predicates...)
+
+	if len(extensionTypes) == 1 {
+		resultPredicates = append(resultPredicates, HasType(extensionTypes[0]))
+		return resultPredicates
+	}
+
+	orPreds := make([]predicate.Predicate, 0, len(extensionTypes))
+	for _, extensionType := range extensionTypes {
+		orPreds = append(orPreds, HasType(extensionType))
+	}
+	orPred := Or(orPreds...)
+
+	return append(resultPredicates, orPred)
 }
 
 // HasPurpose filters the incoming Controlplanes  for the given spec.purpose


### PR DESCRIPTION
**What this PR does / why we need it**:
For OS Extensions which have to handle semantically identical OS derivates like ubuntu/debian, or coreos/flatcar, two almost identical controllers have to be written.

Modify the AddArgs to support slice of types which are or´ed afterwards.

All affected os-controllers are modified to match.

Closes  #318

```noteworthy developer
All extension controllers can now provide multiple extension types instead of only one. This allows to bundle multiple responsibilities into the same extension controller.
```