### PR TITLE
Generate v1beta1 version of ControllerRegistrations

### DIFF
--- a/hack/generate-controller-registration.sh
+++ b/hack/generate-controller-registration.sh
@@ -75,7 +75,7 @@ mkdir -p "$(dirname "$DEST")"
 
 cat <<EOM > "$DEST"
 ---
-apiVersion: core.gardener.cloud/v1alpha1
+apiVersion: core.gardener.cloud/v1beta1
 kind: ControllerRegistration
 metadata:
   name: $NAME


### PR DESCRIPTION
**What this PR does / why we need it**:
Generate v1beta1 version of ControllerRegistrations instead of v1alpha1

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
`hack/generate-controller-registration.sh` now generates ControllerRegistrations in version `v1beta1`. Please regenerate the ControllerRegistrations of your extensions.
```
