### PR TITLE
Make some Terraformer functions public

### DIFF
--- a/pkg/mock/gardener-extensions/terraformer/mocks.go
+++ b/pkg/mock/gardener-extensions/terraformer/mocks.go
@@ -53,6 +53,20 @@ func (mr *MockTerraformerMockRecorder) Apply() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockTerraformer)(nil).Apply))
 }
 
+// CleanupConfiguration mocks base method
+func (m *MockTerraformer) CleanupConfiguration(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanupConfiguration", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CleanupConfiguration indicates an expected call of CleanupConfiguration
+func (mr *MockTerraformerMockRecorder) CleanupConfiguration(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupConfiguration", reflect.TypeOf((*MockTerraformer)(nil).CleanupConfiguration), arg0)
+}
+
 // ConfigExists mocks base method
 func (m *MockTerraformer) ConfigExists() (bool, error) {
 	m.ctrl.T.Helper()
@@ -97,6 +111,21 @@ func (mr *MockTerraformerMockRecorder) GetRawState(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRawState", reflect.TypeOf((*MockTerraformer)(nil).GetRawState), arg0)
 }
 
+// GetState mocks base method
+func (m *MockTerraformer) GetState() ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetState")
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetState indicates an expected call of GetState
+func (mr *MockTerraformerMockRecorder) GetState() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetState", reflect.TypeOf((*MockTerraformer)(nil).GetState))
+}
+
 // GetStateOutputVariables mocks base method
 func (m *MockTerraformer) GetStateOutputVariables(arg0 ...string) (map[string]string, error) {
 	m.ctrl.T.Helper()
@@ -128,6 +157,21 @@ func (m *MockTerraformer) InitializeWith(arg0 terraformer.Initializer) terraform
 func (mr *MockTerraformerMockRecorder) InitializeWith(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitializeWith", reflect.TypeOf((*MockTerraformer)(nil).InitializeWith), arg0)
+}
+
+// NumberOfResources mocks base method
+func (m *MockTerraformer) NumberOfResources(arg0 context.Context) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NumberOfResources", arg0)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NumberOfResources indicates an expected call of NumberOfResources
+func (mr *MockTerraformerMockRecorder) NumberOfResources(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NumberOfResources", reflect.TypeOf((*MockTerraformer)(nil).NumberOfResources), arg0)
 }
 
 // SetDeadlineCleaning mocks base method

--- a/pkg/terraformer/state.go
+++ b/pkg/terraformer/state.go
@@ -40,8 +40,8 @@ type terraformStateV4 struct {
 	Outputs map[string]outputState `json:"outputs"`
 }
 
-// getState returns the Terraform state as byte slice.
-func (t *terraformer) getState() ([]byte, error) {
+// GetState returns the Terraform state as byte slice.
+func (t *terraformer) GetState() ([]byte, error) {
 	ctx := context.TODO()
 	configMap := &corev1.ConfigMap{}
 	if err := t.client.Get(ctx, kutil.Key(t.namespace, t.stateName), configMap); err != nil {
@@ -61,7 +61,7 @@ func (t *terraformer) GetStateOutputVariables(variables ...string) (map[string]s
 		foundVariables  = sets.NewString()
 	)
 
-	stateConfigMap, err := t.getState()
+	stateConfigMap, err := t.GetState()
 	if err != nil {
 		return nil, err
 	}
@@ -89,9 +89,9 @@ func (t *terraformer) GetStateOutputVariables(variables ...string) (map[string]s
 	return output, nil
 }
 
-// isStateEmpty returns true if the Terraform state is empty, and false otherwise.
-func (t *terraformer) isStateEmpty() bool {
-	state, err := t.getState()
+// IsStateEmpty returns true if the Terraform state is empty, and false otherwise.
+func (t *terraformer) IsStateEmpty() bool {
+	state, err := t.GetState()
 	if err != nil {
 		return apierrors.IsNotFound(err)
 	}

--- a/pkg/terraformer/terraformer.go
+++ b/pkg/terraformer/terraformer.go
@@ -134,7 +134,7 @@ func (t *terraformer) Destroy() error {
 	if err := t.execute(context.TODO(), "destroy"); err != nil {
 		return err
 	}
-	return t.cleanupConfiguration(context.TODO())
+	return t.CleanupConfiguration(context.TODO())
 }
 
 // execute creates a Terraform Pod which runs the provided scriptName (apply or destroy), waits for the Pod to be completed
@@ -175,7 +175,7 @@ func (t *terraformer) execute(ctx context.Context, scriptName string) error {
 	// because of syntax errors. In this case, we want to skip the Terraform destroy pod (as it wouldn't do anything
 	// anyway) and just delete the related ConfigMaps/Secrets.
 	if scriptName == "destroy" {
-		skipApplyOrDestroyPod = t.isStateEmpty()
+		skipApplyOrDestroyPod = t.IsStateEmpty()
 	}
 
 	if !skipApplyOrDestroyPod {

--- a/pkg/terraformer/types.go
+++ b/pkg/terraformer/types.go
@@ -95,9 +95,12 @@ type Terraformer interface {
 	InitializeWith(initializer Initializer) Terraformer
 	Apply() error
 	Destroy() error
+	GetRawState(context.Context) (*RawState, error)
+	GetState() ([]byte, error)
+	CleanupConfiguration(ctx context.Context) error
 	GetStateOutputVariables(variables ...string) (map[string]string, error)
 	ConfigExists() (bool, error)
-	GetRawState(context.Context) (*RawState, error)
+	NumberOfResources(context.Context) (int, error)
 }
 
 // Initializer can initialize a Terraformer.


### PR DESCRIPTION
**What this PR does / why we need it**:
Make some Terraformer functions public to help fixing https://github.com/gardener/gardener-extension-provider-aws/issues/18 and related issues.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
The Terraformer functions `IsStateEmpty`, `NumberOfResources`, `CleanupConfiguration`, and `GetState` are now exported.
```
