### PR TITLE
Allow to extend workerpool hash with addional data

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -90,7 +90,7 @@ func (m MachineDeployments) HasSecret(secretName string) bool {
 }
 
 // WorkerPoolHash returns a hash value for a given worker pool and a given cluster resource.
-func WorkerPoolHash(pool extensionsv1alpha1.WorkerPool, cluster *extensionscontroller.Cluster) (string, error) {
+func WorkerPoolHash(pool extensionsv1alpha1.WorkerPool, cluster *extensionscontroller.Cluster, additionalData ...string) (string, error) {
 	shootVersionMajorMinor, err := util.VersionMajorMinor(cluster.Shoot.Spec.Kubernetes.Version)
 	if err != nil {
 		return "", err
@@ -114,6 +114,7 @@ func WorkerPoolHash(pool extensionsv1alpha1.WorkerPool, cluster *extensionscontr
 		data = append(data, string(pool.ProviderConfig.Raw))
 	}
 
+	data = append(data, additionalData...)
 	var result string
 	for _, v := range data {
 		result += utils.ComputeSHA256Hex([]byte(v))

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -222,6 +222,10 @@ var _ = Describe("Machines", func() {
 					},
 				})
 			})
+
+			It("when adding addionalData", func() {
+				v, err = WorkerPoolHash(*p, cluster, "some-addional-data")
+			})
 		})
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Need to give the provider extensions an option to add additional data to the worker pool hashs to control when worker pools machines need to be rolled due to infrastructure specific configurations.

See here: https://github.com/gardener/gardener-extensions/pull/586#issuecomment-580222938

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```developer noteworthy
Extensions providers can now influence when machines of a worker pool need to be rolled in case there are specific needs.
```
