### PR TITLE
Add old object to mutators

### DIFF
--- a/pkg/mock/gardener-extensions/webhook/controlplane/genericmutator/mocks.go
+++ b/pkg/mock/gardener-extensions/webhook/controlplane/genericmutator/mocks.go
@@ -41,101 +41,101 @@ func (m *MockEnsurer) EXPECT() *MockEnsurerMockRecorder {
 }
 
 // EnsureAdditionalFiles mocks base method
-func (m *MockEnsurer) EnsureAdditionalFiles(arg0 context.Context, arg1 genericmutator.EnsurerContext, arg2 *[]v1alpha10.File) error {
+func (m *MockEnsurer) EnsureAdditionalFiles(arg0 context.Context, arg1 genericmutator.EnsurerContext, arg2, arg3 *[]v1alpha10.File) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureAdditionalFiles", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "EnsureAdditionalFiles", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureAdditionalFiles indicates an expected call of EnsureAdditionalFiles
-func (mr *MockEnsurerMockRecorder) EnsureAdditionalFiles(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureAdditionalFiles(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureAdditionalFiles", reflect.TypeOf((*MockEnsurer)(nil).EnsureAdditionalFiles), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureAdditionalFiles", reflect.TypeOf((*MockEnsurer)(nil).EnsureAdditionalFiles), arg0, arg1, arg2, arg3)
 }
 
 // EnsureAdditionalUnits mocks base method
-func (m *MockEnsurer) EnsureAdditionalUnits(arg0 context.Context, arg1 genericmutator.EnsurerContext, arg2 *[]v1alpha10.Unit) error {
+func (m *MockEnsurer) EnsureAdditionalUnits(arg0 context.Context, arg1 genericmutator.EnsurerContext, arg2, arg3 *[]v1alpha10.Unit) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureAdditionalUnits", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "EnsureAdditionalUnits", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureAdditionalUnits indicates an expected call of EnsureAdditionalUnits
-func (mr *MockEnsurerMockRecorder) EnsureAdditionalUnits(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureAdditionalUnits(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureAdditionalUnits", reflect.TypeOf((*MockEnsurer)(nil).EnsureAdditionalUnits), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureAdditionalUnits", reflect.TypeOf((*MockEnsurer)(nil).EnsureAdditionalUnits), arg0, arg1, arg2, arg3)
 }
 
 // EnsureETCD mocks base method
-func (m *MockEnsurer) EnsureETCD(arg0 context.Context, arg1 genericmutator.EnsurerContext, arg2 *v1alpha1.Etcd) error {
+func (m *MockEnsurer) EnsureETCD(arg0 context.Context, arg1 genericmutator.EnsurerContext, arg2, arg3 *v1alpha1.Etcd) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureETCD", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "EnsureETCD", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureETCD indicates an expected call of EnsureETCD
-func (mr *MockEnsurerMockRecorder) EnsureETCD(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureETCD(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureETCD", reflect.TypeOf((*MockEnsurer)(nil).EnsureETCD), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureETCD", reflect.TypeOf((*MockEnsurer)(nil).EnsureETCD), arg0, arg1, arg2, arg3)
 }
 
 // EnsureKubeAPIServerDeployment mocks base method
-func (m *MockEnsurer) EnsureKubeAPIServerDeployment(arg0 context.Context, arg1 genericmutator.EnsurerContext, arg2 *v1.Deployment) error {
+func (m *MockEnsurer) EnsureKubeAPIServerDeployment(arg0 context.Context, arg1 genericmutator.EnsurerContext, arg2, arg3 *v1.Deployment) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureKubeAPIServerDeployment", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "EnsureKubeAPIServerDeployment", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureKubeAPIServerDeployment indicates an expected call of EnsureKubeAPIServerDeployment
-func (mr *MockEnsurerMockRecorder) EnsureKubeAPIServerDeployment(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureKubeAPIServerDeployment(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeAPIServerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeAPIServerDeployment), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeAPIServerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeAPIServerDeployment), arg0, arg1, arg2, arg3)
 }
 
 // EnsureKubeAPIServerService mocks base method
-func (m *MockEnsurer) EnsureKubeAPIServerService(arg0 context.Context, arg1 genericmutator.EnsurerContext, arg2 *v10.Service) error {
+func (m *MockEnsurer) EnsureKubeAPIServerService(arg0 context.Context, arg1 genericmutator.EnsurerContext, arg2, arg3 *v10.Service) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureKubeAPIServerService", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "EnsureKubeAPIServerService", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureKubeAPIServerService indicates an expected call of EnsureKubeAPIServerService
-func (mr *MockEnsurerMockRecorder) EnsureKubeAPIServerService(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureKubeAPIServerService(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeAPIServerService", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeAPIServerService), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeAPIServerService", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeAPIServerService), arg0, arg1, arg2, arg3)
 }
 
 // EnsureKubeControllerManagerDeployment mocks base method
-func (m *MockEnsurer) EnsureKubeControllerManagerDeployment(arg0 context.Context, arg1 genericmutator.EnsurerContext, arg2 *v1.Deployment) error {
+func (m *MockEnsurer) EnsureKubeControllerManagerDeployment(arg0 context.Context, arg1 genericmutator.EnsurerContext, arg2, arg3 *v1.Deployment) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureKubeControllerManagerDeployment", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "EnsureKubeControllerManagerDeployment", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureKubeControllerManagerDeployment indicates an expected call of EnsureKubeControllerManagerDeployment
-func (mr *MockEnsurerMockRecorder) EnsureKubeControllerManagerDeployment(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureKubeControllerManagerDeployment(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeControllerManagerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeControllerManagerDeployment), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeControllerManagerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeControllerManagerDeployment), arg0, arg1, arg2, arg3)
 }
 
 // EnsureKubeSchedulerDeployment mocks base method
-func (m *MockEnsurer) EnsureKubeSchedulerDeployment(arg0 context.Context, arg1 genericmutator.EnsurerContext, arg2 *v1.Deployment) error {
+func (m *MockEnsurer) EnsureKubeSchedulerDeployment(arg0 context.Context, arg1 genericmutator.EnsurerContext, arg2, arg3 *v1.Deployment) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureKubeSchedulerDeployment", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "EnsureKubeSchedulerDeployment", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureKubeSchedulerDeployment indicates an expected call of EnsureKubeSchedulerDeployment
-func (mr *MockEnsurerMockRecorder) EnsureKubeSchedulerDeployment(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureKubeSchedulerDeployment(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeSchedulerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeSchedulerDeployment), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeSchedulerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeSchedulerDeployment), arg0, arg1, arg2, arg3)
 }
 
 // EnsureKubeletCloudProviderConfig mocks base method
@@ -153,46 +153,46 @@ func (mr *MockEnsurerMockRecorder) EnsureKubeletCloudProviderConfig(arg0, arg1, 
 }
 
 // EnsureKubeletConfiguration mocks base method
-func (m *MockEnsurer) EnsureKubeletConfiguration(arg0 context.Context, arg1 genericmutator.EnsurerContext, arg2 *v1beta1.KubeletConfiguration) error {
+func (m *MockEnsurer) EnsureKubeletConfiguration(arg0 context.Context, arg1 genericmutator.EnsurerContext, arg2, arg3 *v1beta1.KubeletConfiguration) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureKubeletConfiguration", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "EnsureKubeletConfiguration", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureKubeletConfiguration indicates an expected call of EnsureKubeletConfiguration
-func (mr *MockEnsurerMockRecorder) EnsureKubeletConfiguration(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureKubeletConfiguration(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeletConfiguration", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeletConfiguration), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeletConfiguration", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeletConfiguration), arg0, arg1, arg2, arg3)
 }
 
 // EnsureKubeletServiceUnitOptions mocks base method
-func (m *MockEnsurer) EnsureKubeletServiceUnitOptions(arg0 context.Context, arg1 genericmutator.EnsurerContext, arg2 []*unit.UnitOption) ([]*unit.UnitOption, error) {
+func (m *MockEnsurer) EnsureKubeletServiceUnitOptions(arg0 context.Context, arg1 genericmutator.EnsurerContext, arg2, arg3 []*unit.UnitOption) ([]*unit.UnitOption, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureKubeletServiceUnitOptions", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "EnsureKubeletServiceUnitOptions", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]*unit.UnitOption)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EnsureKubeletServiceUnitOptions indicates an expected call of EnsureKubeletServiceUnitOptions
-func (mr *MockEnsurerMockRecorder) EnsureKubeletServiceUnitOptions(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureKubeletServiceUnitOptions(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeletServiceUnitOptions", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeletServiceUnitOptions), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeletServiceUnitOptions", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeletServiceUnitOptions), arg0, arg1, arg2, arg3)
 }
 
 // EnsureKubernetesGeneralConfiguration mocks base method
-func (m *MockEnsurer) EnsureKubernetesGeneralConfiguration(arg0 context.Context, arg1 genericmutator.EnsurerContext, arg2 *string) error {
+func (m *MockEnsurer) EnsureKubernetesGeneralConfiguration(arg0 context.Context, arg1 genericmutator.EnsurerContext, arg2, arg3 *string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureKubernetesGeneralConfiguration", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "EnsureKubernetesGeneralConfiguration", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureKubernetesGeneralConfiguration indicates an expected call of EnsureKubernetesGeneralConfiguration
-func (mr *MockEnsurerMockRecorder) EnsureKubernetesGeneralConfiguration(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureKubernetesGeneralConfiguration(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubernetesGeneralConfiguration", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubernetesGeneralConfiguration), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubernetesGeneralConfiguration", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubernetesGeneralConfiguration), arg0, arg1, arg2, arg3)
 }
 
 // ShouldProvisionKubeletCloudProviderConfig mocks base method

--- a/pkg/mock/gardener-extensions/webhook/mocks.go
+++ b/pkg/mock/gardener-extensions/webhook/mocks.go
@@ -35,15 +35,15 @@ func (m *MockMutator) EXPECT() *MockMutatorMockRecorder {
 }
 
 // Mutate mocks base method
-func (m *MockMutator) Mutate(arg0 context.Context, arg1 runtime.Object) error {
+func (m *MockMutator) Mutate(arg0 context.Context, arg1, arg2 runtime.Object) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Mutate", arg0, arg1)
+	ret := m.ctrl.Call(m, "Mutate", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Mutate indicates an expected call of Mutate
-func (mr *MockMutatorMockRecorder) Mutate(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMutatorMockRecorder) Mutate(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Mutate", reflect.TypeOf((*MockMutator)(nil).Mutate), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Mutate", reflect.TypeOf((*MockMutator)(nil).Mutate), arg0, arg1, arg2)
 }

--- a/pkg/webhook/controlplane/genericmutator/mutator_test.go
+++ b/pkg/webhook/controlplane/genericmutator/mutator_test.go
@@ -34,6 +34,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -46,14 +47,17 @@ import (
 )
 
 const (
-	oldServiceContent = "old kubelet.service content"
-	newServiceContent = "new kubelet.service content"
+	oldServiceContent     = "new kubelet.service content"
+	newServiceContent     = "old kubelet.service content"
+	mutatedServiceContent = "mutated kubelet.service content"
 
-	oldKubeletConfigData = "old kubelet config data"
-	newKubeletConfigData = "new kubelet config data"
+	oldKubeletConfigData     = "old kubelet config data"
+	newKubeletConfigData     = "new kubelet config data"
+	mutatedKubeletConfigData = "mutated kubelet config data"
 
-	oldKubernetesGeneralConfigData = "# Increase the tcp-time-wait buckets pool size to prevent simple DOS attacks\nnet.ipv4.tcp_tw_reuse = 1"
-	newKubernetesGeneralConfigData = "# Increase the tcp-time-wait buckets pool size to prevent simple DOS attacks\nnet.ipv4.tcp_tw_reuse = 1\n# Provider specific settings"
+	oldKubernetesGeneralConfigData     = "# Increase the tcp-time-wait buckets pool size to prevent simple DOS attacks\nnet.ipv4.tcp_tw_reuse = 1\n# OLD Settings"
+	newKubernetesGeneralConfigData     = "# Increase the tcp-time-wait buckets pool size to prevent simple DOS attacks\nnet.ipv4.tcp_tw_reuse = 1"
+	mutatedKubernetesGeneralConfigData = "# Increase the tcp-time-wait buckets pool size to prevent simple DOS attacks\nnet.ipv4.tcp_tw_reuse = 1\n# Provider specific settings"
 
 	encoding                 = "b64"
 	cloudproviderconf        = "[Global]\nauth-url: whatever-url/keystone"
@@ -111,197 +115,166 @@ var _ = Describe("Mutator", func() {
 	})
 
 	Describe("#Mutate", func() {
-		It("should invoke ensurer.EnsureKubeAPIServerService with a kube-apiserver service", func() {
-			var (
-				svc = &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer},
-				}
-			)
+		var (
+			mutator  extensionswebhook.Mutator
+			kcc      *mockcontrolplane.MockKubeletConfigCodec
+			ensurer  *mockgenericmutator.MockEnsurer
+			us       *mockcontrolplane.MockUnitSerializer
+			fcic     *mockcontrolplane.MockFileContentInlineCodec
+			old, new runtime.Object
+		)
 
-			// Create mock ensurer
-			ensurer := mockgenericmutator.NewMockEnsurer(ctrl)
-			ensurer.EXPECT().EnsureKubeAPIServerService(context.TODO(), gomock.Any(), svc).Return(nil)
-
-			// Create mutator
-			mutator := genericmutator.NewMutator(ensurer, nil, nil, nil, logger)
-
-			// Call Mutate method and check the result
-			err := mutator.Mutate(context.TODO(), svc)
-			Expect(err).To(Not(HaveOccurred()))
+		BeforeEach(func() {
+			ensurer = mockgenericmutator.NewMockEnsurer(ctrl)
+			kcc = mockcontrolplane.NewMockKubeletConfigCodec(ctrl)
+			us = mockcontrolplane.NewMockUnitSerializer(ctrl)
+			fcic = mockcontrolplane.NewMockFileContentInlineCodec(ctrl)
+			mutator = genericmutator.NewMutator(ensurer, us, kcc, fcic, logger)
+			old = nil
+			new = nil
 		})
 
-		It("should ignore other services than kube-apiserver", func() {
-			var (
-				svc = &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{Name: "test"},
-				}
-			)
-
-			// Create mutator
-			mutator := genericmutator.NewMutator(nil, nil, nil, nil, logger)
-
-			// Call Mutate method and check the result
-			err := mutator.Mutate(context.TODO(), svc)
+		DescribeTable("Should ignore", func(new, old runtime.Object) {
+			err := mutator.Mutate(context.TODO(), new, old)
 			Expect(err).To(Not(HaveOccurred()))
-		})
+		},
+			Entry(
+				"other services than kube-apiserver",
+				&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "test"}},
+				nil,
+			),
+			Entry(
+				"other deployments than kube-apiserver, kube-controller-manager, and kube-scheduler",
+				&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test"}},
+				nil,
+			),
+			Entry(
+				"other etcds than etcd-main and etcd-events",
+				&druidv1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: "test"}},
+				nil,
+			),
+		)
 
-		It("should invoke ensurer.EnsureKubeAPIServerDeployment with a kube-apiserver deployment", func() {
-			var (
-				dep = &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer},
-				}
-			)
+		DescribeTable("Should ensure", func(ensureFunc func()) {
+			ensureFunc()
 
-			// Create mock ensurer
-			ensurer := mockgenericmutator.NewMockEnsurer(ctrl)
-			ensurer.EXPECT().EnsureKubeAPIServerDeployment(context.TODO(), gomock.Any(), dep).Return(nil)
-
-			// Create mutator
-			mutator := genericmutator.NewMutator(ensurer, nil, nil, nil, logger)
-
-			// Call Mutate method and check the result
-			err := mutator.Mutate(context.TODO(), dep)
+			err := mutator.Mutate(context.TODO(), new, old)
 			Expect(err).To(Not(HaveOccurred()))
-		})
+		},
+			Entry(
+				"EnsureKubeAPIServerService with a kube-apiserver service",
+				func() {
+					new = &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer}}
+					ensurer.EXPECT().EnsureKubeAPIServerService(context.TODO(), gomock.Any(), new, old).Return(nil)
+				},
+			),
+			Entry(
+				"EnsureKubeAPIServerService with a kube-apiserver service and existing service",
+				func() {
+					new = &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer}}
+					old = new.DeepCopyObject()
+					ensurer.EXPECT().EnsureKubeAPIServerService(context.TODO(), gomock.Any(), new, old).Return(nil)
+				},
+			),
+			Entry(
+				"EnsureKubeAPIServerDeployment with a kube-apiserver deployment",
+				func() {
+					new = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer}}
+					ensurer.EXPECT().EnsureKubeAPIServerDeployment(context.TODO(), gomock.Any(), new, old).Return(nil)
+				},
+			),
+			Entry(
+				"EnsureKubeAPIServerDeployment with a kube-apiserver deployment and existing deployment",
+				func() {
+					new = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer}}
+					old = new.DeepCopyObject()
+					ensurer.EXPECT().EnsureKubeAPIServerDeployment(context.TODO(), gomock.Any(), new, old).Return(nil)
+				},
+			),
+			Entry(
+				"EnsureKubeControllerManagerDeployment with a kube-controller-manager deployment",
+				func() {
+					new = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeControllerManager}}
+					ensurer.EXPECT().EnsureKubeControllerManagerDeployment(context.TODO(), gomock.Any(), new, old).Return(nil)
+				},
+			),
+			Entry(
+				"EnsureKubeControllerManagerDeployment with a kube-controller-manager deployment and existing deployment",
+				func() {
+					new = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeControllerManager}}
+					old = new.DeepCopyObject()
+					ensurer.EXPECT().EnsureKubeControllerManagerDeployment(context.TODO(), gomock.Any(), new, old).Return(nil)
+				},
+			),
+			Entry(
+				"EnsureKubeSchedulerDeployment with a kube-scheduler deployment",
+				func() {
+					new = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeScheduler}}
+					ensurer.EXPECT().EnsureKubeSchedulerDeployment(context.TODO(), gomock.Any(), new, old).Return(nil)
+				},
+			),
+			Entry(
+				"EnsureKubeSchedulerDeployment with a kube-scheduler deployment and existing deployment",
+				func() {
+					new = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeScheduler}}
+					old = new.DeepCopyObject()
+					ensurer.EXPECT().EnsureKubeSchedulerDeployment(context.TODO(), gomock.Any(), new, old).Return(nil)
+				},
+			),
+		)
 
-		It("should invoke ensurer.EnsureKubeControllerManagerDeployment with a kube-controller-manager deployment", func() {
-			var (
-				dep = &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeControllerManager},
-				}
-			)
-
-			// Create mock ensurer
-			ensurer := mockgenericmutator.NewMockEnsurer(ctrl)
-			ensurer.EXPECT().EnsureKubeControllerManagerDeployment(context.TODO(), gomock.Any(), dep).Return(nil)
-
-			// Create mutator
-			mutator := genericmutator.NewMutator(ensurer, nil, nil, nil, logger)
-
-			// Call Mutate method and check the result
-			err := mutator.Mutate(context.TODO(), dep)
-			Expect(err).To(Not(HaveOccurred()))
-		})
-
-		It("should invoke ensurer.EnsureKubeSchedulerDeployment with a kube-scheduler deployment", func() {
-			var (
-				dep = &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeScheduler},
-				}
-			)
-
-			// Create mock ensurer
-			ensurer := mockgenericmutator.NewMockEnsurer(ctrl)
-			ensurer.EXPECT().EnsureKubeSchedulerDeployment(context.TODO(), gomock.Any(), dep).Return(nil)
-
-			// Create mutator
-			mutator := genericmutator.NewMutator(ensurer, nil, nil, nil, logger)
-
-			// Call Mutate method and check the result
-			err := mutator.Mutate(context.TODO(), dep)
-			Expect(err).To(Not(HaveOccurred()))
-		})
-
-		It("should ignore other deployments than kube-apiserver, kube-controller-manager, and kube-scheduler", func() {
-			var (
-				dep = &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: "test"},
-				}
-			)
-
-			// Create mutator
-			mutator := genericmutator.NewMutator(nil, nil, nil, nil, logger)
-
-			// Call Mutate method and check the result
-			err := mutator.Mutate(context.TODO(), dep)
-			Expect(err).To(Not(HaveOccurred()))
-		})
-
-		It("should invoke ensurer.EnsureETCD with a etcd-main", func() {
-			var (
-				etcd = &druidv1alpha1.Etcd{
-					ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDMain, Namespace: namespace},
-				}
-			)
-
-			// Create mock client
+		DescribeTable("EnsureETCD", func(new, old *druidv1alpha1.Etcd) {
 			client := mockclient.NewMockClient(ctrl)
 			client.EXPECT().Get(context.TODO(), clusterKey, &extensionsv1alpha1.Cluster{}).DoAndReturn(clientGet(clusterObject(cluster)))
 
-			// Create mock ensurer
-			ensurer := mockgenericmutator.NewMockEnsurer(ctrl)
-			ensurer.EXPECT().EnsureETCD(context.TODO(), gomock.Any(), etcd).Return(nil).Do(func(ctx context.Context, ectx genericmutator.EnsurerContext, etcd *druidv1alpha1.Etcd) {
+			ensurer.EXPECT().EnsureETCD(context.TODO(), gomock.Any(), new, old).Return(nil).Do(func(ctx context.Context, ectx genericmutator.EnsurerContext, new, old *druidv1alpha1.Etcd) {
 				_, err := ectx.GetCluster(ctx)
 				if err != nil {
 					logger.Error(err, "failed to get cluster object")
 				}
 			})
 
-			// Create mutator
-			mutator := genericmutator.NewMutator(ensurer, nil, nil, nil, logger)
 			err := mutator.(inject.Client).InjectClient(client)
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call Mutate method and check the result
-			err = mutator.Mutate(context.TODO(), etcd)
+			err = mutator.Mutate(context.TODO(), new, old)
 			Expect(err).To(Not(HaveOccurred()))
-		})
+		},
+			Entry(
+				"with a etcd-main",
+				&druidv1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDMain, Namespace: namespace}},
+				nil,
+			),
+			Entry(
+				"with a etcd-main and existing druid",
+				&druidv1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDMain, Namespace: namespace}},
+				&druidv1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDMain, Namespace: namespace}},
+			),
+			Entry(
+				"with a etcd-events",
+				&druidv1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDEvents, Namespace: namespace}},
+				nil,
+			),
+			Entry(
+				"with a etcd-events and existing druid",
+				&druidv1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDEvents, Namespace: namespace}},
+				&druidv1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDEvents, Namespace: namespace}},
+			),
+		)
 
-		It("should invoke ensurer.EnsureETCD with a etcd-events", func() {
-			var (
-				etcd = &druidv1alpha1.Etcd{
-					ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDEvents, Namespace: namespace},
-				}
-			)
-
-			// Create mock client
-			client := mockclient.NewMockClient(ctrl)
-			client.EXPECT().Get(context.TODO(), clusterKey, &extensionsv1alpha1.Cluster{}).DoAndReturn(clientGet(clusterObject(cluster)))
-
-			// Create mock ensurer
-			ensurer := mockgenericmutator.NewMockEnsurer(ctrl)
-			ensurer.EXPECT().EnsureETCD(context.TODO(), gomock.Any(), etcd).Return(nil).Do(func(ctx context.Context, ectx genericmutator.EnsurerContext, etcd *druidv1alpha1.Etcd) {
-				_, err := ectx.GetCluster(ctx)
-				if err != nil {
-					logger.Error(err, "failed to get cluster object")
-				}
-			})
-
-			// Create mutator
-			mutator := genericmutator.NewMutator(ensurer, nil, nil, nil, logger)
-			err := mutator.(inject.Client).InjectClient(client)
-			Expect(err).To(Not(HaveOccurred()))
-
-			// Call Mutate method and check the result
-			err = mutator.Mutate(context.TODO(), etcd)
-			Expect(err).To(Not(HaveOccurred()))
-		})
-
-		It("should ignore other etcds than etcd-main and etcd-events", func() {
-			var (
-				etcd = &druidv1alpha1.Etcd{
-					ObjectMeta: metav1.ObjectMeta{Name: "test"},
-				}
-			)
-
-			// Create mutator
-			mutator := genericmutator.NewMutator(nil, nil, nil, nil, logger)
-
-			// Call Mutate method and check the result
-			err := mutator.Mutate(context.TODO(), etcd)
-			Expect(err).To(Not(HaveOccurred()))
-		})
-
+		// DescribeTable("should invoke appropriate ensurer methods with OperatingSystemConfig", func() {
 		It("should invoke appropriate ensurer methods with OperatingSystemConfig", func() {
+
 			var (
-				osc = &extensionsv1alpha1.OperatingSystemConfig{
+				newOSC = &extensionsv1alpha1.OperatingSystemConfig{
 					ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 					Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
 						Purpose: extensionsv1alpha1.OperatingSystemConfigPurposeReconcile,
 						Units: []extensionsv1alpha1.Unit{
 							{
 								Name:    v1beta1constants.OperatingSystemConfigUnitNameKubeletService,
-								Content: util.StringPtr(oldServiceContent),
+								Content: util.StringPtr(newServiceContent),
 							},
 						},
 						Files: []extensionsv1alpha1.File{
@@ -309,7 +282,7 @@ var _ = Describe("Mutator", func() {
 								Path: v1beta1constants.OperatingSystemConfigFilePathKubeletConfig,
 								Content: extensionsv1alpha1.FileContent{
 									Inline: &extensionsv1alpha1.FileContentInline{
-										Data: oldKubeletConfigData,
+										Data: newKubeletConfigData,
 									},
 								},
 							},
@@ -317,36 +290,46 @@ var _ = Describe("Mutator", func() {
 								Path: v1beta1constants.OperatingSystemConfigFilePathKernelSettings,
 								Content: extensionsv1alpha1.FileContent{
 									Inline: &extensionsv1alpha1.FileContentInline{
-										Data: oldKubernetesGeneralConfigData,
+										Data: newKubernetesGeneralConfigData,
 									},
 								},
 							},
 						},
 					},
 				}
-
 				oldUnitOptions = []*unit.UnitOption{
 					{
 						Section: "Service",
 						Name:    "Foo",
-						Value:   "bar",
+						Value:   "old",
 					},
 				}
 				newUnitOptions = []*unit.UnitOption{
 					{
 						Section: "Service",
 						Name:    "Foo",
+						Value:   "bar",
+					},
+				}
+				mutatedUnitOptions = []*unit.UnitOption{
+					{
+						Section: "Service",
+						Name:    "Foo",
 						Value:   "baz",
 					},
 				}
-
 				oldKubeletConfig = &kubeletconfigv1beta1.KubeletConfiguration{
+					FeatureGates: map[string]bool{
+						"Old": true,
+					},
+				}
+				newKubeletConfig = &kubeletconfigv1beta1.KubeletConfiguration{
 					FeatureGates: map[string]bool{
 						"Foo": true,
 						"Bar": true,
 					},
 				}
-				newKubeletConfig = &kubeletconfigv1beta1.KubeletConfiguration{
+				mutatedKubeletConfig = &kubeletconfigv1beta1.KubeletConfiguration{
 					FeatureGates: map[string]bool{
 						"Foo": true,
 					},
@@ -355,71 +338,70 @@ var _ = Describe("Mutator", func() {
 				additionalFile = extensionsv1alpha1.File{Path: "/test/path"}
 			)
 
+			oldOSC := newOSC.DeepCopy()
+			oldOSC.Spec.Units[0].Content = util.StringPtr(oldServiceContent)
+			oldOSC.Spec.Files[0].Content.Inline.Data = oldKubeletConfigData
+			oldOSC.Spec.Files[1].Content.Inline.Data = oldKubernetesGeneralConfigData
+
 			// Create mock ensurer
-			ensurer := mockgenericmutator.NewMockEnsurer(ctrl)
-			ensurer.EXPECT().EnsureKubeletServiceUnitOptions(context.TODO(), gomock.Any(), oldUnitOptions).Return(newUnitOptions, nil)
-			ensurer.EXPECT().EnsureKubeletConfiguration(context.TODO(), gomock.Any(), oldKubeletConfig).DoAndReturn(
-				func(ctx context.Context, ectx genericmutator.EnsurerContext, kubeletConfig *kubeletconfigv1beta1.KubeletConfiguration) error {
-					*kubeletConfig = *newKubeletConfig
+			ensurer.EXPECT().EnsureKubeletServiceUnitOptions(context.TODO(), gomock.Any(), newUnitOptions, oldUnitOptions).Return(mutatedUnitOptions, nil)
+			ensurer.EXPECT().EnsureKubeletConfiguration(context.TODO(), gomock.Any(), newKubeletConfig, oldKubeletConfig).DoAndReturn(
+				func(ctx context.Context, ectx genericmutator.EnsurerContext, kubeletConfig, newKubeletConfig *kubeletconfigv1beta1.KubeletConfiguration) error {
+					*kubeletConfig = *mutatedKubeletConfig
 					return nil
 				},
 			)
-			ensurer.EXPECT().EnsureKubernetesGeneralConfiguration(context.TODO(), gomock.Any(), util.StringPtr(oldKubernetesGeneralConfigData)).DoAndReturn(
-				func(ctx context.Context, ectx genericmutator.EnsurerContext, data *string) error {
-					*data = newKubernetesGeneralConfigData
+			ensurer.EXPECT().EnsureKubernetesGeneralConfiguration(context.TODO(), gomock.Any(), util.StringPtr(newKubernetesGeneralConfigData), util.StringPtr(oldKubernetesGeneralConfigData)).DoAndReturn(
+				func(ctx context.Context, ectx genericmutator.EnsurerContext, data, newData *string) error {
+					*data = mutatedKubernetesGeneralConfigData
 					return nil
 				},
 			)
-			ensurer.EXPECT().EnsureAdditionalUnits(context.TODO(), gomock.Any(), &osc.Spec.Units).DoAndReturn(
-				func(ctx context.Context, ectx genericmutator.EnsurerContext, oscUnits *[]extensionsv1alpha1.Unit) error {
+			ensurer.EXPECT().EnsureAdditionalUnits(context.TODO(), gomock.Any(), &newOSC.Spec.Units, &oldOSC.Spec.Units).DoAndReturn(
+				func(ctx context.Context, ectx genericmutator.EnsurerContext, oscUnits, oldOSCUnits *[]extensionsv1alpha1.Unit) error {
 					*oscUnits = append(*oscUnits, additionalUnit)
 					return nil
 				})
-			ensurer.EXPECT().EnsureAdditionalFiles(context.TODO(), gomock.Any(), &osc.Spec.Files).DoAndReturn(
-				func(ctx context.Context, ectx genericmutator.EnsurerContext, oscFiles *[]extensionsv1alpha1.File) error {
+			ensurer.EXPECT().EnsureAdditionalFiles(context.TODO(), gomock.Any(), &newOSC.Spec.Files, &oldOSC.Spec.Files).DoAndReturn(
+				func(ctx context.Context, ectx genericmutator.EnsurerContext, oscFiles, oldOSCFiles *[]extensionsv1alpha1.File) error {
 					*oscFiles = append(*oscFiles, additionalFile)
 					return nil
 				})
 
 			ensurer.EXPECT().ShouldProvisionKubeletCloudProviderConfig().Return(true)
-			ensurer.EXPECT().EnsureKubeletCloudProviderConfig(context.TODO(), gomock.Any(), util.StringPtr(""), osc.Namespace).DoAndReturn(
+			ensurer.EXPECT().EnsureKubeletCloudProviderConfig(context.TODO(), gomock.Any(), gomock.Any(), newOSC.Namespace).DoAndReturn(
 				func(ctx context.Context, ectx genericmutator.EnsurerContext, data *string, _ string) error {
 					*data = cloudproviderconf
 					return nil
 				},
 			)
 
-			// Create mock UnitSerializer
-			us := mockcontrolplane.NewMockUnitSerializer(ctrl)
+			us.EXPECT().Deserialize(newServiceContent).Return(newUnitOptions, nil)
 			us.EXPECT().Deserialize(oldServiceContent).Return(oldUnitOptions, nil)
-			us.EXPECT().Serialize(newUnitOptions).Return(newServiceContent, nil)
+			us.EXPECT().Serialize(mutatedUnitOptions).Return(mutatedServiceContent, nil)
 
-			// Create mock KubeletConfigCodec
-			kcc := mockcontrolplane.NewMockKubeletConfigCodec(ctrl)
+			kcc.EXPECT().Decode(&extensionsv1alpha1.FileContentInline{Data: newKubeletConfigData}).Return(newKubeletConfig, nil)
 			kcc.EXPECT().Decode(&extensionsv1alpha1.FileContentInline{Data: oldKubeletConfigData}).Return(oldKubeletConfig, nil)
-			kcc.EXPECT().Encode(newKubeletConfig, "").Return(&extensionsv1alpha1.FileContentInline{Data: newKubeletConfigData}, nil)
+			kcc.EXPECT().Encode(mutatedKubeletConfig, "").Return(&extensionsv1alpha1.FileContentInline{Data: mutatedKubeletConfigData}, nil)
 
-			// Create mock FileContentInlineCodec
-			fcic := mockcontrolplane.NewMockFileContentInlineCodec(ctrl)
+			fcic.EXPECT().Decode(&extensionsv1alpha1.FileContentInline{Data: newKubernetesGeneralConfigData}).Return([]byte(newKubernetesGeneralConfigData), nil)
 			fcic.EXPECT().Decode(&extensionsv1alpha1.FileContentInline{Data: oldKubernetesGeneralConfigData}).Return([]byte(oldKubernetesGeneralConfigData), nil)
-			fcic.EXPECT().Encode([]byte(newKubernetesGeneralConfigData), "").Return(&extensionsv1alpha1.FileContentInline{Data: newKubernetesGeneralConfigData}, nil)
+			fcic.EXPECT().Encode([]byte(mutatedKubernetesGeneralConfigData), "").Return(&extensionsv1alpha1.FileContentInline{Data: mutatedKubernetesGeneralConfigData}, nil)
 			fcic.EXPECT().Encode([]byte(cloudproviderconf), encoding).Return(&extensionsv1alpha1.FileContentInline{Data: cloudproviderconfEncoded, Encoding: encoding}, nil)
 
-			// Create mutator
-			mutator := genericmutator.NewMutator(ensurer, us, kcc, fcic, logger)
-
 			// Call Mutate method and check the result
-			err := mutator.Mutate(context.TODO(), osc)
+			err := mutator.Mutate(context.TODO(), newOSC, oldOSC)
 			Expect(err).To(Not(HaveOccurred()))
-			checkOperatingSystemConfig(osc)
-		})
+			checkOperatingSystemConfig(newOSC)
+		},
+		)
 	})
 })
 
 func checkOperatingSystemConfig(osc *extensionsv1alpha1.OperatingSystemConfig) {
 	kubeletUnit := extensionswebhook.UnitWithName(osc.Spec.Units, v1beta1constants.OperatingSystemConfigUnitNameKubeletService)
 	Expect(kubeletUnit).To(Not(BeNil()))
-	Expect(kubeletUnit.Content).To(Equal(util.StringPtr(newServiceContent)))
+	Expect(kubeletUnit.Content).To(Equal(util.StringPtr(mutatedServiceContent)))
 
 	customMTU := extensionswebhook.UnitWithName(osc.Spec.Units, "custom-mtu.service")
 	Expect(customMTU).To(Not(BeNil()))
@@ -429,11 +411,11 @@ func checkOperatingSystemConfig(osc *extensionsv1alpha1.OperatingSystemConfig) {
 
 	kubeletFile := extensionswebhook.FileWithPath(osc.Spec.Files, v1beta1constants.OperatingSystemConfigFilePathKubeletConfig)
 	Expect(kubeletFile).To(Not(BeNil()))
-	Expect(kubeletFile.Content.Inline).To(Equal(&extensionsv1alpha1.FileContentInline{Data: newKubeletConfigData}))
+	Expect(kubeletFile.Content.Inline).To(Equal(&extensionsv1alpha1.FileContentInline{Data: mutatedKubeletConfigData}))
 
 	general := extensionswebhook.FileWithPath(osc.Spec.Files, v1beta1constants.OperatingSystemConfigFilePathKernelSettings)
 	Expect(general).To(Not(BeNil()))
-	Expect(general.Content.Inline).To(Equal(&extensionsv1alpha1.FileContentInline{Data: newKubernetesGeneralConfigData}))
+	Expect(general.Content.Inline).To(Equal(&extensionsv1alpha1.FileContentInline{Data: mutatedKubernetesGeneralConfigData}))
 
 	cloudProvider := extensionswebhook.FileWithPath(osc.Spec.Files, genericmutator.CloudProviderConfigPath)
 	Expect(cloudProvider).To(Not(BeNil()))

--- a/pkg/webhook/controlplane/genericmutator/noopensurer.go
+++ b/pkg/webhook/controlplane/genericmutator/noopensurer.go
@@ -28,43 +28,45 @@ import (
 // NoopEnsurer provides no-op implementation of Ensurer. This can be anonymously composed by actual Ensurers for convenience.
 type NoopEnsurer struct{}
 
+var _ Ensurer = &NoopEnsurer{}
+
 // EnsureKubeAPIServerService ensures that the kube-apiserver service conforms to the provider requirements.
-func (e *NoopEnsurer) EnsureKubeAPIServerService(context.Context, EnsurerContext, *corev1.Service) error {
+func (e *NoopEnsurer) EnsureKubeAPIServerService(ctx context.Context, ectx EnsurerContext, new, old *corev1.Service) error {
 	return nil
 }
 
 // EnsureKubeAPIServerDeployment ensures that the kube-apiserver deployment conforms to the provider requirements.
-func (e *NoopEnsurer) EnsureKubeAPIServerDeployment(context.Context, EnsurerContext, *appsv1.Deployment) error {
+func (e *NoopEnsurer) EnsureKubeAPIServerDeployment(ctx context.Context, ectx EnsurerContext, new, old *appsv1.Deployment) error {
 	return nil
 }
 
 // EnsureKubeControllerManagerDeployment ensures that the kube-controller-manager deployment conforms to the provider requirements.
-func (e *NoopEnsurer) EnsureKubeControllerManagerDeployment(context.Context, EnsurerContext, *appsv1.Deployment) error {
+func (e *NoopEnsurer) EnsureKubeControllerManagerDeployment(ctx context.Context, ectx EnsurerContext, new, old *appsv1.Deployment) error {
 	return nil
 }
 
 // EnsureKubeSchedulerDeployment ensures that the kube-scheduler deployment conforms to the provider requirements.
-func (e *NoopEnsurer) EnsureKubeSchedulerDeployment(context.Context, EnsurerContext, *appsv1.Deployment) error {
+func (e *NoopEnsurer) EnsureKubeSchedulerDeployment(ctx context.Context, ectx EnsurerContext, new, old *appsv1.Deployment) error {
 	return nil
 }
 
 // EnsureETCD ensures that the etcd stateful sets conform to the provider requirements.
-func (e *NoopEnsurer) EnsureETCD(context.Context, EnsurerContext, *druidv1alpha1.Etcd) error {
+func (e *NoopEnsurer) EnsureETCD(ctx context.Context, ectx EnsurerContext, new, old *druidv1alpha1.Etcd) error {
 	return nil
 }
 
 // EnsureKubeletServiceUnitOptions ensures that the kubelet.service unit options conform to the provider requirements.
-func (e *NoopEnsurer) EnsureKubeletServiceUnitOptions(ctx context.Context, ectx EnsurerContext, opts []*unit.UnitOption) ([]*unit.UnitOption, error) {
-	return opts, nil
+func (e *NoopEnsurer) EnsureKubeletServiceUnitOptions(ctx context.Context, ectx EnsurerContext, new, old []*unit.UnitOption) ([]*unit.UnitOption, error) {
+	return new, nil
 }
 
 // EnsureKubeletConfiguration ensures that the kubelet configuration conforms to the provider requirements.
-func (e *NoopEnsurer) EnsureKubeletConfiguration(context.Context, EnsurerContext, *kubeletconfigv1beta1.KubeletConfiguration) error {
+func (e *NoopEnsurer) EnsureKubeletConfiguration(ctx context.Context, etcx EnsurerContext, new, old *kubeletconfigv1beta1.KubeletConfiguration) error {
 	return nil
 }
 
 // EnsureKubernetesGeneralConfiguration ensures that the kubernetes general configuration conforms to the provider requirements.
-func (e *NoopEnsurer) EnsureKubernetesGeneralConfiguration(context.Context, EnsurerContext, *string) error {
+func (e *NoopEnsurer) EnsureKubernetesGeneralConfiguration(ctx context.Context, etcx EnsurerContext, new, old *string) error {
 	return nil
 }
 
@@ -79,11 +81,11 @@ func (e *NoopEnsurer) EnsureKubeletCloudProviderConfig(context.Context, EnsurerC
 }
 
 // EnsureAdditionalUnits ensures that additional required system units are added.
-func (e *NoopEnsurer) EnsureAdditionalUnits(ctx context.Context, ectx EnsurerContext, units *[]extensionsv1alpha1.Unit) error {
+func (e *NoopEnsurer) EnsureAdditionalUnits(ctx context.Context, ectx EnsurerContext, new, old *[]extensionsv1alpha1.Unit) error {
 	return nil
 }
 
 // EnsureAdditionalFiles ensures that additional required system files are added.
-func (e *NoopEnsurer) EnsureAdditionalFiles(ctx context.Context, ectx EnsurerContext, files *[]extensionsv1alpha1.File) error {
+func (e *NoopEnsurer) EnsureAdditionalFiles(ctx context.Context, ectx EnsurerContext, new, old *[]extensionsv1alpha1.File) error {
 	return nil
 }

--- a/pkg/webhook/handler_shootclient.go
+++ b/pkg/webhook/handler_shootclient.go
@@ -86,7 +86,7 @@ func (h *handlerShootClient) InjectClient(client client.Client) error {
 }
 
 func (h *handlerShootClient) HandleWithRequest(ctx context.Context, req admission.Request, r *http.Request) admission.Response {
-	f := func(ctx context.Context, newObj runtime.Object, r *http.Request) error {
+	f := func(ctx context.Context, new, old runtime.Object, r *http.Request) error {
 		ipPort := strings.Split(r.RemoteAddr, ":")
 		if len(ipPort) < 1 {
 			return fmt.Errorf("remote address not parseable: %s", r.RemoteAddr)
@@ -118,7 +118,7 @@ func (h *handlerShootClient) HandleWithRequest(ctx context.Context, req admissio
 			return errors.Wrapf(err, "could not create shoot client")
 		}
 
-		return h.mutator.Mutate(ctx, newObj, shootClient)
+		return h.mutator.Mutate(ctx, new, old, shootClient)
 	}
 
 	return handle(ctx, req, r, f, h.typesMap, h.decoder, h.logger)

--- a/pkg/webhook/mutator.go
+++ b/pkg/webhook/mutator.go
@@ -24,11 +24,13 @@ import (
 // Mutator validates and if needed mutates objects.
 type Mutator interface {
 	// Mutate validates and if needed mutates the given object.
-	Mutate(ctx context.Context, obj runtime.Object) error
+	// "old" is optional and it must always be checked for nil.
+	Mutate(ctx context.Context, new, old runtime.Object) error
 }
 
 // MutatorWithShootClient validates and if needed mutates objects. It needs the shoot client.
 type MutatorWithShootClient interface {
 	// Mutate validates and if needed mutates the given object.
-	Mutate(ctx context.Context, obj runtime.Object, shootClient client.Client) error
+	// "old" is optional and it must always be checked for nil.
+	Mutate(ctx context.Context, new, old runtime.Object, shootClient client.Client) error
 }


### PR DESCRIPTION
Mutators might be interested in the oldObject before the mutation. This old object is now passed to every single Ensurer. It is `nil` if the operation is `CREATE` and must always be checked.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes # gardener/gardener#2048

**Special notes for your reviewer**:

This is still draft as it needs all other ensurers to get this implementation. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action developer
All methods of `pkg/webhook/controlplane/genericmutator.Ensurer` now have an additional argument which can optionally contain the old value of the object. If the admission request was `CREATE` this value is always `nil`.
```
