### PR TITLE
update credentials during worker deletion

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -126,7 +126,6 @@ github.com/gardener/external-dns-management v0.7.3 h1:SAW9ur2mjZ+x89xbmcplJgqNUm
 github.com/gardener/external-dns-management v0.7.3/go.mod h1:Y3om11E865x4aQ7cmcHjknb8RMgCO153huRb/SvP+9o=
 github.com/gardener/gardener v1.0.1-0.20200213093126-7a6123b6ae21 h1:RuGhuc4SdfS6q20u2slVPofigoto36i1b5LHRKTkqgo=
 github.com/gardener/gardener v1.0.1-0.20200213093126-7a6123b6ae21/go.mod h1:CP9I0tCDVXTLPkJv/jUtXVUh948kSNKEGUg0haLz9gk=
-github.com/gardener/gardener v1.0.4 h1:ChZgQ3NCraQ6WrMuSdawCAHQQ4eOpw5zNxO7u9utMsg=
 github.com/gardener/gardener-resource-manager v0.10.0 h1:6OUKoWI3oha42F0oJN8OEo3UR+D3onOCel4Th+zgotU=
 github.com/gardener/gardener-resource-manager v0.10.0/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=
 github.com/gardener/hvpa-controller v0.0.0-20191014062307-fad3bdf06a25 h1:nOFITmV7vt4fcYPEXgj66Qs83FdDEMvL/LQcR0diRRE=

--- a/pkg/controller/worker/genericactuator/actuator_delete.go
+++ b/pkg/controller/worker/genericactuator/actuator_delete.go
@@ -54,6 +54,12 @@ func (a *genericActuator) Delete(ctx context.Context, worker *extensionsv1alpha1
 		return err
 	}
 
+	// Redeploy generated machine classes to update credentials machine-controller-manager used.
+	a.logger.Info("Deploying the machine classes", "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
+	if err := workerDelegate.DeployMachineClasses(ctx); err != nil {
+		return errors.Wrapf(err, "failed to deploy the machine classes")
+	}
+
 	// Mark all existing machines to become forcefully deleted.
 	a.logger.Info("Deleting all machines", "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
 	if err := a.markAllMachinesForcefulDeletion(ctx, worker.Namespace); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, user cannot change the cloud provider credentials which machine-controller-manager used during worker deletion: The credentials referenced by <CloudProviderType>MachineClass is updated during worker reconciliation, however, when a worker has DeletionTimestamp, it can not be reconciled any more.
By redeploying machineclasses during worker deletion, we can get the specific credentials up-to-date.

**Which issue(s) this PR fixes**:
Fixes
- https://github.com/gardener/gardener-extension-provider-alicloud/issues/13
- https://github.com/gardener/gardener-extension-provider-aws/issues/19
- https://github.com/gardener/gardener-extension-provider-azure/issues/22
- https://github.com/gardener/gardener-extension-provider-gcp/issues/19
- https://github.com/gardener/gardener-extension-provider-openstack/issues/16
- https://github.com/gardener/gardener-extension-provider-vsphere/issues/4
- https://github.com/gardener/gardener-extension-provider-packet/issues/6

**Special notes for your reviewer**:
Worker controller is using generic actuator provided by gardener-extensions itself, so instead of fixing this issue in every provider respectively, we can fix it here.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Credentials used by machine-controller-manager are now updated during worker deletion.
```
