### PR TITLE
Remove .spec.activeDeadlineSeconds from the terraformer Pod

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,7 @@ github.com/gardener/external-dns-management v0.7.3 h1:SAW9ur2mjZ+x89xbmcplJgqNUm
 github.com/gardener/external-dns-management v0.7.3/go.mod h1:Y3om11E865x4aQ7cmcHjknb8RMgCO153huRb/SvP+9o=
 github.com/gardener/gardener v1.0.1-0.20200213093126-7a6123b6ae21 h1:RuGhuc4SdfS6q20u2slVPofigoto36i1b5LHRKTkqgo=
 github.com/gardener/gardener v1.0.1-0.20200213093126-7a6123b6ae21/go.mod h1:CP9I0tCDVXTLPkJv/jUtXVUh948kSNKEGUg0haLz9gk=
+github.com/gardener/gardener v1.0.4 h1:ChZgQ3NCraQ6WrMuSdawCAHQQ4eOpw5zNxO7u9utMsg=
 github.com/gardener/gardener-resource-manager v0.10.0 h1:6OUKoWI3oha42F0oJN8OEo3UR+D3onOCel4Th+zgotU=
 github.com/gardener/gardener-resource-manager v0.10.0/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=
 github.com/gardener/hvpa-controller v0.0.0-20191014062307-fad3bdf06a25 h1:nOFITmV7vt4fcYPEXgj66Qs83FdDEMvL/LQcR0diRRE=

--- a/pkg/mock/gardener-extensions/terraformer/mocks.go
+++ b/pkg/mock/gardener-extensions/terraformer/mocks.go
@@ -130,20 +130,6 @@ func (mr *MockTerraformerMockRecorder) InitializeWith(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitializeWith", reflect.TypeOf((*MockTerraformer)(nil).InitializeWith), arg0)
 }
 
-// SetActiveDeadlineSeconds mocks base method
-func (m *MockTerraformer) SetActiveDeadlineSeconds(arg0 int64) terraformer.Terraformer {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetActiveDeadlineSeconds", arg0)
-	ret0, _ := ret[0].(terraformer.Terraformer)
-	return ret0
-}
-
-// SetActiveDeadlineSeconds indicates an expected call of SetActiveDeadlineSeconds
-func (mr *MockTerraformerMockRecorder) SetActiveDeadlineSeconds(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetActiveDeadlineSeconds", reflect.TypeOf((*MockTerraformer)(nil).SetActiveDeadlineSeconds), arg0)
-}
-
 // SetDeadlineCleaning mocks base method
 func (m *MockTerraformer) SetDeadlineCleaning(arg0 time.Duration) terraformer.Terraformer {
 	m.ctrl.T.Helper()
@@ -170,6 +156,20 @@ func (m *MockTerraformer) SetDeadlinePod(arg0 time.Duration) terraformer.Terrafo
 func (mr *MockTerraformerMockRecorder) SetDeadlinePod(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDeadlinePod", reflect.TypeOf((*MockTerraformer)(nil).SetDeadlinePod), arg0)
+}
+
+// SetTerminationGracePeriodSeconds mocks base method
+func (m *MockTerraformer) SetTerminationGracePeriodSeconds(arg0 int64) terraformer.Terraformer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetTerminationGracePeriodSeconds", arg0)
+	ret0, _ := ret[0].(terraformer.Terraformer)
+	return ret0
+}
+
+// SetTerminationGracePeriodSeconds indicates an expected call of SetTerminationGracePeriodSeconds
+func (mr *MockTerraformerMockRecorder) SetTerminationGracePeriodSeconds(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTerminationGracePeriodSeconds", reflect.TypeOf((*MockTerraformer)(nil).SetTerminationGracePeriodSeconds), arg0)
 }
 
 // SetVariablesEnvironment mocks base method

--- a/pkg/terraformer/config.go
+++ b/pkg/terraformer/config.go
@@ -45,9 +45,9 @@ func (t *terraformer) SetVariablesEnvironment(tfvarsEnvironment map[string]strin
 	return t
 }
 
-// SetActiveDeadlineSeconds configures the active deadline seconds for the Terraformer pod.
-func (t *terraformer) SetActiveDeadlineSeconds(adl int64) Terraformer {
-	t.activeDeadlineSeconds = adl
+// SetTerminationGracePeriodSeconds configures the .spec.terminationGracePeriodSeconds for the Terraformer pod.
+func (t *terraformer) SetTerminationGracePeriodSeconds(terminationGracePeriodSeconds int64) Terraformer {
+	t.terminationGracePeriodSeconds = terminationGracePeriodSeconds
 	return t
 }
 

--- a/pkg/terraformer/terraformer.go
+++ b/pkg/terraformer/terraformer.go
@@ -114,7 +114,7 @@ func New(
 		variablesName: prefix + TerraformerVariablesSuffix,
 		stateName:     prefix + TerraformerStateSuffix,
 
-		activeDeadlineSeconds: int64(3600),
+		terminationGracePeriodSeconds: int64(3600),
 
 		deadlineCleaning: 10 * time.Minute,
 		deadlinePod:      20 * time.Minute,
@@ -336,13 +336,11 @@ func (t *terraformer) podSpec(scriptName string) *corev1.PodSpec {
 		tfStateVolumeMountPath = "tf-state-in"
 	)
 
-	activeDeadlineSeconds := t.activeDeadlineSeconds
-	terminationGracePeriodSeconds := t.activeDeadlineSeconds
+	terminationGracePeriodSeconds := t.terminationGracePeriodSeconds
 	shCommand := fmt.Sprintf("sh /terraform.sh %s 2>&1; [[ -f /success ]] && exit 0 || exit 1", scriptName)
 
 	return &corev1.PodSpec{
-		RestartPolicy:         corev1.RestartPolicyNever,
-		ActiveDeadlineSeconds: &activeDeadlineSeconds,
+		RestartPolicy: corev1.RestartPolicyNever,
 		Containers: []corev1.Container{
 			{
 				Name:            "terraform",

--- a/pkg/terraformer/types.go
+++ b/pkg/terraformer/types.go
@@ -36,7 +36,7 @@ import (
 //   with TF_VAR_).
 // * configurationDefined indicates whether the required configuration ConfigMaps/Secrets have been
 //   successfully defined.
-// * activeDeadlineSeconds is the respective Pod spec field passed to Terraformer Pods.
+// * terminationGracePeriodSeconds is the respective Pod spec field passed to Terraformer Pods.
 // * deadlineCleaning is the timeout to wait Terraformer Pods to be cleaned up.
 // * deadlinePod is the time to wait apply/destroy Pod to be completed.
 type terraformer struct {
@@ -55,7 +55,7 @@ type terraformer struct {
 	variablesEnvironment map[string]string
 	configurationDefined bool
 
-	activeDeadlineSeconds int64
+	terminationGracePeriodSeconds int64
 
 	deadlineCleaning time.Duration
 	deadlinePod      time.Duration
@@ -89,7 +89,7 @@ const (
 // Terraformer is the Terraformer interface.
 type Terraformer interface {
 	SetVariablesEnvironment(tfVarsEnvironment map[string]string) Terraformer
-	SetActiveDeadlineSeconds(int64) Terraformer
+	SetTerminationGracePeriodSeconds(int64) Terraformer
 	SetDeadlineCleaning(time.Duration) Terraformer
 	SetDeadlinePod(time.Duration) Terraformer
 	InitializeWith(initializer Initializer) Terraformer


### PR DESCRIPTION
**What this PR does / why we need it**:
As discussed in #597, the delete request fo DeadlineExceed Pod completes right away and the Pod is removed from the store, but the associated container on the Node runs/lives for `.spec.terminationGracePeriodSeconds` before it is SIGKILL-ed.
This PR removes `.spec.activeDeadlineSeconds` from the terraformer Pod spec to prevent the case described above.

**Which issue(s) this PR fixes**:
Part of #597

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue causing running terraformer container to leak on the Node without associated Pod resource is now fixed. This will prevent multiple containers to execute `apply/destroy` commands simultaneously in some cases (especially for long running terraformer Pods).
```

