### PR TITLE
disable containerd until gardener is updated

### DIFF
--- a/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_util.go
+++ b/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_util.go
@@ -67,11 +67,13 @@ func CloudConfigFromOperatingSystemConfig(ctx context.Context, cli runtimeclient
 	}
 
 	return generator.Generate(&commonosgenerator.OperatingSystemConfig{
-		Bootstrap:           config.Spec.Purpose == extensionsv1alpha1.OperatingSystemConfigPurposeProvision,
-		Files:               files,
-		Units:               units,
-		Path:                config.Spec.ReloadConfigFilePath,
-		IsContainerDEnabled: config.Spec.CRIConfig != nil && config.Spec.CRIConfig.Name == extensionsv1alpha1.CRINameContainerD,
+		Bootstrap: config.Spec.Purpose == extensionsv1alpha1.OperatingSystemConfigPurposeProvision,
+		Files:     files,
+		Units:     units,
+		Path:      config.Spec.ReloadConfigFilePath,
+		// TODO @rfranzke @nimrodoron enable this once the CRIConfig field is actually added in the master.
+		// IsContainerDEnabled: config.Spec.CRIConfig != nil && config.Spec.CRIConfig.Name == extensionsv1alpha1.CRINameContainerD,
+		IsContainerDEnabled: false,
 	})
 }
 

--- a/pkg/controller/operatingsystemconfig/oscommon/template/template_generator.go
+++ b/pkg/controller/operatingsystemconfig/oscommon/template/template_generator.go
@@ -60,10 +60,9 @@ type initScriptData struct {
 
 // CloudInitGenerator generates cloud-init scripts.
 type CloudInitGenerator struct {
-	cloudInitTemplate   *template.Template
-	unitsPath           string
-	cmd                 string
-	isContainerDEnabled bool
+	cloudInitTemplate *template.Template
+	unitsPath         string
+	cmd               string
 }
 
 func b64(data []byte) string {


### PR DESCRIPTION
**What this PR does / why we need it**:

Master is not building at all.

**Which issue(s) this PR fixes**:

related #604 

```console
make verify
> Check
Executing check-generate
Executing golangci-lint
WARN [runner] Can't run linter unused: buildssa: analysis skipped: errors in package: [/go/go/src/github.com/gardener/gardener-extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_util.go:74:36: config.Spec.CRIConfig undefined (type v1alpha1.OperatingSystemConfigSpec has no field or method CRIConfig) /go/go/src/github.com/gardener/gardener-extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_util.go:74:68: config.Spec.CRIConfig undefined (type v1alpha1.OperatingSyste
mConfigSpec has no field or method CRIConfig) /go/go/src/github.com/gardener/gardener-extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_util.go:74:105: CRINameContainerD not declared by package v1alpha1]
WARN [runner] Can't run linter goanalysis_metalinter: assign: failed prerequisites: inspect@github.com/gardener/gardener-extensions/pkg/controller/operatingsystemconfig/oscommon/actuator
Checking for format issues with gofmt
All checks successful
> Generate

pkg/controller/operatingsystemconfig/oscommon/template/template_generator.go:66:2: `isContainerDEnabled` is unused (structcheck)
        isContainerDEnabled bool
        ^

Ginkgo ran 1 suite in 113.378346ms
Test Suite Failed
make: *** [test] Error 1
````

/cc @rfranzke @nimrodoron
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
