### PR TITLE
implement restore and migrate worker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	go.uber.org/zap v1.13.0
 	gomodules.xyz/jsonpatch/v2 v2.0.1
+	google.golang.org/genproto v0.0.0-20191216164720-4f79533eabd1
 	k8s.io/api v0.17.0
 	k8s.io/apiextensions-apiserver v0.17.0
 	k8s.io/apimachinery v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -692,6 +692,7 @@ google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190911173649-1774047e7e51/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=
+google.golang.org/genproto v0.0.0-20191216164720-4f79533eabd1 h1:aQktFqmDE2yjveXJlVIfslDFmFnUXSqG0i6KRcJAeMc=
 google.golang.org/genproto v0.0.0-20191216164720-4f79533eabd1/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=

--- a/pkg/controller/worker/actuator.go
+++ b/pkg/controller/worker/actuator.go
@@ -28,4 +28,15 @@ type Actuator interface {
 	Reconcile(context.Context, *extensionsv1alpha1.Worker, *extensionscontroller.Cluster) error
 	// Delete deletes the Worker.
 	Delete(context.Context, *extensionsv1alpha1.Worker, *extensionscontroller.Cluster) error
+	// Restore reads from the worker.status.state field and deploys the machines and machineSet
+	Restore(context.Context, *extensionsv1alpha1.Worker, *extensionscontroller.Cluster) error
+	// Migrate deletes the MCM, machineDeployments, machineClasses, machineClassSecrets,
+	// machineSets and the machines. The underlying VMs representing the Shoot nodes are not deleted
+	Migrate(context.Context, *extensionsv1alpha1.Worker, *extensionscontroller.Cluster) error
+}
+
+// StateActuator acts upon Worker's State resources.
+type StateActuator interface {
+	// Reconcile reconciles the Worker State.
+	Reconcile(context.Context, *extensionsv1alpha1.Worker) error
 }

--- a/pkg/controller/worker/controller.go
+++ b/pkg/controller/worker/controller.go
@@ -17,10 +17,12 @@ package worker
 import (
 	extensionshandler "github.com/gardener/gardener-extensions/pkg/handler"
 	extensionspredicate "github.com/gardener/gardener-extensions/pkg/predicate"
-
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -31,6 +33,8 @@ const (
 	FinalizerName = "extensions.gardener.cloud/worker"
 	// ControllerName is the name of the controller.
 	ControllerName = "worker_controller"
+	// StateUpdatingControllerName is the name of the controller responsible for updating the worker's state.
+	StateUpdatingControllerName = "worker_state_controller"
 )
 
 // AddArgs are arguments for adding an worker controller to a manager.
@@ -75,7 +79,11 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 func Add(mgr manager.Manager, args AddArgs) error {
 	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator)
 	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	return add(mgr, args.ControllerOptions, predicates)
+	if err := add(mgr, args.ControllerOptions, predicates); err != nil {
+		return err
+	}
+
+	return addStateUpdatingController(mgr, args.ControllerOptions)
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -92,4 +100,34 @@ func add(mgr manager.Manager, options controller.Options, predicates []predicate
 	return ctrl.Watch(&source.Kind{Type: &extensionsv1alpha1.Cluster{}}, &extensionshandler.EnqueueRequestsFromMapFunc{
 		ToRequests: extensionshandler.SimpleMapper(ClusterToWorkerMapper(predicates), extensionshandler.UpdateWithNew),
 	})
+}
+
+func addStateUpdatingController(mgr manager.Manager, options controller.Options) error {
+	stateActuator := NewStateActuator(log.Log.WithName("worker-state-actuator"))
+	stateReconciler := NewStateReconciler(mgr, stateActuator)
+	addStateUpdatingControllerOptions := controller.Options{
+		MaxConcurrentReconciles: options.MaxConcurrentReconciles,
+		Reconciler:              stateReconciler,
+	}
+	predicates := []predicate.Predicate{
+		extensionspredicate.Or(
+			MachineStatusHasChanged(),
+			predicate.GenerationChangedPredicate{},
+		),
+	}
+
+	ctrl, err := controller.New(StateUpdatingControllerName, mgr, addStateUpdatingControllerOptions)
+	if err != nil {
+		return err
+	}
+
+	if err := ctrl.Watch(&source.Kind{Type: &machinev1alpha1.MachineSet{}}, &extensionshandler.EnqueueRequestsFromMapFunc{
+		ToRequests: extensionshandler.SimpleMapper(MachineSetToWorkerMapper(nil), extensionshandler.UpdateWithNew),
+	}, predicates...); err != nil {
+		return err
+	}
+
+	return ctrl.Watch(&source.Kind{Type: &machinev1alpha1.Machine{}}, &extensionshandler.EnqueueRequestsFromMapFunc{
+		ToRequests: extensionshandler.SimpleMapper(MachineToWorkerMapper(nil), extensionshandler.UpdateWithNew),
+	}, predicates...)
 }

--- a/pkg/controller/worker/genericactuator/actuator_migrate.go
+++ b/pkg/controller/worker/genericactuator/actuator_migrate.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package genericactuator
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gardener/gardener-extensions/pkg/controller"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/pkg/errors"
+)
+
+// Migrate removes all machine related resources (e.g. MachineDeployments, MachineClasses, MachineClassSecrets, MachineSets and Machines)
+// without waiting for machine-controller-manager to do that. Before removal it ensures that the MCM is deleted.
+func (a *genericActuator) Migrate(ctx context.Context, worker *extensionsv1alpha1.Worker, cluster *controller.Cluster) error {
+	workerDelegate, err := a.delegateFactory.WorkerDelegate(ctx, worker, cluster)
+	if err != nil {
+		return errors.Wrap(err, "could not instantiate actuator context")
+	}
+
+	// Make sure machine-controller-manager is deleted before deleting the machines.
+	if err := a.deleteMachineControllerManager(ctx, worker); err != nil {
+		return errors.Wrap(err, "failed deleting machine-controller-manager")
+	}
+
+	if err := a.waitUntilMachineControllerManagerIsDeleted(ctx, worker.Namespace); err != nil {
+		return errors.Wrap(err, "failed deleting machine-controller-manager manager")
+	}
+
+	if err := a.shallowDeleteAllObjects(ctx, worker.Namespace, &machinev1alpha1.MachineList{}); err != nil {
+		return errors.Wrap(err, "shallow Deletion of all machine failed")
+	}
+
+	if err := a.shallowDeleteAllObjects(ctx, worker.Namespace, &machinev1alpha1.MachineSetList{}); err != nil {
+		return errors.Wrap(err, "shallow Deletion of all machineSets failed")
+	}
+
+	if err := a.shallowDeleteAllObjects(ctx, worker.Namespace, &machinev1alpha1.MachineDeploymentList{}); err != nil {
+		return errors.Wrap(err, "shallow Deletion of all machineDeployments failed")
+	}
+
+	if err := a.shallowDeleteAllObjects(ctx, worker.Namespace, workerDelegate.MachineClassList()); err != nil {
+		return errors.Wrap(err, "cleaning up machine classes failed")
+	}
+
+	if err := a.shallowDeleteMachineClassSecrets(ctx, worker.Namespace, nil); err != nil {
+		return errors.Wrap(err, "cleaning up machine class secrets failed")
+	}
+
+	// Wait until all machine resources have been properly deleted.
+	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	if err := a.waitUntilMachineResourcesDeleted(timeoutCtx, worker, workerDelegate); err != nil {
+		return gardencorev1beta1helper.DetermineError(err, fmt.Sprintf("Failed while waiting for all machine resources to be deleted: '%s'", err.Error()))
+	}
+
+	return nil
+}
+
+func (a *genericActuator) waitUntilMachineControllerManagerIsDeleted(ctx context.Context, namespace string) error {
+	return wait.PollUntil(5*time.Second, func() (bool, error) {
+		machineControllerManagerDeployment := &appsv1.Deployment{}
+		if err := a.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: McmDeploymentName}, machineControllerManagerDeployment); err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+
+		return false, nil
+	}, ctx.Done())
+}

--- a/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -232,7 +232,13 @@ func (a *genericActuator) deployMachineDeployments(ctx context.Context, cluster 
 		// If the machine deployment does not yet exist we set replicas to min so that the cluster
 		// autoscaler can scale them as required.
 		case existingMachineDeployment == nil:
-			replicas = deployment.Minimum
+			if deployment.State != nil {
+				// During restoration the actual replica count is in the State.Replicas
+				// If wanted deployment has no corresponding existing deployment, but has State, then we are in restoration process
+				replicas = deployment.State.Replicas
+			} else {
+				replicas = deployment.Minimum
+			}
 		// If the Shoot was hibernated and is now woken up we set replicas to min so that the cluster
 		// autoscaler can scale them as required.
 		case shootIsAwake(controller.IsHibernated(cluster), existingMachineDeployments):

--- a/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package genericactuator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
+	workercontroller "github.com/gardener/gardener-extensions/pkg/controller/worker"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	gardeneretry "github.com/gardener/gardener/pkg/utils/retry"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Restore uses the Worker's spec to figure out the wanted MachineDeployments. Then it parses the Worker's state.
+// If there is a record in the state  corresponding to a wanted deployment then the Restore function
+// deploys that MachineDeployemnt with all related MachineSet and Machines.
+func (a *genericActuator) Restore(ctx context.Context, worker *extensionsv1alpha1.Worker, cluster *extensionscontroller.Cluster) error {
+	workerDelegate, err := a.delegateFactory.WorkerDelegate(ctx, worker, cluster)
+	if err != nil {
+		return errors.Wrap(err, "could not instantiate actuator context")
+	}
+
+	// Generate the desired machine deployments.
+	wantedMachineDeployments, err := workerDelegate.GenerateMachineDeployments(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to generate the machine deployments")
+	}
+
+	// Get the list of all existing machine deployments.
+	existingMachineDeployments := &machinev1alpha1.MachineDeploymentList{}
+	if err := a.client.List(ctx, existingMachineDeployments, client.InNamespace(worker.Namespace)); err != nil {
+		return err
+	}
+
+	// Parse the worker state to a separate machineDeployment states and attach them to
+	// the corresponding machineDeployments which are to be deployed later
+	a.logger.Info("Extracting the worker status.state", "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
+	if err := a.addStateToMachineDeployment(ctx, worker, wantedMachineDeployments); err != nil {
+		return err
+	}
+
+	wantedMachineDeployments = removeWantedDeploymentWithoutState(wantedMachineDeployments)
+
+	// Delete the machine-controller-manager. During restoration MCM must not exist
+	a.logger.Info("Deleting machine-controller-manager for a Worker restore operation during control-plane migration", "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
+	if err := a.deleteMachineControllerManager(ctx, worker); err != nil {
+		return errors.Wrap(err, "failed deleting machine-controller-manager")
+	}
+
+	a.logger.Info("Wait until machine-controller-manager is deleted", "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
+	if err := a.waitUntilMachineControllerManagerIsDeleted(ctx, worker.Namespace); err != nil {
+		return errors.Wrap(err, "failed deleting machine-controller-manager")
+	}
+
+	// Do the actual restoration
+	a.logger.Info("Deploying the Machines and MachineSets", "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
+	if err := a.deployMachineSetsAndMachines(ctx, worker, wantedMachineDeployments); err != nil {
+		return errors.Wrap(err, "failed restoration of the machineSet and the machines")
+	}
+
+	// Generate machine deployment configuration based on previously computed list of deployments and deploy them.
+	a.logger.Info("Deploying the MachineDeployments in Worker.Status.State", "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
+	if err := a.deployMachineDeployments(ctx, cluster, worker, existingMachineDeployments, wantedMachineDeployments, workerDelegate.MachineClassKind(), true); err != nil {
+		return errors.Wrap(err, "failed to restore the machine deployment config")
+	}
+
+	return nil
+}
+
+func (a *genericActuator) addStateToMachineDeployment(ctx context.Context, worker *extensionsv1alpha1.Worker, wantedMachineDeployments workercontroller.MachineDeployments) error {
+	if worker.Status.State == nil || len(worker.Status.State.Raw) <= 0 {
+		return nil
+	}
+
+	// Parse the worker state to MachineDeploymentStates
+	workerState := &workercontroller.State{
+		MachineDeployments: make(map[string]*workercontroller.MachineDeploymentState),
+	}
+
+	if err := json.Unmarshal(worker.Status.State.Raw, &workerState); err != nil {
+		return err
+	}
+
+	// Attach the parsed MachineDeploymentStates to the wanted MachineDeployments
+	for index, wantedMachineDeployment := range wantedMachineDeployments {
+		wantedMachineDeployments[index].State = workerState.MachineDeployments[wantedMachineDeployment.Name]
+	}
+
+	return nil
+}
+
+func (a *genericActuator) deployMachineSetsAndMachines(ctx context.Context, worker *extensionsv1alpha1.Worker, wantedMachineDeployments workercontroller.MachineDeployments) error {
+	for _, wantedMachineDeployment := range wantedMachineDeployments {
+		machineSets := wantedMachineDeployment.State.MachineSets
+
+		for _, machineSet := range machineSets {
+			// Create the MachineSet if not already exists. We do not care about the MachineSet status
+			// because the MCM will update it
+			if err := a.client.Create(ctx, &machineSet); err != nil && !apierrors.IsAlreadyExists(err) {
+				return err
+			}
+		}
+
+		// Deploy each machine owned by the MachineSet which was restored above
+		for _, machine := range wantedMachineDeployment.State.Machines {
+			// Create the machine if it not exists already
+			err := a.client.Create(ctx, &machine)
+			if err != nil && !apierrors.IsAlreadyExists(err) {
+				return err
+			}
+
+			// Attach the Shoot node to the Machine status
+			node := machine.Status.Node
+			if err := a.waitUntilStatusIsUpdates(ctx, &machine, func() error {
+				machine.Status.Node = node
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (a *genericActuator) waitUntilStatusIsUpdates(ctx context.Context, obj runtime.Object, transform func() error) error {
+	return gardeneretry.Until(ctx, 5*time.Second, func(ctx context.Context) (done bool, err error) {
+		if err := extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, a.client, obj, transform); err != nil {
+			if apierrors.IsNotFound(err) {
+				return gardeneretry.NotOk()
+			}
+			return gardeneretry.SevereError(err)
+		}
+		return gardeneretry.Ok()
+	})
+}
+
+func removeWantedDeploymentWithoutState(wantedMachineDeployments workercontroller.MachineDeployments) workercontroller.MachineDeployments {
+	var reducedMachineDeployments workercontroller.MachineDeployments
+	for _, wantedMachineDeployment := range wantedMachineDeployments {
+		if wantedMachineDeployment.State != nil || len(wantedMachineDeployment.State.MachineSets) < 1 {
+			reducedMachineDeployments = append(reducedMachineDeployments, wantedMachineDeployment)
+		}
+	}
+	return reducedMachineDeployments
+}

--- a/pkg/controller/worker/genericactuator/machine_controller_manager.go
+++ b/pkg/controller/worker/genericactuator/machine_controller_manager.go
@@ -34,6 +34,9 @@ import (
 // McmShootResourceName is the name of the managed resource that contains the Machine Controller Manager
 const McmShootResourceName = "extension-worker-mcm-shoot"
 
+// McmDeploymentName is the name of the deployment that spawn machine-cotroll-manager pods
+const McmDeploymentName = "machine-controller-manager"
+
 // ReplicaCount determines the number of replicas.
 type ReplicaCount func() (int32, error)
 

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -22,9 +22,9 @@ import (
 
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	"github.com/gardener/gardener-extensions/pkg/util"
-
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -51,10 +51,24 @@ type MachineDeployment struct {
 	Labels         map[string]string
 	Annotations    map[string]string
 	Taints         []corev1.Taint
+	State          *MachineDeploymentState
 }
 
 // MachineDeployments is a list of machine deployments.
 type MachineDeployments []MachineDeployment
+
+// MachineDeploymentState stores the last versions of the machine sets and machine which
+// the machine deployment corresponds
+type MachineDeploymentState struct {
+	Replicas    int32                        `json:"replicas,omitempty"`
+	MachineSets []machinev1alpha1.MachineSet `json:"machineSets,omitempty"`
+	Machines    []machinev1alpha1.Machine    `json:"machines,omitempty"`
+}
+
+// State represent the last known state of a Worker
+type State struct {
+	MachineDeployments map[string]*MachineDeploymentState `json:"machineDeployments,omitempty"`
+}
 
 // HasDeployment checks whether the <name> is part of the <machineDeployments>
 // list, i.e. whether there is an entry whose 'Name' attribute matches <name>. It returns true or false.

--- a/pkg/controller/worker/mapper.go
+++ b/pkg/controller/worker/mapper.go
@@ -15,16 +15,153 @@
 package worker
 
 import (
-	extensionshandler "github.com/gardener/gardener-extensions/pkg/handler"
+	"context"
 
+	extensionshandler "github.com/gardener/gardener-extensions/pkg/handler"
+	extensionspredicate "github.com/gardener/gardener-extensions/pkg/predicate"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 )
 
 // ClusterToWorkerMapper returns a mapper that returns requests for Worker whose
 // referenced clusters have been modified.
 func ClusterToWorkerMapper(predicates []predicate.Predicate) handler.Mapper {
 	return extensionshandler.ClusterToObjectMapper(func() runtime.Object { return &extensionsv1alpha1.WorkerList{} }, predicates)
+}
+
+// MachineSetToWorkerMapper returns a mapper that returns requests for Worker whose
+// referenced MachineSets have been modified.
+func MachineSetToWorkerMapper(predicates []predicate.Predicate) handler.Mapper {
+	return newMachineSetToObjectMapper(func() runtime.Object { return &extensionsv1alpha1.WorkerList{} }, predicates)
+}
+
+// MachineToWorkerMapper returns a mapper that returns requests for Worker whose
+// referenced Machines have been modified.
+func MachineToWorkerMapper(predicates []predicate.Predicate) handler.Mapper {
+	return newMachineToObjectMapper(func() runtime.Object { return &extensionsv1alpha1.WorkerList{} }, predicates)
+}
+
+type machineSetToObjectMapper struct {
+	client         client.Client
+	newObjListFunc func() runtime.Object
+	predicates     []predicate.Predicate
+}
+
+func (m *machineSetToObjectMapper) InjectClient(c client.Client) error {
+	m.client = c
+	return nil
+}
+
+func (m *machineSetToObjectMapper) InjectFunc(f inject.Func) error {
+	for _, p := range m.predicates {
+		if err := f(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *machineSetToObjectMapper) Map(obj handler.MapObject) []reconcile.Request {
+	ctx := context.TODO()
+
+	if obj.Object == nil {
+		return nil
+	}
+
+	machineSet, ok := obj.Object.(*machinev1alpha1.MachineSet)
+	if !ok {
+		return nil
+	}
+
+	objList := m.newObjListFunc()
+	if err := m.client.List(ctx, objList, client.InNamespace(machineSet.Namespace)); err != nil {
+		return nil
+	}
+
+	return getReconcileRequestsFromObjectList(objList, m.predicates)
+}
+
+// newMachineSetToObjectMapper returns a mapper that returns requests for objects whose
+// referenced MachineSets have been modified.
+func newMachineSetToObjectMapper(newObjListFunc func() runtime.Object, predicates []predicate.Predicate) handler.Mapper {
+	return &machineSetToObjectMapper{newObjListFunc: newObjListFunc, predicates: predicates}
+}
+
+type machineToObjectMapper struct {
+	client         client.Client
+	newObjListFunc func() runtime.Object
+	predicates     []predicate.Predicate
+}
+
+func (m *machineToObjectMapper) InjectClient(c client.Client) error {
+	m.client = c
+	return nil
+}
+
+func (m *machineToObjectMapper) InjectFunc(f inject.Func) error {
+	for _, p := range m.predicates {
+		if err := f(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *machineToObjectMapper) Map(obj handler.MapObject) []reconcile.Request {
+	ctx := context.TODO()
+
+	if obj.Object == nil {
+		return nil
+	}
+
+	machine, ok := obj.Object.(*machinev1alpha1.Machine)
+	if !ok {
+		return nil
+	}
+
+	objList := m.newObjListFunc()
+	if err := m.client.List(ctx, objList, client.InNamespace(machine.Namespace)); err != nil {
+		return nil
+	}
+
+	return getReconcileRequestsFromObjectList(objList, m.predicates)
+}
+
+// newMachineToObjectMapper returns a mapper that returns requests for objects whose
+// referenced Machines have been modified.
+func newMachineToObjectMapper(newObjListFunc func() runtime.Object, predicates []predicate.Predicate) handler.Mapper {
+	return &machineToObjectMapper{newObjListFunc: newObjListFunc, predicates: predicates}
+}
+
+func getReconcileRequestsFromObjectList(objList runtime.Object, predicates []predicate.Predicate) []reconcile.Request {
+	var requests []reconcile.Request
+
+	utilruntime.HandleError(meta.EachListItem(objList, func(obj runtime.Object) error {
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return err
+		}
+
+		if !extensionspredicate.EvalGeneric(obj, predicates...) {
+			return nil
+		}
+
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: accessor.GetNamespace(),
+				Name:      accessor.GetName(),
+			},
+		})
+		return nil
+	}))
+	return requests
 }

--- a/pkg/controller/worker/mapper_test.go
+++ b/pkg/controller/worker/mapper_test.go
@@ -1,0 +1,311 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker_test
+
+import (
+	"context"
+
+	"github.com/gardener/gardener-extensions/pkg/controller/worker"
+	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+var _ = Describe("Worker Mapper", func() {
+	var (
+		ctrl *gomock.Controller
+		c    *mockclient.MockClient
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		c = mockclient.NewMockClient(ctrl)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#MachineSetToWorkerMapper", func() {
+		var (
+			resourceName = "machineSet"
+			namespace    = "shoot"
+		)
+
+		It("should find all objects for the passed worker", func() {
+			mapper := worker.MachineSetToWorkerMapper(nil)
+			ExpectInject(inject.ClientInto(c, mapper))
+
+			c.EXPECT().
+				List(
+					gomock.AssignableToTypeOf(context.TODO()),
+					gomock.AssignableToTypeOf(&extensionsv1alpha1.WorkerList{}),
+					gomock.AssignableToTypeOf(client.InNamespace(namespace)),
+				).
+				DoAndReturn(func(_ context.Context, actual *extensionsv1alpha1.WorkerList, _ ...client.ListOption) error {
+					*actual = extensionsv1alpha1.WorkerList{
+						Items: []extensionsv1alpha1.Worker{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      resourceName,
+									Namespace: namespace,
+								},
+							},
+						},
+					}
+					return nil
+				})
+
+			result := mapper.Map(handler.MapObject{
+				Object: &machinev1alpha1.MachineSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: namespace,
+					},
+				},
+			})
+
+			Expect(result).To(ConsistOf(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      resourceName,
+					Namespace: namespace,
+				},
+			}))
+		})
+
+		It("should find no objects for the passed cluster because predicates do not match", func() {
+			var (
+				predicates = []predicate.Predicate{
+					predicate.Funcs{
+						GenericFunc: func(event event.GenericEvent) bool {
+							return false
+						},
+					},
+				}
+				mapper = worker.MachineSetToWorkerMapper(predicates)
+			)
+			ExpectInject(inject.ClientInto(c, mapper))
+
+			c.EXPECT().
+				List(
+					gomock.AssignableToTypeOf(context.TODO()),
+					gomock.AssignableToTypeOf(&extensionsv1alpha1.WorkerList{}),
+					gomock.AssignableToTypeOf(client.InNamespace(namespace)),
+				).
+				DoAndReturn(func(_ context.Context, actual *extensionsv1alpha1.WorkerList, _ ...client.ListOption) error {
+					*actual = extensionsv1alpha1.WorkerList{
+						Items: []extensionsv1alpha1.Worker{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      resourceName,
+									Namespace: namespace,
+								},
+							},
+						},
+					}
+					return nil
+				})
+
+			result := mapper.Map(handler.MapObject{
+				Object: &machinev1alpha1.MachineSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: namespace,
+					},
+				},
+			})
+
+			Expect(result).To(BeEmpty())
+		})
+
+		It("should find no objects because list is empty", func() {
+			mapper := worker.MachineSetToWorkerMapper(nil)
+
+			ExpectInject(inject.ClientInto(c, mapper))
+
+			c.EXPECT().
+				List(
+					gomock.AssignableToTypeOf(context.TODO()),
+					gomock.AssignableToTypeOf(&extensionsv1alpha1.WorkerList{}),
+					gomock.AssignableToTypeOf(client.InNamespace(namespace)),
+				).
+				DoAndReturn(func(_ context.Context, actual *extensionsv1alpha1.WorkerList, _ ...client.ListOption) error {
+					*actual = extensionsv1alpha1.WorkerList{}
+					return nil
+				})
+
+			result := mapper.Map(handler.MapObject{
+				Object: &machinev1alpha1.MachineSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: namespace,
+					},
+				},
+			})
+
+			Expect(result).To(BeEmpty())
+		})
+
+		It("should find no objects because the passed object is no worker", func() {
+			mapper := worker.MachineSetToWorkerMapper(nil)
+			result := mapper.Map(handler.MapObject{
+				Object: &extensionsv1alpha1.Cluster{},
+			})
+			ExpectInject(inject.ClientInto(c, mapper))
+			Expect(result).To(BeNil())
+		})
+	})
+
+	Describe("#MachineToWorkerMapper", func() {
+		var (
+			resourceName = "machineSet"
+			namespace    = "shoot"
+		)
+
+		It("should find all objects for the passed worker", func() {
+			mapper := worker.MachineToWorkerMapper(nil)
+			ExpectInject(inject.ClientInto(c, mapper))
+
+			c.EXPECT().
+				List(
+					gomock.AssignableToTypeOf(context.TODO()),
+					gomock.AssignableToTypeOf(&extensionsv1alpha1.WorkerList{}),
+					gomock.AssignableToTypeOf(client.InNamespace(namespace)),
+				).
+				DoAndReturn(func(_ context.Context, actual *extensionsv1alpha1.WorkerList, _ ...client.ListOption) error {
+					*actual = extensionsv1alpha1.WorkerList{
+						Items: []extensionsv1alpha1.Worker{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      resourceName,
+									Namespace: namespace,
+								},
+							},
+						},
+					}
+					return nil
+				})
+
+			result := mapper.Map(handler.MapObject{
+				Object: &machinev1alpha1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: namespace,
+					},
+				},
+			})
+
+			Expect(result).To(ConsistOf(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      resourceName,
+					Namespace: namespace,
+				},
+			}))
+		})
+
+		It("should find no objects for the passed cluster because predicates do not match", func() {
+			var (
+				predicates = []predicate.Predicate{
+					predicate.Funcs{
+						GenericFunc: func(event event.GenericEvent) bool {
+							return false
+						},
+					},
+				}
+				mapper = worker.MachineToWorkerMapper(predicates)
+			)
+			ExpectInject(inject.ClientInto(c, mapper))
+
+			c.EXPECT().
+				List(
+					gomock.AssignableToTypeOf(context.TODO()),
+					gomock.AssignableToTypeOf(&extensionsv1alpha1.WorkerList{}),
+					gomock.AssignableToTypeOf(client.InNamespace(namespace)),
+				).
+				DoAndReturn(func(_ context.Context, actual *extensionsv1alpha1.WorkerList, _ ...client.ListOption) error {
+					*actual = extensionsv1alpha1.WorkerList{
+						Items: []extensionsv1alpha1.Worker{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      resourceName,
+									Namespace: namespace,
+								},
+							},
+						},
+					}
+					return nil
+				})
+
+			result := mapper.Map(handler.MapObject{
+				Object: &machinev1alpha1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: namespace,
+					},
+				},
+			})
+
+			Expect(result).To(BeEmpty())
+		})
+
+		It("should find no objects because list is empty", func() {
+			mapper := worker.MachineToWorkerMapper(nil)
+
+			ExpectInject(inject.ClientInto(c, mapper))
+
+			c.EXPECT().
+				List(
+					gomock.AssignableToTypeOf(context.TODO()),
+					gomock.AssignableToTypeOf(&extensionsv1alpha1.WorkerList{}),
+					gomock.AssignableToTypeOf(client.InNamespace(namespace)),
+				).
+				DoAndReturn(func(_ context.Context, actual *extensionsv1alpha1.WorkerList, _ ...client.ListOption) error {
+					*actual = extensionsv1alpha1.WorkerList{}
+					return nil
+				})
+
+			result := mapper.Map(handler.MapObject{
+				Object: &machinev1alpha1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: namespace,
+					},
+				},
+			})
+
+			Expect(result).To(BeEmpty())
+		})
+
+		It("should find no objects because the passed object is no worker", func() {
+			mapper := worker.MachineToWorkerMapper(nil)
+			result := mapper.Map(handler.MapObject{
+				Object: &extensionsv1alpha1.Cluster{},
+			})
+			ExpectInject(inject.ClientInto(c, mapper))
+			Expect(result).To(BeNil())
+		})
+	})
+})
+
+func ExpectInject(ok bool, err error) {
+	Expect(err).NotTo(HaveOccurred())
+	Expect(ok).To(BeTrue(), "no injection happened")
+}

--- a/pkg/controller/worker/predicate.go
+++ b/pkg/controller/worker/predicate.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// MachineStatusHasChanged is a predicate deciding wether the status of a MCM's Machine has been changed.
+func MachineStatusHasChanged() predicate.Predicate {
+	statusHasChanged := func(oldObj runtime.Object, newObj runtime.Object) bool {
+		oldMachine, ok := oldObj.(*machinev1alpha1.Machine)
+		if !ok {
+			return false
+		}
+		newMachine, ok := newObj.(*machinev1alpha1.Machine)
+		if !ok {
+			return false
+		}
+		oldStatus := oldMachine.Status
+		newStatus := newMachine.Status
+
+		return oldStatus.Node != newStatus.Node
+	}
+
+	return predicate.Funcs{
+		CreateFunc: func(event event.CreateEvent) bool {
+			return true
+		},
+		UpdateFunc: func(event event.UpdateEvent) bool {
+			result := statusHasChanged(event.ObjectOld, event.ObjectNew)
+			return result
+		},
+		GenericFunc: func(event event.GenericEvent) bool {
+			return false
+		},
+		DeleteFunc: func(event event.DeleteEvent) bool {
+			return true
+		},
+	}
+}

--- a/pkg/controller/worker/predicate_test.go
+++ b/pkg/controller/worker/predicate_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker_test
+
+import (
+	"github.com/gardener/gardener-extensions/pkg/controller/worker"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+var _ = Describe("Worker Predicates", func() {
+	Describe("#MachineStatusHasChanged", func() {
+		var (
+			oldMachine   *machinev1alpha1.Machine
+			newMachine   *machinev1alpha1.Machine
+			createEvent  event.CreateEvent
+			updateEvent  event.UpdateEvent
+			deleteEvent  event.DeleteEvent
+			genericEvent event.GenericEvent
+		)
+
+		BeforeEach(func() {
+			oldMachine = &machinev1alpha1.Machine{}
+			newMachine = &machinev1alpha1.Machine{}
+
+			createEvent = event.CreateEvent{
+				Object: newMachine,
+			}
+			updateEvent = event.UpdateEvent{
+				ObjectOld: oldMachine,
+				ObjectNew: newMachine,
+			}
+			deleteEvent = event.DeleteEvent{
+				Object: newMachine,
+			}
+			genericEvent = event.GenericEvent{
+				Object: newMachine,
+			}
+		})
+
+		It("should notice the change of the Node in the Status", func() {
+			predicate := worker.MachineStatusHasChanged()
+			newMachine.Status.Node = "ip.10-256-18-291.cluster.node"
+			Expect(predicate.Create(createEvent)).To(BeTrue())
+			Expect(predicate.Update(updateEvent)).To(BeTrue())
+			Expect(predicate.Delete(deleteEvent)).To(BeTrue())
+			Expect(predicate.Generic(genericEvent)).To(BeFalse())
+		})
+
+		It("should not react when there are no changes of the Node in the Status", func() {
+			predicate := worker.MachineStatusHasChanged()
+			oldMachine.Status.Node = "ip.10-256-18-291.cluster.node"
+			newMachine.Status.Node = "ip.10-256-18-291.cluster.node"
+			Expect(predicate.Create(createEvent)).To(BeTrue())
+			Expect(predicate.Update(updateEvent)).To(BeFalse())
+			Expect(predicate.Delete(deleteEvent)).To(BeTrue())
+			Expect(predicate.Generic(genericEvent)).To(BeFalse())
+		})
+		It("should not react when there is not specified Node in the Status", func() {
+			predicate := worker.MachineStatusHasChanged()
+			Expect(predicate.Create(createEvent)).To(BeTrue())
+			Expect(predicate.Update(updateEvent)).To(BeFalse())
+			Expect(predicate.Delete(deleteEvent)).To(BeTrue())
+			Expect(predicate.Generic(genericEvent)).To(BeFalse())
+		})
+	})
+})

--- a/pkg/controller/worker/reconciler.go
+++ b/pkg/controller/worker/reconciler.go
@@ -21,8 +21,8 @@ import (
 	"github.com/gardener/gardener-extensions/pkg/controller"
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	"github.com/gardener/gardener-extensions/pkg/util"
-
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
@@ -84,91 +84,162 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, err
 	}
 
-	// Deletion flow
-	if worker.DeletionTimestamp != nil {
-		hasFinalizer, err := extensionscontroller.HasFinalizer(worker, FinalizerName)
-		if err != nil {
-			r.logger.Error(err, "Could not instantiate finalizer deletion")
-			return reconcile.Result{}, err
-		}
-		if !hasFinalizer {
-			r.logger.Info("Deleting worker causes a no-op as there is no finalizer.", "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
-			return reconcile.Result{}, nil
-		}
-
-		operationType := gardencorev1beta1helper.ComputeOperationType(worker.ObjectMeta, worker.Status.LastOperation)
-		if err := r.updateStatusProcessing(r.ctx, worker, operationType, "Deleting the worker"); err != nil {
-			return reconcile.Result{}, err
-		}
-
-		r.logger.Info("Starting the deletion of worker", "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
-		if err := r.actuator.Delete(r.ctx, worker, cluster); err != nil {
-			msg := "Error deleting worker"
-			utilruntime.HandleError(r.updateStatusError(r.ctx, extensionscontroller.ReconcileErrCauseOrErr(err), worker, operationType, msg))
-			r.logger.Error(err, msg, "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
-			return extensionscontroller.ReconcileErr(err)
-		}
-
-		msg := "Successfully deleted worker"
-		r.logger.Info(msg, "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
-		if err := r.updateStatusSuccess(r.ctx, worker, operationType, msg); err != nil {
-			return reconcile.Result{}, err
-		}
-
-		r.logger.Info("Removing finalizer.", "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
-		if err := extensionscontroller.DeleteFinalizer(r.ctx, r.client, FinalizerName, worker); err != nil {
-			r.logger.Error(err, "Error removing finalizer from Worker", "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
-			return reconcile.Result{}, err
-		}
-
-		return reconcile.Result{}, nil
-	}
-
-	// Reconcile flow
-	if err := controller.EnsureFinalizer(r.ctx, r.client, FinalizerName, worker); err != nil {
-		return reconcile.Result{}, err
-	}
-
 	operationType := gardencorev1beta1helper.ComputeOperationType(worker.ObjectMeta, worker.Status.LastOperation)
-	if err := r.updateStatusProcessing(r.ctx, worker, operationType, "Reconciling the worker"); err != nil {
-		return reconcile.Result{}, err
-	}
 
-	if err := r.actuator.Reconcile(r.ctx, worker, cluster); err != nil {
-		msg := "Error reconciling worker"
-		utilruntime.HandleError(r.updateStatusError(r.ctx, extensionscontroller.ReconcileErrCauseOrErr(err), worker, operationType, msg))
-		r.logger.Error(err, msg, "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
-		return extensionscontroller.ReconcileErr(err)
+	switch {
+	case isWorkerMigrated(worker):
+		return reconcile.Result{}, nil
+	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
+		return r.migrate(worker, cluster)
+	case worker.DeletionTimestamp != nil:
+		return r.delete(worker, cluster)
+	case worker.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationRestore:
+		return r.restore(worker, cluster, operationType)
+	default:
+		return r.reconcile(worker, cluster, operationType)
 	}
-
-	msg := "Successfully reconciled worker"
-	r.logger.Info(msg, "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
-	if err := r.updateStatusSuccess(r.ctx, worker, operationType, msg); err != nil {
-		return reconcile.Result{}, err
-	}
-
-	return reconcile.Result{}, nil
 }
 
 func (r *reconciler) updateStatusProcessing(ctx context.Context, worker *extensionsv1alpha1.Worker, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
+	r.logger.Info(description, "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
 	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, worker, func() error {
 		worker.Status.LastOperation = extensionscontroller.LastOperation(lastOperationType, gardencorev1beta1.LastOperationStateProcessing, 1, description)
 		return nil
 	})
 }
 
-func (r *reconciler) updateStatusError(ctx context.Context, err error, worker *extensionsv1alpha1.Worker, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, worker, func() error {
+func (r *reconciler) updateStatusError(ctx context.Context, err error, worker *extensionsv1alpha1.Worker, lastOperationType gardencorev1beta1.LastOperationType, description string) {
+	r.logger.Error(err, description, "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
+	updateErr := extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, worker, func() error {
 		worker.Status.ObservedGeneration = worker.Generation
-		worker.Status.LastOperation, worker.Status.LastError = extensionscontroller.ReconcileError(lastOperationType, gardencorev1beta1helper.FormatLastErrDescription(fmt.Errorf("%s: %v", description, err)), 50, gardencorev1beta1helper.ExtractErrorCodes(err)...)
+		worker.Status.LastOperation, worker.Status.LastError = extensionscontroller.ReconcileError(lastOperationType, gardencorev1beta1helper.FormatLastErrDescription(fmt.Errorf("%s: %v", description, extensionscontroller.ReconcileErrCauseOrErr(err))), 50, gardencorev1beta1helper.ExtractErrorCodes(err)...)
 		return nil
 	})
+	utilruntime.HandleError(updateErr)
 }
 
 func (r *reconciler) updateStatusSuccess(ctx context.Context, worker *extensionsv1alpha1.Worker, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
+	r.logger.Info(description, "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
 	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, worker, func() error {
 		worker.Status.ObservedGeneration = worker.Generation
 		worker.Status.LastOperation, worker.Status.LastError = extensionscontroller.ReconcileSucceeded(lastOperationType, description)
 		return nil
 	})
+}
+
+func (r *reconciler) removeFinalizerFromWorker(worker *extensionsv1alpha1.Worker) error {
+	r.logger.Info("Removing finalizer.", "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
+	if err := extensionscontroller.DeleteFinalizer(r.ctx, r.client, FinalizerName, worker); err != nil {
+		r.logger.Error(err, "Error removing finalizer from Worker", "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
+		return err
+	}
+	return nil
+}
+
+func (r *reconciler) migrate(worker *extensionsv1alpha1.Worker, cluster *extensionscontroller.Cluster) (reconcile.Result, error) {
+	if err := r.updateStatusProcessing(r.ctx, worker, gardencorev1beta1.LastOperationTypeMigrate, "Starting Migration of the worker"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.actuator.Migrate(r.ctx, worker, cluster); err != nil {
+		r.updateStatusError(r.ctx, extensionscontroller.ReconcileErrCauseOrErr(err), worker, gardencorev1beta1.LastOperationTypeMigrate, "Error migrating worker")
+		return extensionscontroller.ReconcileErr(err)
+	}
+
+	if err := r.updateStatusSuccess(r.ctx, worker, gardencorev1beta1.LastOperationTypeMigrate, "Successfully migrate worker"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.removeFinalizerFromWorker(worker); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// remove operation annotation 'migrate'
+	if err := removeAnnotation(r.ctx, r.client, worker, v1beta1constants.GardenerOperation); err != nil {
+		r.logger.Error(err, "Error removing annotation from Worker", "annotation", fmt.Sprintf("%s/%s", v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationMigrate), "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) delete(worker *extensionsv1alpha1.Worker, cluster *extensionscontroller.Cluster) (reconcile.Result, error) {
+	hasFinalizer, err := extensionscontroller.HasFinalizer(worker, FinalizerName)
+	if err != nil {
+		r.logger.Error(err, "Could not instantiate finalizer deletion")
+		return reconcile.Result{}, err
+	}
+	if !hasFinalizer {
+		r.logger.Info("Deleting worker causes a no-op as there is no finalizer.", "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
+		return reconcile.Result{}, nil
+	}
+
+	if err := r.updateStatusProcessing(r.ctx, worker, gardencorev1beta1.LastOperationTypeDelete, "Deleting the worker"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.actuator.Delete(r.ctx, worker, cluster); err != nil {
+		r.updateStatusError(r.ctx, extensionscontroller.ReconcileErrCauseOrErr(err), worker, gardencorev1beta1.LastOperationTypeDelete, "Error deleting worker")
+
+		return extensionscontroller.ReconcileErr(err)
+	}
+
+	if err := r.updateStatusSuccess(r.ctx, worker, gardencorev1beta1.LastOperationTypeDelete, "Successfully deleted worker"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	err = r.removeFinalizerFromWorker(worker)
+	return reconcile.Result{}, err
+}
+
+func (r *reconciler) reconcile(worker *extensionsv1alpha1.Worker, cluster *extensionscontroller.Cluster, operationType gardencorev1beta1.LastOperationType) (reconcile.Result, error) {
+	if err := controller.EnsureFinalizer(r.ctx, r.client, FinalizerName, worker); err != nil {
+		return reconcile.Result{}, err
+	}
+	if err := r.updateStatusProcessing(r.ctx, worker, operationType, "Reconciling the worker"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.actuator.Reconcile(r.ctx, worker, cluster); err != nil {
+		r.updateStatusError(r.ctx, err, worker, operationType, "Error reconciling worker")
+		return extensionscontroller.ReconcileErr(err)
+	}
+
+	if err := r.updateStatusSuccess(r.ctx, worker, operationType, "Successfully reconciled worker"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) restore(worker *extensionsv1alpha1.Worker, cluster *extensionscontroller.Cluster, operationType gardencorev1beta1.LastOperationType) (reconcile.Result, error) {
+	if err := r.updateStatusProcessing(r.ctx, worker, operationType, "Restoring the worker"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.actuator.Restore(r.ctx, worker, cluster); err != nil {
+		r.updateStatusError(r.ctx, extensionscontroller.ReconcileErrCauseOrErr(err), worker, operationType, "Error restoring worker")
+		return extensionscontroller.ReconcileErr(err)
+	}
+
+	// remove operation annotation 'restore'
+	if err := removeAnnotation(r.ctx, r.client, worker, v1beta1constants.GardenerOperation); err != nil {
+		r.logger.Error(err, "Error removing annotation from Worker", "annotation", fmt.Sprintf("%s/%s", v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationRestore), "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
+		return reconcile.Result{}, err
+	}
+
+	// requeue to triger reconciliation
+	return reconcile.Result{Requeue: true}, nil
+}
+
+func removeAnnotation(ctx context.Context, c client.Client, worker *extensionsv1alpha1.Worker, annotation string) error {
+	withOpAnnotation := worker.DeepCopyObject()
+	delete(worker.Annotations, annotation)
+	return c.Patch(ctx, worker, client.MergeFrom(withOpAnnotation))
+}
+
+func isWorkerMigrated(worker *extensionsv1alpha1.Worker) bool {
+	return worker.Status.LastOperation != nil &&
+		worker.Status.LastOperation.GetType() == gardencorev1beta1.LastOperationTypeMigrate &&
+		worker.Status.LastOperation.GetState() == gardencorev1beta1.LastOperationStateSucceeded
 }

--- a/pkg/controller/worker/reconciler_test.go
+++ b/pkg/controller/worker/reconciler_test.go
@@ -1,0 +1,423 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker_test
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/gardener/gardener-extensions/pkg/controller"
+	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
+	"github.com/gardener/gardener-extensions/pkg/controller/worker"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	extensionsclient "github.com/gardener/gardener/pkg/client/extensions/clientset/versioned/scheme"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+var _ = Describe("Worker Reconcile", func() {
+	type fields struct {
+		logger   logr.Logger
+		actuator worker.Actuator
+		ctx      context.Context
+		client   client.Client
+	}
+	type args struct {
+		request reconcile.Request
+	}
+	type test struct {
+		fields  fields
+		args    args
+		want    reconcile.Result
+		wantErr bool
+	}
+
+	//Ummutable throuth the function calls
+	arguments := args{
+		request: reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "workerTestReconcile",
+				Namespace: "test",
+			},
+		},
+	}
+
+	var logger logr.Logger
+
+	BeforeEach(func() {
+		logger = log.Log.WithName("Reconcile-Test-Controller")
+	})
+
+	DescribeTable("Reconcile function", func(t *test) {
+		reconciler := worker.NewReconciler(nil, t.fields.actuator)
+		expectInject(inject.ClientInto(t.fields.client, reconciler))
+		expectInject(inject.InjectorInto(inject.Func(func(i interface{}) error {
+			expectInject(inject.ClientInto(t.fields.client, i))
+			expectInject(inject.StopChannelInto(make(chan struct{}), i))
+			return nil
+		}), reconciler))
+
+		got, err := reconciler.Reconcile(t.args.request)
+		Expect(err != nil).To(Equal(t.wantErr))
+		Expect(reflect.DeepEqual(got, t.want)).To(BeTrue())
+	},
+		Entry("test reconcile", &test{
+			fields: fields{
+				logger:   logger,
+				actuator: newFakeActuator(true, false, false, false),
+				ctx:      context.TODO(),
+				client: fake.NewFakeClientWithScheme(
+					extensionsclient.Scheme,
+					addOperationAnnotationToWorker(
+						getWorker(),
+						v1beta1constants.GardenerOperationReconcile),
+					getCluster()),
+			},
+			args:    arguments,
+			want:    reconcile.Result{},
+			wantErr: false,
+		}),
+		Entry("test after successful migrate", &test{
+			fields: fields{
+				logger:   logger,
+				actuator: newFakeActuator(false, false, false, false),
+				ctx:      context.TODO(),
+				client: fake.NewFakeClientWithScheme(
+					extensionsclient.Scheme,
+					addDeletionTimestampToWorker(
+						addOperationAnnotationToWorker(
+							addLastOperationToWorker(
+								getWorker(),
+								gardencorev1beta1.LastOperationTypeMigrate,
+								gardencorev1beta1.LastOperationStateSucceeded,
+								"Migrate worker"),
+							v1beta1constants.GardenerOperationReconcile)),
+					getCluster()),
+			},
+			args:    arguments,
+			want:    reconcile.Result{},
+			wantErr: false,
+		}),
+		Entry("test migrate when operrationAnnotation Migrate occurs", &test{
+			fields: fields{
+				logger:   logger,
+				actuator: newFakeActuator(false, false, false, true),
+				ctx:      context.TODO(),
+				client: fake.NewFakeClientWithScheme(
+					extensionsclient.Scheme,
+					addOperationAnnotationToWorker(
+						getWorker(),
+						v1beta1constants.GardenerOperationMigrate),
+					getCluster()),
+			},
+			args:    arguments,
+			want:    reconcile.Result{},
+			wantErr: false,
+		}),
+		Entry("test error during migrate when operrationAnnotation Migrate occurs", &test{
+			fields: fields{
+				logger:   logger,
+				actuator: newFakeActuator(false, false, false, false),
+				ctx:      context.TODO(),
+				client: fake.NewFakeClientWithScheme(
+					extensionsclient.Scheme,
+					addOperationAnnotationToWorker(
+						getWorker(),
+						v1beta1constants.GardenerOperationMigrate),
+					getCluster()),
+			},
+			args:    arguments,
+			want:    reconcile.Result{},
+			wantErr: true,
+		}),
+		Entry("test Migrate after unssuccesful Migrate", &test{
+			fields: fields{
+				logger:   logger,
+				actuator: newFakeActuator(false, false, false, true),
+				ctx:      context.TODO(),
+				client: fake.NewFakeClientWithScheme(
+					extensionsclient.Scheme,
+					addLastOperationToWorker(
+						getWorker(),
+						gardencorev1beta1.LastOperationTypeMigrate,
+						gardencorev1beta1.LastOperationStateFailed,
+						"Migrate worker"),
+					getCluster()),
+			},
+			args:    arguments,
+			want:    reconcile.Result{},
+			wantErr: false,
+		}),
+		Entry("test error during Migrate after unssuccesful Migrate", &test{
+			fields: fields{
+				logger:   logger,
+				actuator: newFakeActuator(true, true, true, false),
+				ctx:      context.TODO(),
+				client: fake.NewFakeClientWithScheme(
+					extensionsclient.Scheme,
+					addLastOperationToWorker(
+						getWorker(),
+						gardencorev1beta1.LastOperationTypeMigrate,
+						gardencorev1beta1.LastOperationStateFailed,
+						"Migrate worker"),
+					getCluster()),
+			},
+			args:    arguments,
+			want:    reconcile.Result{},
+			wantErr: true,
+		}),
+		Entry("test Delete Worker", &test{
+			fields: fields{
+				logger:   logger,
+				actuator: newFakeActuator(false, true, false, false),
+				ctx:      context.TODO(),
+				client: fake.NewFakeClientWithScheme(
+					extensionsclient.Scheme,
+					addFinalizerToWorker(addDeletionTimestampToWorker(getWorker()), worker.FinalizerName),
+					getCluster()),
+			},
+			args:    arguments,
+			want:    reconcile.Result{},
+			wantErr: false,
+		}),
+		Entry("test error when Delete Worker", &test{
+			fields: fields{
+				logger:   logger,
+				actuator: newFakeActuator(true, false, true, true),
+				ctx:      context.TODO(),
+				client: fake.NewFakeClientWithScheme(
+					extensionsclient.Scheme,
+					addFinalizerToWorker(addDeletionTimestampToWorker(getWorker()), worker.FinalizerName),
+					getCluster()),
+			},
+			args:    arguments,
+			want:    reconcile.Result{},
+			wantErr: true,
+		}),
+		Entry("test restore when operrationAnnotation Restore occurs", &test{
+			fields: fields{
+				logger:   logger,
+				actuator: newFakeActuator(false, false, true, false),
+				ctx:      context.TODO(),
+				client: fake.NewFakeClientWithScheme(
+					extensionsclient.Scheme,
+					addOperationAnnotationToWorker(
+						getWorker(),
+						v1beta1constants.GardenerOperationRestore),
+					getCluster()),
+			},
+			args:    arguments,
+			want:    reconcile.Result{Requeue: true},
+			wantErr: false,
+		}),
+		Entry("test error restore when operrationAnnotation Restore occurs", &test{
+			fields: fields{
+				logger:   logger,
+				actuator: newFakeActuator(true, true, false, true),
+				ctx:      context.TODO(),
+				client: fake.NewFakeClientWithScheme(
+					extensionsclient.Scheme,
+					addOperationAnnotationToWorker(
+						getWorker(),
+						v1beta1constants.GardenerOperationRestore),
+					getCluster()),
+			},
+			args:    arguments,
+			want:    reconcile.Result{},
+			wantErr: true,
+		}),
+		Entry("test reconcile after failed reconcilation", &test{
+			fields: fields{
+				logger:   logger,
+				actuator: newFakeActuator(true, false, false, false),
+				ctx:      context.TODO(),
+				client: fake.NewFakeClientWithScheme(
+					extensionsclient.Scheme,
+					addLastOperationToWorker(
+						getWorker(),
+						gardencorev1beta1.LastOperationTypeReconcile,
+						gardencorev1beta1.LastOperationStateFailed,
+						"Reconcile worker"),
+					getCluster()),
+			},
+			args:    arguments,
+			want:    reconcile.Result{},
+			wantErr: false,
+		}),
+		Entry("test reconcile after successful restoration reconcilation", &test{
+			fields: fields{
+				logger:   logger,
+				actuator: newFakeActuator(true, false, false, false),
+				ctx:      context.TODO(),
+				client: fake.NewFakeClientWithScheme(
+					extensionsclient.Scheme,
+					addLastOperationToWorker(
+						getWorker(),
+						gardencorev1beta1.LastOperationTypeReconcile,
+						gardencorev1beta1.LastOperationStateProcessing,
+						"Processs worker reconcilation"),
+					getCluster()),
+			},
+			args:    arguments,
+			want:    reconcile.Result{},
+			wantErr: false,
+		}),
+		Entry("test error while reconciliation after failed reconcilation", &test{
+			fields: fields{
+				logger:   logger,
+				actuator: newFakeActuator(false, true, true, true),
+				ctx:      context.TODO(),
+				client: fake.NewFakeClientWithScheme(
+					extensionsclient.Scheme,
+					addLastOperationToWorker(
+						getWorker(),
+						gardencorev1beta1.LastOperationTypeReconcile,
+						gardencorev1beta1.LastOperationStateFailed,
+						"Reconcile worker"),
+					getCluster()),
+			},
+			args:    arguments,
+			want:    reconcile.Result{},
+			wantErr: true,
+		}),
+		Entry("test error while reconciliation after successful restoration reconcilation", &test{
+			fields: fields{
+				logger:   logger,
+				actuator: newFakeActuator(false, true, true, true),
+				ctx:      context.TODO(),
+				client: fake.NewFakeClientWithScheme(
+					extensionsclient.Scheme,
+					addLastOperationToWorker(
+						getWorker(),
+						gardencorev1beta1.LastOperationTypeReconcile,
+						gardencorev1beta1.LastOperationStateProcessing,
+						"Processs worker reconcilation"),
+					getCluster()),
+			},
+			args:    arguments,
+			want:    reconcile.Result{},
+			wantErr: true,
+		}),
+	)
+})
+
+func getWorker() *extensionsv1alpha1.Worker {
+	return &extensionsv1alpha1.Worker{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Worker",
+			APIVersion: "extensions.gardener.cloud/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "workerTestReconcile",
+			Namespace: "test",
+		},
+		Spec: extensionsv1alpha1.WorkerSpec{},
+	}
+}
+
+func addOperationAnnotationToWorker(worker *extensionsv1alpha1.Worker, annotation string) *extensionsv1alpha1.Worker {
+	worker.Annotations = make(map[string]string)
+	worker.Annotations[v1beta1constants.GardenerOperation] = annotation
+	return worker
+}
+
+func addLastOperationToWorker(worker *extensionsv1alpha1.Worker, lastOperationType gardencorev1beta1.LastOperationType, lastOperationState gardencorev1beta1.LastOperationState, description string) *extensionsv1alpha1.Worker {
+	worker.Status.LastOperation = extensionscontroller.LastOperation(lastOperationType, lastOperationState, 1, description)
+	return worker
+}
+
+func addDeletionTimestampToWorker(worker *extensionsv1alpha1.Worker) *extensionsv1alpha1.Worker {
+	worker.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	return worker
+}
+
+func addFinalizerToWorker(worker *extensionsv1alpha1.Worker, finalizer string) *extensionsv1alpha1.Worker {
+	worker.Finalizers = append(worker.Finalizers, finalizer)
+	return worker
+}
+
+func getCluster() *extensionsv1alpha1.Cluster {
+	return &extensionsv1alpha1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Cluster",
+			APIVersion: "extensions.gardener.cloud/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+	}
+}
+
+type fakeActuator struct {
+	reconcile bool
+	delete    bool
+	restore   bool
+	migrate   bool
+}
+
+func newFakeActuator(reconcile, delete, restore, migrate bool) worker.Actuator {
+	return &fakeActuator{
+		reconcile: reconcile,
+		delete:    delete,
+		restore:   restore,
+		migrate:   migrate,
+	}
+}
+
+func (a *fakeActuator) Reconcile(ctx context.Context, worker *extensionsv1alpha1.Worker, cluster *controller.Cluster) error {
+	if a.reconcile {
+		return nil
+	}
+	return fmt.Errorf("Wrong function call: actuator Reconcile")
+}
+
+func (a *fakeActuator) Delete(ctx context.Context, worker *extensionsv1alpha1.Worker, cluster *controller.Cluster) error {
+	if a.delete {
+		return nil
+	}
+	return fmt.Errorf("Wrong function call: actuator Delete")
+}
+
+func (a *fakeActuator) Restore(ctx context.Context, worker *extensionsv1alpha1.Worker, cluster *controller.Cluster) error {
+	if a.restore {
+		return nil
+	}
+	return fmt.Errorf("Wrong function call: actuator Restore")
+}
+
+func (a *fakeActuator) Migrate(ctx context.Context, worker *extensionsv1alpha1.Worker, cluster *controller.Cluster) error {
+	if a.migrate {
+		return nil
+	}
+	return fmt.Errorf("Wrong function call: actuator Migrate")
+}
+
+func expectInject(ok bool, err error) {
+	Expect(err).NotTo(HaveOccurred())
+	Expect(ok).To(BeTrue(), "no injection happened")
+}

--- a/pkg/controller/worker/state_actuator.go
+++ b/pkg/controller/worker/state_actuator.go
@@ -1,0 +1,218 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"context"
+	"encoding/json"
+
+	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	machineDeploymentKind = "MachineDeployment"
+	nameLabel             = "name"
+	machineSetKind        = "MachineSet"
+)
+
+type genericStateActuator struct {
+	logger logr.Logger
+
+	client client.Client
+}
+
+// NewStateActuator creates a new Actuator that reconciles Worker's State subresource
+// It provides a default implementation that allows easier integration of providers.
+func NewStateActuator(logger logr.Logger) StateActuator {
+	return &genericStateActuator{logger: logger.WithName("worker-state-actuator")}
+}
+
+func (a *genericStateActuator) InjectClient(client client.Client) error {
+	a.client = client
+	return nil
+}
+
+// Reconcile update the Worker state with the latest.
+func (a *genericStateActuator) Reconcile(ctx context.Context, worker *extensionsv1alpha1.Worker) error {
+	copyOfWorker := worker.DeepCopy()
+	if err := a.updateWorkerState(ctx, copyOfWorker); err != nil {
+		return errors.Wrapf(err, "failed to update the state in worker status")
+	}
+
+	return nil
+}
+
+func (a *genericStateActuator) updateWorkerState(ctx context.Context, worker *extensionsv1alpha1.Worker) error {
+	state, err := a.getWorkerState(ctx, worker.Namespace)
+	if err != nil {
+		return err
+	}
+	rawState, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, a.client, worker, func() error {
+		worker.Status.State = &runtime.RawExtension{Raw: rawState}
+		return nil
+	})
+}
+
+func (a *genericStateActuator) getWorkerState(ctx context.Context, namespace string) (*State, error) {
+	existingMachineDeployments := &machinev1alpha1.MachineDeploymentList{}
+	if err := a.client.List(ctx, existingMachineDeployments, client.InNamespace(namespace)); err != nil {
+		return nil, err
+	}
+
+	machineSets, err := a.getExistingMachineSetsMap(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	machines, err := a.getExistingMachinesMap(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	workerState := &State{
+		MachineDeployments: make(map[string]*MachineDeploymentState),
+	}
+	for _, deployment := range existingMachineDeployments.Items {
+		machineDeploymentState := &MachineDeploymentState{}
+
+		machineDeploymentState.Replicas = deployment.Spec.Replicas
+
+		machineDeploymentMachineSets, ok := machineSets[deployment.Name]
+		if !ok {
+			continue
+		}
+		addMachineSetToMachineDeploymentState(machineDeploymentMachineSets, machineDeploymentState)
+
+		for _, machineSet := range machineDeploymentMachineSets {
+			currentMachines := append(machines[machineSet.Name], machines[deployment.Name]...)
+			if len(currentMachines) <= 0 {
+				continue
+			}
+
+			for index := range currentMachines {
+				addMachineToMachineDeploymentState(&currentMachines[index], machineDeploymentState)
+			}
+		}
+
+		workerState.MachineDeployments[deployment.Name] = machineDeploymentState
+	}
+
+	return workerState, nil
+}
+
+// getExistingMachineSetsMap returns a map of existing MachineSets as values and their owners as keys
+func (a *genericStateActuator) getExistingMachineSetsMap(ctx context.Context, namespace string) (map[string][]machinev1alpha1.MachineSet, error) {
+	existingMachineSets := &machinev1alpha1.MachineSetList{}
+	if err := a.client.List(ctx, existingMachineSets, client.InNamespace(namespace)); err != nil {
+		return nil, err
+	}
+
+	machineSets := make(map[string][]machinev1alpha1.MachineSet)
+	for index, machineSet := range existingMachineSets.Items {
+		if len(machineSet.OwnerReferences) > 0 {
+			for _, referant := range machineSet.OwnerReferences {
+				if referant.Kind == machineDeploymentKind {
+					machineSets[referant.Name] = append(machineSets[referant.Name], existingMachineSets.Items[index])
+				}
+			}
+		} else if len(machineSet.Labels) > 0 {
+			if machineDeploymentName, ok := machineSet.Labels[nameLabel]; ok {
+				machineSets[machineDeploymentName] = append(machineSets[machineDeploymentName], existingMachineSets.Items[index])
+			}
+		}
+	}
+	return machineSets, nil
+}
+
+// getExistingMachinesMap returns a map of the existing Machines as values and the name of their owner
+// no matter of being machineSet or MachineDeployment. If a Machine has a ownerRefernce the key(owner)
+// will be the MachineSet if not the key will be the name of the MachineDeployment which is stored as
+// a lable. We assume that there is no MachineDeployment and MachineSet with the same names.
+func (a *genericStateActuator) getExistingMachinesMap(ctx context.Context, namespace string) (map[string][]machinev1alpha1.Machine, error) {
+	existingMachines := &machinev1alpha1.MachineList{}
+	if err := a.client.List(ctx, existingMachines, client.InNamespace(namespace)); err != nil {
+		return nil, err
+	}
+
+	machines := make(map[string][]machinev1alpha1.Machine)
+	for index, machine := range existingMachines.Items {
+		if len(machine.OwnerReferences) > 0 {
+			for _, referant := range machine.OwnerReferences {
+				if referant.Kind == machineSetKind {
+					machines[referant.Name] = append(machines[referant.Name], existingMachines.Items[index])
+				}
+			}
+		} else if len(machine.Labels) > 0 {
+			if machineDeploymentName, ok := machine.Labels[nameLabel]; ok {
+				machines[machineDeploymentName] = append(machines[machineDeploymentName], existingMachines.Items[index])
+			}
+		}
+	}
+	return machines, nil
+}
+
+func addMachineSetToMachineDeploymentState(machineSets []machinev1alpha1.MachineSet, machineDeploymentState *MachineDeploymentState) {
+	if len(machineSets) < 1 || machineDeploymentState == nil {
+		return
+	}
+
+	//remove redundant data from the machine set
+	for index := range machineSets {
+		machineSet := &machineSets[index]
+		machineSet.ObjectMeta = metav1.ObjectMeta{
+			Name:        machineSet.Name,
+			Namespace:   machineSet.Namespace,
+			Annotations: machineSet.Annotations,
+			Labels:      machineSet.Labels,
+		}
+		machineSet.OwnerReferences = nil
+		machineSet.Status = machinev1alpha1.MachineSetStatus{}
+	}
+
+	machineDeploymentState.MachineSets = machineSets
+}
+
+func addMachineToMachineDeploymentState(machine *machinev1alpha1.Machine, machineDeploymentState *MachineDeploymentState) {
+	if machine == nil || machineDeploymentState == nil {
+		return
+	}
+
+	//remove redundant data from the machine
+	machine.ObjectMeta = metav1.ObjectMeta{
+		Name:        machine.Name,
+		Namespace:   machine.Namespace,
+		Annotations: machine.Annotations,
+		Labels:      machine.Labels,
+	}
+	machine.OwnerReferences = nil
+	machine.Status = machinev1alpha1.MachineStatus{
+		Node: machine.Status.Node,
+	}
+
+	machineDeploymentState.Machines = append(machineDeploymentState.Machines, *machine)
+}

--- a/pkg/controller/worker/state_reconciler.go
+++ b/pkg/controller/worker/state_reconciler.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"context"
+	"fmt"
+
+	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
+	"github.com/gardener/gardener-extensions/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+const (
+	// StartToSyncState is used as part of the Event 'reason' when a Worker state starts to synchronize
+	StartToSyncState = "SynchronizingState"
+	// SuccessSynced is used as part of the Event 'reason' when a Worker state is synced
+	SuccessSynced = "StateSynced"
+	// ErrorStateSync is used as part of the Event 'reason' when a Worker state fail to sync
+	ErrorStateSync = "ErrorSynchronizingState"
+	// StateSyncControllerName is the name of the controller which synchronize the Worker state
+	StateSyncControllerName = "worker-state-controller"
+)
+
+type stateReconciler struct {
+	logger   logr.Logger
+	actuator StateActuator
+	recorder record.EventRecorder
+
+	ctx    context.Context
+	client client.Client
+}
+
+// NewStateReconciler creates a new reconcile.Reconciler that reconciles
+// Worker's State resources of Gardener's `extensions.gardener.cloud` API group.
+func NewStateReconciler(mgr manager.Manager, actuator StateActuator) reconcile.Reconciler {
+	return &stateReconciler{
+		logger:   log.Log.WithName(StateUpdatingControllerName),
+		actuator: actuator,
+		recorder: mgr.GetEventRecorderFor(StateSyncControllerName),
+	}
+}
+
+func (r *stateReconciler) InjectFunc(f inject.Func) error {
+	return f(r.actuator)
+}
+
+func (r *stateReconciler) InjectClient(client client.Client) error {
+	r.client = client
+	return nil
+}
+
+func (r *stateReconciler) InjectStopChannel(stopCh <-chan struct{}) error {
+	r.ctx = util.ContextFromStopChannel(stopCh)
+	return nil
+}
+
+func (r *stateReconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	worker := &extensionsv1alpha1.Worker{}
+	if err := r.client.Get(r.ctx, request.NamespacedName, worker); err != nil {
+		if errors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	// Deletion flow
+	if worker.DeletionTimestamp != nil {
+		//Nothing to do
+		return reconcile.Result{}, nil
+	}
+
+	// Reconcile flow
+	operationType := gardencorev1beta1helper.ComputeOperationType(worker.ObjectMeta, worker.Status.LastOperation)
+	if operationType != gardencorev1beta1.LastOperationTypeReconcile {
+		return reconcile.Result{Requeue: true}, nil
+	} else if isWorkerMigrated(worker) {
+		//Nothing to do
+		return reconcile.Result{}, nil
+	}
+
+	r.recorder.Event(worker, corev1.EventTypeNormal, StartToSyncState, "Updating the worker state")
+
+	if err := r.actuator.Reconcile(r.ctx, worker); err != nil {
+		msg := "Error updating worker state"
+		r.logger.Error(err, msg, "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
+		r.recorder.Event(worker, corev1.EventTypeWarning, ErrorStateSync, msg)
+		return extensionscontroller.ReconcileErr(err)
+	}
+
+	msg := "Successfully update worker state"
+	r.logger.Info(msg, "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
+	r.recorder.Event(worker, corev1.EventTypeNormal, SuccessSynced, msg)
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/handler/mapper.go
+++ b/pkg/handler/mapper.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	extensionspredicate "github.com/gardener/gardener-extensions/pkg/predicate"
-
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -158,7 +158,9 @@ func HasName(name string) predicate.Predicate {
 // HasOperationAnnotation is a predicate for the operation annotation.
 func HasOperationAnnotation() predicate.Predicate {
 	return FromMapper(MapperFunc(func(e event.GenericEvent) bool {
-		return e.Meta.GetAnnotations()[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationReconcile
+		return e.Meta.GetAnnotations()[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationReconcile ||
+			e.Meta.GetAnnotations()[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationRestore ||
+			e.Meta.GetAnnotations()[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationMigrate
 	}), CreateTrigger, UpdateNewTrigger, GenericTrigger)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR we expand the worker actuator interface with Restore and Migrate functions.

The restoration restore previous state stored under worker.status.state which consist of machineDeloyments, machineSets and Machenes. Thus wen we migrate a shoot control plane, we keep the existing VM representing the shoot cluster nodes.

The migration makes shallow deletion of MachineClass, MachineSecrets, MachineDeployment, MachineSets and Machines. This shallow deletion remove Machine-Control-Manager from the shoot control plane, then remove the finalizers and then delete the resources. Thus we don't allow the MCM to delete the shoot nodes.

With this PR we also add a sidecar controller which handles any changes related to the Machine resources and if needed update the worker.status.state subresource.  
**Which issue(s) this PR fixes**:
Part of  [#1631](https://github.com/gardener/gardener/issues/1631)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
- Add Separate sidecar controller to save worker state under Worker.Status.State
- Add Worker.Status.State restoration functionality 
- Add migration functionality
```
