### PR TITLE
Remove `install` command from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,6 @@ install-requirements:
 	@go install -mod=vendor ./vendor/github.com/onsi/ginkgo/ginkgo
 	@./hack/install-requirements.sh
 
-.PHONY: install
-install:
-	@./hack/install.sh ./...
-
 .PHONY: revendor
 revendor:
 	@GO111MODULE=on go mod vendor


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the `install` command from the Makefile

**Which issue(s) this PR fixes**:
Fixes #590 

**Special notes for your reviewer**:
None

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
Removed unnecessary `install` command from Makefile
```
