### PR TITLE
Adapt to gardener/terraformer@v1.0.0

### DIFF
--- a/pkg/terraformer/terraformer.go
+++ b/pkg/terraformer/terraformer.go
@@ -320,7 +320,9 @@ func (t *terraformer) env() []corev1.EnvVar {
 	envVars := []corev1.EnvVar{
 		{Name: "MAX_BACKOFF_SEC", Value: "60"},
 		{Name: "MAX_TIME_SEC", Value: "1800"},
+		{Name: "TF_CONFIGURATION_CONFIG_MAP_NAME", Value: t.configName},
 		{Name: "TF_STATE_CONFIG_MAP_NAME", Value: t.stateName},
+		{Name: "TF_VARIABLES_SECRET_NAME", Value: t.variablesName},
 	}
 	for k, v := range t.variablesEnvironment {
 		envVars = append(envVars, corev1.EnvVar{Name: k, Value: v})
@@ -329,18 +331,10 @@ func (t *terraformer) env() []corev1.EnvVar {
 }
 
 func (t *terraformer) podSpec(scriptName string) *corev1.PodSpec {
-	const (
-		tfVolume      = "tf"
-		tfVarsVolume  = "tfvars"
-		tfStateVolume = "tfstate"
-
-		tfVolumeMountPath      = tfVolume
-		tfVarsVolumeMountPath  = tfVarsVolume
-		tfStateVolumeMountPath = "tf-state-in"
+	var (
+		terminationGracePeriodSeconds = t.terminationGracePeriodSeconds
+		shCommand                     = fmt.Sprintf("sh /terraform.sh %s 2>&1; [[ -f /success ]] && exit 0 || exit 1", scriptName)
 	)
-
-	terminationGracePeriodSeconds := t.terminationGracePeriodSeconds
-	shCommand := fmt.Sprintf("sh /terraform.sh %s 2>&1; [[ -f /success ]] && exit 0 || exit 1", scriptName)
 
 	return &corev1.PodSpec{
 		RestartPolicy: corev1.RestartPolicyNever,
@@ -365,41 +359,10 @@ func (t *terraformer) podSpec(scriptName string) *corev1.PodSpec {
 					},
 				},
 				Env: t.env(),
-				VolumeMounts: []corev1.VolumeMount{
-					{Name: tfVolume, MountPath: fmt.Sprintf("/%s", tfVolumeMountPath)},
-					{Name: tfVarsVolume, MountPath: fmt.Sprintf("/%s", tfVarsVolumeMountPath)},
-					{Name: tfStateVolume, MountPath: fmt.Sprintf("/%s", tfStateVolumeMountPath)},
-				},
 			},
 		},
 		ServiceAccountName:            terraformerName,
 		TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
-		Volumes: []corev1.Volume{
-			{
-				Name: tfVolume,
-				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{Name: t.configName},
-					},
-				},
-			},
-			{
-				Name: tfVarsVolume,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: t.variablesName,
-					},
-				},
-			},
-			{
-				Name: tfStateVolume,
-				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{Name: t.stateName},
-					},
-				},
-			},
-		},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adapt `terraformer` package to `v1.0` of [gardener/terraformer](https://github.com/gardener/terraformer).

**Special notes for your reviewer**:
* ❌Requires merge of https://github.com/gardener/terraformer/pull/37
* ❌Release of [gardener/terraformer](https://github.com/gardener/terraformer)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action developer
When using this version of the Gardener Extensions library you have to make sure that you use at least `v1.0` of the `gardener/terraformer` image.
```
