### PR TITLE
Make hack/generate-controller-registration.sh work with helm 3

### DIFF
--- a/hack/generate-controller-registration.sh
+++ b/hack/generate-controller-registration.sh
@@ -64,7 +64,7 @@ function cleanup {
 trap cleanup EXIT ERR INT TERM
 
 export HELM_HOME="$temp_helm_home"
-helm init --client-only > /dev/null 2>&1
+[ "$(helm version --client --template "{{.Version}}" | head -c2 | tail -c1)" = "3" ] || helm init --client-only > /dev/null 2>&1
 helm package "$CHART_DIR" --version "$VERSION" --app-version "$VERSION" --destination "$temp_dir" > /dev/null
 tar -xzm -C "$temp_extract_dir" -f "$temp_dir"/*
 chart="$(tar --sort=name -c --owner=root:0 --group=root:0 --mtime='UTC 2019-01-01' -C "$temp_extract_dir" "$(basename "$temp_extract_dir"/*)" | gzip -n | base64 | tr -d '\n')"


### PR DESCRIPTION
**What this PR does / why we need it**:
Make `hack/generate-controller-registration.sh` work with helm 3.

**Which issue(s) this PR fixes**:
Helm 3 does not have an `init` command, therefore `hack/generate-controller-registration.sh` fails, if the developer has helm 3 installed.
`helm init` is only now executed if version is <= 2.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
`hack/generate-controller-registration.sh` now works with helm 3.
```
