### PR TITLE
[WIP]Add Migrate functionality in the worker generic actuator

### DIFF
--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -175,6 +175,17 @@ func DeleteFinalizer(ctx context.Context, client client.Client, finalizerName st
 	return client.Update(ctx, obj)
 }
 
+// DeleteAllFinalizers removes all finalizers from the object and issues an update.
+func DeleteAllFinalizers(ctx context.Context, client client.Client, obj runtime.Object) error {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	accessor.SetFinalizers([]string{})
+	return client.Update(ctx, obj)
+}
+
 // SecretReferenceToKey returns the key of the given SecretReference.
 func SecretReferenceToKey(ref *corev1.SecretReference) client.ObjectKey {
 	return kutil.Key(ref.Namespace, ref.Name)

--- a/pkg/controller/worker/actuator.go
+++ b/pkg/controller/worker/actuator.go
@@ -28,4 +28,7 @@ type Actuator interface {
 	Reconcile(context.Context, *extensionsv1alpha1.Worker, *extensionscontroller.Cluster) error
 	// Delete deletes the Worker.
 	Delete(context.Context, *extensionsv1alpha1.Worker, *extensionscontroller.Cluster) error
+	// Migrate delete the MCM, machineDeployments, mahicneClasees, machineClassSecrets,
+	// machineSets and the machines, then deletes the worker
+	Migrate(context.Context, *extensionsv1alpha1.Worker, *extensionscontroller.Cluster) error
 }

--- a/pkg/controller/worker/genericactuator/actuator_delete.go
+++ b/pkg/controller/worker/genericactuator/actuator_delete.go
@@ -97,6 +97,8 @@ func (a *genericActuator) Delete(ctx context.Context, worker *extensionsv1alpha1
 	return nil
 }
 
+//func (a *genericActuator) deleteMachineDeploymentsAndMAchineCla
+
 // Mark all existing machines to become forcefully deleted.
 func (a *genericActuator) markAllMachinesForcefulDeletion(ctx context.Context, namespace string) error {
 	// Mark all existing machines to become forcefully deleted.

--- a/pkg/controller/worker/genericactuator/actuator_migrate.go
+++ b/pkg/controller/worker/genericactuator/actuator_migrate.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package genericactuator
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gardener/gardener-extensions/pkg/controller"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/pkg/errors"
+)
+
+// Migrate remove all machine related resources (e.g. MachineDeployments, MachineClasses, MachineClassSecrets, MachineSets and Machines)
+// without waiting for machine-cotroll-manager to do that. Before removal it ensures that the MCM is deleted.
+func (a *genericActuator) Migrate(ctx context.Context, worker *extensionsv1alpha1.Worker, cluster *controller.Cluster) error {
+	workerDelegate, err := a.delegateFactory.WorkerDelegate(ctx, worker, cluster)
+	if err != nil {
+		return errors.Wrapf(err, "could not instantiate actuator context")
+	}
+
+	// Make sure machine-controller-manager is deleted before deleting the machines.
+	if err := a.deleteMachineControllerManager(ctx, worker); err != nil {
+		return errors.Wrapf(err, "failed deleting machine-controller-manager")
+	}
+
+	// Delete all existing machines without deleting the VM corresponding to them.
+	a.logger.Info("Shallow Deleting all machines", "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
+	if err := a.shallowDeleteAllExistingMachines(ctx, worker.Namespace); err != nil {
+		return errors.Wrapf(err, "Shallow Deletion of all machines failed")
+	}
+	// Delete all existing machineSets.
+	a.logger.Info("Shallow Deleting all machineSets", "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
+	if err := a.shallowDeleteAllExistingMachineSets(ctx, worker.Namespace); err != nil {
+		return errors.Wrapf(err, "Shallow Deletion of all machineSets failed")
+	}
+
+	// Get the list of all existing machine deployments.
+	existingMachineDeployments := &machinev1alpha1.MachineDeploymentList{}
+	if err := a.client.List(ctx, existingMachineDeployments, client.InNamespace(worker.Namespace)); err != nil {
+		return err
+	}
+
+	// Shallow delete all machine deployments.
+	if err := a.shallowDeleteMachineDeployments(ctx, existingMachineDeployments, nil); err != nil {
+		return errors.Wrapf(err, "cleaning up machine deployments failed")
+	}
+
+	// Delete all machine classes.
+	if err := a.shallowDeleteMachineClasses(ctx, worker.Namespace, workerDelegate.MachineClassList(), nil); err != nil {
+		return errors.Wrapf(err, "cleaning up machine classes failed")
+	}
+
+	// Delete all machine class secrets.
+	if err := a.shallowDeleteMachineClassSecrets(ctx, worker.Namespace, nil); err != nil {
+		return errors.Wrapf(err, "cleaning up machine class secrets failed")
+	}
+
+	// Wait until all machine resources have been properly deleted.
+	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	if err := a.waitUntilMachineResourcesDeleted(timeoutCtx, worker, workerDelegate); err != nil {
+		return gardencorev1beta1helper.DetermineError(fmt.Sprintf("Failed while waiting for all machine resources to be deleted: '%s'", err.Error()))
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR when we annotate a Worker with "gardener.cloud/operation=migrate" it will delete the machine-controll-manager and will make shallow delete(it will remove the finalizers) all of the machine related resource. The Virtual Machines (Shoot's Nodes) will be untouched.
**Which issue(s) this PR fixes**:
Part of [#1631](https://github.com/gardener/gardener/issues/1631)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Implement handling of "gardener.cloud/operation=migrate" annotation
```
