### PR TITLE
[WIP]Expand the infrastructure actuator interface to Migrate and Restore

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,7 @@ github.com/gardener/etcd-druid v0.1.12/go.mod h1:yZrUQY9clD8/ZXK+MmEq8OS1TaKJeip
 github.com/gardener/external-dns-management v0.7.3 h1:SAW9ur2mjZ+x89xbmcplJgqNUmFGYIZLI2E+PaBhhG0=
 github.com/gardener/external-dns-management v0.7.3/go.mod h1:Y3om11E865x4aQ7cmcHjknb8RMgCO153huRb/SvP+9o=
 github.com/gardener/gardener v1.1.2/go.mod h1:CP9I0tCDVXTLPkJv/jUtXVUh948kSNKEGUg0haLz9gk=
+github.com/gardener/gardener v1.2.0 h1:VMCwCUHQataXSrbe9BlijzgtLWczpUyoTqa81T0dqOs=
 github.com/gardener/gardener v1.2.1-0.20200402092110-3e4c4917c83f h1:ZHdCrWpKNc6IRtLJEOBMA6ST3dqqtzgTXjKcTDS8Wsg=
 github.com/gardener/gardener v1.2.1-0.20200402092110-3e4c4917c83f/go.mod h1:/MJQRKKNZsujwABEspRiq9+V9u3Frvtii6zBoAZXh8Q=
 github.com/gardener/gardener-resource-manager v0.10.0 h1:6OUKoWI3oha42F0oJN8OEo3UR+D3onOCel4Th+zgotU=

--- a/pkg/controller/infrastructure/actuator.go
+++ b/pkg/controller/infrastructure/actuator.go
@@ -28,4 +28,8 @@ type Actuator interface {
 	Reconcile(context.Context, *extensionsv1alpha1.Infrastructure, *extensionscontroller.Cluster) error
 	// Delete the Infrastructure config.
 	Delete(context.Context, *extensionsv1alpha1.Infrastructure, *extensionscontroller.Cluster) error
+	// Restore takes the state of the Infrastrucure resource and applies it to the terraform pod's output state
+	Restore(context.Context, *extensionsv1alpha1.Infrastructure, *extensionscontroller.Cluster) error
+	// Migrate deletes the terraform k8s resources without deleting the corresponding resources in the IaaS provider
+	Migrate(context.Context, *extensionsv1alpha1.Infrastructure, *extensionscontroller.Cluster) error
 }

--- a/pkg/controller/infrastructure/reconciler.go
+++ b/pkg/controller/infrastructure/reconciler.go
@@ -20,8 +20,8 @@ import (
 
 	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	"github.com/gardener/gardener-extensions/pkg/util"
-
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
@@ -40,8 +40,12 @@ import (
 const (
 	// EventInfrastructureReconciliation an event reason to describe infrastructure reconciliation.
 	EventInfrastructureReconciliation string = "InfrastructureReconciliation"
-	// EventInfrastructureDeleton an event reason to describe infrastructure deletion.
-	EventInfrastructureDeleton string = "InfrastructureDeleton"
+	// EventInfrastructureDeletion an event reason to describe infrastructure deletion.
+	EventInfrastructureDeletion string = "InfrastructureDeletion"
+	// EventInfrastructureMigration an event reason to describe infrastructure migration.
+	EventInfrastructureMigration string = "InfrastructureMigration"
+	// EventInfrastructureRestoration an event reason to describe infrastructure restoration.
+	EventInfrastructureRestoration string = "InfrastructureRestoration"
 )
 
 type reconciler struct {
@@ -94,35 +98,38 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, err
 	}
 
-	if infrastructure.DeletionTimestamp != nil {
+	operationType := gardencorev1beta1helper.ComputeOperationType(infrastructure.ObjectMeta, infrastructure.Status.LastOperation)
+
+	switch {
+	case extensionscontroller.IsMigrated(infrastructure):
+		return reconcile.Result{}, nil
+	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
+		return r.migrate(r.ctx, infrastructure, cluster)
+	case infrastructure.DeletionTimestamp != nil:
 		return r.delete(r.ctx, infrastructure, cluster)
+	case infrastructure.Annotations[gardencorev1beta1constants.GardenerOperation] == gardencorev1beta1constants.GardenerOperationRestore:
+		return r.restore(r.ctx, infrastructure, cluster, operationType)
+	default:
+		return r.reconcile(r.ctx, infrastructure, cluster, operationType)
 	}
-	return r.reconcile(r.ctx, infrastructure, cluster)
 }
 
-func (r *reconciler) reconcile(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster) (reconcile.Result, error) {
+func (r *reconciler) reconcile(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster, operationType gardencorev1beta1.LastOperationType) (reconcile.Result, error) {
 	if err := extensionscontroller.EnsureFinalizer(ctx, r.client, FinalizerName, infrastructure); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	operationType := gardencorev1beta1helper.ComputeOperationType(infrastructure.ObjectMeta, infrastructure.Status.LastOperation)
 	if err := r.updateStatusProcessing(ctx, infrastructure, operationType, "Reconciling the infrastructure"); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	r.logger.Info("Starting the reconciliation of infrastructure", "infrastructure", infrastructure.Name)
-	r.recorder.Event(infrastructure, corev1.EventTypeNormal, EventInfrastructureReconciliation, "Reconciling the infrastructure")
+	r.logInfo(infrastructure, EventInfrastructureReconciliation, "Reconciling the infrastructure", "infrastructure", infrastructure.Name)
 	if err := r.actuator.Reconcile(ctx, infrastructure, cluster); err != nil {
-		msg := "Error reconciling infrastructure"
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), infrastructure, operationType, msg))
-		r.logger.Error(err, msg, "infrastructure", infrastructure.Name)
+		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), infrastructure, operationType, EventInfrastructureReconciliation, "Error reconciling infrastructure"))
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	msg := "Successfully reconciled infrastructure"
-	r.logger.Info(msg, "infrastructure", infrastructure.Name)
-	r.recorder.Event(infrastructure, corev1.EventTypeNormal, EventInfrastructureReconciliation, msg)
-	if err := r.updateStatusSuccess(ctx, infrastructure, operationType, msg); err != nil {
+	if err := r.updateStatusSuccess(ctx, infrastructure, operationType, EventInfrastructureReconciliation, "Successfully reconciled infrastructure"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -140,35 +147,83 @@ func (r *reconciler) delete(ctx context.Context, infrastructure *extensionsv1alp
 		return reconcile.Result{}, nil
 	}
 
-	operationType := gardencorev1beta1helper.ComputeOperationType(infrastructure.ObjectMeta, infrastructure.Status.LastOperation)
-	if err := r.updateStatusProcessing(ctx, infrastructure, operationType, "Deleting the infrastructure"); err != nil {
+	if err := r.updateStatusProcessing(ctx, infrastructure, gardencorev1beta1.LastOperationTypeDelete, "Deleting the infrastructure"); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	r.logger.Info("Starting the deletion of infrastructure", "infrastructure", infrastructure.Name)
-	r.recorder.Event(infrastructure, corev1.EventTypeNormal, EventInfrastructureDeleton, "Deleting the infrastructure")
-	if err := r.actuator.Delete(r.ctx, infrastructure, cluster); err != nil {
-		msg := "Error deleting infrastructure"
-		r.recorder.Eventf(infrastructure, corev1.EventTypeWarning, EventInfrastructureDeleton, "%s: %+v", msg, err)
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), infrastructure, operationType, msg))
-		r.logger.Error(err, msg, "infrastructure", infrastructure.Name)
+	r.logInfo(infrastructure, EventInfrastructureDeletion, "Deleting the infrastructure", "infrastructure", infrastructure.Name)
+	if err := r.actuator.Delete(ctx, infrastructure, cluster); err != nil {
+		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), infrastructure, gardencorev1beta1.LastOperationTypeDelete, EventInfrastructureDeletion, "Error deleting infrastructure"))
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	msg := "Successfully deleted infrastructure"
-	r.logger.Info(msg, "infrastructure", infrastructure.Name)
-	r.recorder.Event(infrastructure, corev1.EventTypeNormal, EventInfrastructureDeleton, msg)
-	if err := r.updateStatusSuccess(ctx, infrastructure, operationType, msg); err != nil {
+	if err := r.updateStatusSuccess(ctx, infrastructure, gardencorev1beta1.LastOperationTypeDelete, EventInfrastructureDeletion, "Successfully deleted infrastructure"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	r.logger.Info("Removing finalizer.", "infrastructure", infrastructure.Name)
 	if err := extensionscontroller.DeleteFinalizer(ctx, r.client, FinalizerName, infrastructure); err != nil {
-		r.logger.Error(err, "Error removing finalizer from Infrastructure", "infrastructure", infrastructure.Name)
+		r.logError(infrastructure, err, EventInfrastructureMigration, "Error removing finalizer from Infrastructure", "infrastructure", fmt.Sprintf("%s/%s", infrastructure.Namespace, infrastructure.Name))
 		return reconcile.Result{}, err
 	}
 
 	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) migrate(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster) (reconcile.Result, error) {
+	if err := r.updateStatusProcessing(ctx, infrastructure, gardencorev1beta1.LastOperationTypeMigrate, "Starting Migration of the Infrastructure"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	r.logInfo(infrastructure, EventInfrastructureMigration, "Migrating the infrastructure", "infrastructure", infrastructure.Name)
+	if err := r.actuator.Migrate(ctx, infrastructure, cluster); err != nil {
+		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), infrastructure, gardencorev1beta1.LastOperationTypeMigrate, EventInfrastructureMigration, "Error migrating infrastructure"))
+		return extensionscontroller.ReconcileErr(err)
+	}
+
+	if err := r.updateStatusSuccess(ctx, infrastructure, gardencorev1beta1.LastOperationTypeMigrate, EventInfrastructureMigration, "Successfully migrated Infrastructure"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	r.logger.Info("Removing finalizer.", "infrastructure", fmt.Sprintf("%s/%s", infrastructure.Namespace, infrastructure.Name))
+	if err := extensionscontroller.DeleteFinalizer(ctx, r.client, FinalizerName, infrastructure); err != nil {
+		r.logError(infrastructure, err, EventInfrastructureMigration, "Error removing finalizer from Infrastructure", "infrastructure", fmt.Sprintf("%s/%s", infrastructure.Namespace, infrastructure.Name))
+		return reconcile.Result{}, err
+	}
+
+	// remove operation annotation 'migrate'
+	if err := extensionscontroller.RemoveAnnotation(ctx, r.client, infrastructure, gardencorev1beta1constants.GardenerOperation); err != nil {
+		r.logError(infrastructure, err, EventInfrastructureMigration, "Error removing annotation from Infrastructure", "annotation", fmt.Sprintf("%s/%s", gardencorev1beta1constants.GardenerOperation, gardencorev1beta1constants.GardenerOperationMigrate), "infrastructure", fmt.Sprintf("%s/%s", infrastructure.Namespace, infrastructure.Name))
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) restore(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster, operationType gardencorev1beta1.LastOperationType) (reconcile.Result, error) {
+	if err := extensionscontroller.EnsureFinalizer(ctx, r.client, FinalizerName, infrastructure); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.updateStatusProcessing(ctx, infrastructure, operationType, "Restoring the infrastructure"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	r.logInfo(infrastructure, EventInfrastructureRestoration, "Restoring the infrastructure", "infrastructure", infrastructure.Name)
+	if err := r.actuator.Restore(ctx, infrastructure, cluster); err != nil {
+		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), infrastructure, operationType, EventInfrastructureRestoration, "Error restoring infrastructure"))
+		return extensionscontroller.ReconcileErr(err)
+	}
+
+	// remove operation annotation 'restore'
+	if err := extensionscontroller.RemoveAnnotation(ctx, r.client, infrastructure, gardencorev1beta1constants.GardenerOperation); err != nil {
+		r.logError(infrastructure, err, EventInfrastructureRestoration, "Error removing annotation from Infrastructure", "annotation", fmt.Sprintf("%s/%s", gardencorev1beta1constants.GardenerOperation, gardencorev1beta1constants.GardenerOperationMigrate), "infrastructure", fmt.Sprintf("%s/%s", infrastructure.Namespace, infrastructure.Name))
+		return reconcile.Result{}, err
+	}
+
+	err := r.updateStatusSuccess(ctx, infrastructure, gardencorev1beta1.LastOperationTypeMigrate, EventInfrastructureRestoration, "Successfully restored infrastructure")
+
+	return reconcile.Result{}, err
 }
 
 func (r *reconciler) updateStatusProcessing(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
@@ -178,7 +233,8 @@ func (r *reconciler) updateStatusProcessing(ctx context.Context, infrastructure 
 	})
 }
 
-func (r *reconciler) updateStatusError(ctx context.Context, err error, infrastructure *extensionsv1alpha1.Infrastructure, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
+func (r *reconciler) updateStatusError(ctx context.Context, err error, infrastructure *extensionsv1alpha1.Infrastructure, lastOperationType gardencorev1beta1.LastOperationType, event, description string) error {
+	r.logError(infrastructure, err, event, description, "infrastructure", infrastructure.Name)
 	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, infrastructure, func() error {
 		infrastructure.Status.ObservedGeneration = infrastructure.Generation
 		infrastructure.Status.LastOperation, infrastructure.Status.LastError = extensionscontroller.ReconcileError(lastOperationType, gardencorev1beta1helper.FormatLastErrDescription(fmt.Errorf("%s: %v", description, err)), 50, gardencorev1beta1helper.ExtractErrorCodes(err)...)
@@ -186,10 +242,21 @@ func (r *reconciler) updateStatusError(ctx context.Context, err error, infrastru
 	})
 }
 
-func (r *reconciler) updateStatusSuccess(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
+func (r *reconciler) updateStatusSuccess(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure, lastOperationType gardencorev1beta1.LastOperationType, event, description string) error {
+	r.logInfo(infrastructure, event, description, "infrastructure", infrastructure.Name)
 	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, infrastructure, func() error {
 		infrastructure.Status.ObservedGeneration = infrastructure.Generation
 		infrastructure.Status.LastOperation, infrastructure.Status.LastError = extensionscontroller.ReconcileSucceeded(lastOperationType, description)
 		return nil
 	})
+}
+
+func (r *reconciler) logError(infrastructure *extensionsv1alpha1.Infrastructure, err error, event, msg string, keysAndValues ...interface{}) {
+	r.recorder.Eventf(infrastructure, corev1.EventTypeWarning, event, fmt.Sprintf("%s: %+v", msg, err))
+	r.logger.Error(err, msg, keysAndValues)
+}
+
+func (r *reconciler) logInfo(infrastructure *extensionsv1alpha1.Infrastructure, event, msg string, keysAndValues ...interface{}) {
+	r.recorder.Eventf(infrastructure, corev1.EventTypeNormal, event, msg)
+	r.logger.Info(msg, keysAndValues)
 }

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -24,6 +24,8 @@ import (
 	"github.com/gardener/gardener-extensions/pkg/util"
 
 	resourcemanagerv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/api/extensions"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	corev1 "k8s.io/api/core/v1"
@@ -332,4 +334,32 @@ func GetVerticalPodAutoscalerObject() *unstructured.Unstructured {
 	obj.SetAPIVersion(autoscalingv1beta2.SchemeGroupVersion.String())
 	obj.SetKind("VerticalPodAutoscaler")
 	return obj
+}
+
+// RemoveAnnotation removes an annotation key passed as annotation
+func RemoveAnnotation(ctx context.Context, c client.Client, obj runtime.Object, annotation string) error {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	withAnnotation := obj.DeepCopyObject()
+
+	annotations := accessor.GetAnnotations()
+	delete(annotations, annotation)
+	accessor.SetAnnotations(annotations)
+
+	return c.Patch(ctx, obj, client.MergeFrom(withAnnotation))
+}
+
+// IsMigrated checks if an extension object has been migrated
+func IsMigrated(obj runtime.Object) bool {
+	acc, err := extensions.Accessor(obj)
+	if err != nil {
+		return false
+	}
+
+	lastOp := acc.GetExtensionStatus().GetLastOperation()
+	return lastOp != nil &&
+		lastOp.GetType() == gardencorev1beta1.LastOperationTypeMigrate &&
+		lastOp.GetState() == gardencorev1beta1.LastOperationStateSucceeded
 }

--- a/pkg/mock/gardener-extensions/terraformer/mocks.go
+++ b/pkg/mock/gardener-extensions/terraformer/mocks.go
@@ -305,7 +305,7 @@ func (m *MockFactory) EXPECT() *MockFactoryMockRecorder {
 }
 
 // DefaultInitializer mocks base method
-func (m *MockFactory) DefaultInitializer(arg0 client.Client, arg1, arg2 string, arg3 []byte, arg4 string) terraformer.Initializer {
+func (m *MockFactory) DefaultInitializer(arg0 client.Client, arg1, arg2 string, arg3 []byte, arg4 terraformer.StateConfigMapInitializer) terraformer.Initializer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DefaultInitializer", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(terraformer.Initializer)

--- a/pkg/terraformer/state.go
+++ b/pkg/terraformer/state.go
@@ -22,7 +22,10 @@ import (
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 type terraformStateV3 struct {
@@ -159,4 +162,46 @@ func sniffJSONStateVersion(stateConfigMap []byte) (uint64, error) {
 	}
 
 	return *sniff.Version, nil
+}
+
+// Initialize implements
+func (f StateConfigMapInitializerFunc) Initialize(ctx context.Context, c client.Client, namespace, name string) error {
+	return f(ctx, c, namespace, name)
+}
+
+// CreateState create terraform state config map and use empty state
+// It does not create or update state ConfigMap if alredy exists
+func CreateState(ctx context.Context, c client.Client, namespace, name string) error {
+	var err error
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Data: map[string]string{
+			StateKey: "",
+		},
+	}
+
+	if err = c.Create(ctx, configMap); err != nil && !apierrors.IsAlreadyExists(err) {
+		return nil
+	}
+
+	return err
+}
+
+// Initialize implements StateConfigMapInitializer
+func (cus *CreateOrUpdateState) Initialize(ctx context.Context, c client.Client, namespace, name string) error {
+	if cus.state == nil {
+		return fmt.Errorf("missing state when creating or updating terraform state comfigMap %s/%s", namespace, name)
+	}
+	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, c, configMap, func() error {
+		if configMap.Data == nil {
+			configMap.Data = make(map[string]string)
+		}
+		configMap.Data[StateKey] = *cus.state
+		return nil
+	})
+
+	return err
 }

--- a/pkg/terraformer/terraform_test.go
+++ b/pkg/terraformer/terraform_test.go
@@ -87,29 +87,58 @@ var _ = Describe("terraformer", func() {
 		})
 	})
 
-	Describe("#CreateStateConfigMap", func() {
-		It("Should create the config map", func() {
-			const (
-				namespace = "namespace"
-				name      = "name"
+	Describe("#StateConfigMapInitializer", func() {
+		const (
+			namespace = "namespace"
+			name      = "name"
+		)
 
-				state = "state"
-			)
+		Describe("#CreateState", func() {
+			It("Should create the config map", func() {
+				var (
+					objectMeta = metav1.ObjectMeta{Namespace: namespace, Name: name}
+					expected   = &corev1.ConfigMap{
+						ObjectMeta: objectMeta,
+						Data: map[string]string{
+							StateKey: "",
+						},
+					}
+					stateConfigMapInitializer = StateConfigMapInitializerFunc(CreateState)
+				)
 
-			var (
-				objectMeta = metav1.ObjectMeta{Namespace: namespace, Name: name}
-				expected   = &corev1.ConfigMap{
-					ObjectMeta: objectMeta,
-					Data: map[string]string{
-						StateKey: state,
-					},
-				}
-			)
+				c.EXPECT().Create(gomock.Any(), expected.DeepCopy())
 
-			c.EXPECT().Create(gomock.Any(), expected.DeepCopy())
+				err := stateConfigMapInitializer.Initialize(context.TODO(), c, namespace, name)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
 
-			err := CreateStateConfigMap(context.TODO(), c, namespace, name, state)
-			Expect(err).NotTo(HaveOccurred())
+		Describe("#CreateOrUpdateState", func() {
+			It("Should create the config map", func() {
+				var (
+					state      = "state"
+					stateKey   = kutil.Key(namespace, name)
+					objectMeta = metav1.ObjectMeta{Namespace: namespace, Name: name}
+					getState   = &corev1.ConfigMap{ObjectMeta: objectMeta}
+					expected   = &corev1.ConfigMap{
+						ObjectMeta: objectMeta,
+						Data: map[string]string{
+							StateKey: state,
+						},
+					}
+					stateConfigMapInitializer = &CreateOrUpdateState{state: &state}
+					stateNotFound             = apierrors.NewNotFound(configMapGroupResource, name)
+				)
+				gomock.InOrder(
+					c.EXPECT().
+						Get(gomock.Any(), stateKey, getState.DeepCopy()).
+						Return(stateNotFound),
+					c.EXPECT().Create(gomock.Any(), expected.DeepCopy()),
+				)
+
+				err := stateConfigMapInitializer.Initialize(context.TODO(), c, namespace, name)
+				Expect(err).NotTo(HaveOccurred())
+			})
 		})
 	})
 
@@ -145,7 +174,7 @@ var _ = Describe("terraformer", func() {
 		})
 	})
 
-	Describe("#DefaultInitializer", func() {
+	Describe("#Initializers", func() {
 		const (
 			namespace         = "namespace"
 			configurationName = "configuration"
@@ -155,19 +184,39 @@ var _ = Describe("terraformer", func() {
 			main      = "main"
 			variables = "variables"
 		)
-
 		var (
+			tfVars []byte
+
+			configurationKey client.ObjectKey
+			variablesKey     client.ObjectKey
+			stateKey         client.ObjectKey
+
+			configurationObjectMeta metav1.ObjectMeta
+			variablesObjectMeta     metav1.ObjectMeta
+			stateObjectMeta         metav1.ObjectMeta
+
+			getConfiguration *corev1.ConfigMap
+			getVariables     *corev1.Secret
+			getState         *corev1.ConfigMap
+
+			createConfiguration *corev1.ConfigMap
+			createVariables     *corev1.Secret
+		)
+
+		BeforeEach(func() {
 			tfVars = []byte("tfvars")
 
 			configurationKey = kutil.Key(namespace, configurationName)
-			variablesKey     = kutil.Key(namespace, variablesName)
+			variablesKey = kutil.Key(namespace, variablesName)
+			stateKey = kutil.Key(namespace, stateName)
 
 			configurationObjectMeta = kutil.ObjectMeta(namespace, configurationName)
-			variablesObjectMeta     = kutil.ObjectMeta(namespace, variablesName)
-			stateObjectMeta         = kutil.ObjectMeta(namespace, stateName)
+			variablesObjectMeta = kutil.ObjectMeta(namespace, variablesName)
+			stateObjectMeta = kutil.ObjectMeta(namespace, stateName)
 
 			getConfiguration = &corev1.ConfigMap{ObjectMeta: configurationObjectMeta}
-			getVariables     = &corev1.Secret{ObjectMeta: variablesObjectMeta}
+			getVariables = &corev1.Secret{ObjectMeta: variablesObjectMeta}
+			getState = &corev1.ConfigMap{ObjectMeta: stateObjectMeta}
 
 			createConfiguration = &corev1.ConfigMap{
 				ObjectMeta: configurationObjectMeta,
@@ -182,64 +231,145 @@ var _ = Describe("terraformer", func() {
 					TFVarsKey: tfVars,
 				},
 			}
-			createState = &corev1.ConfigMap{
-				ObjectMeta: stateObjectMeta,
-				Data: map[string]string{
-					StateKey: "",
-				},
-			}
-
-			configurationNotFound = apierrors.NewNotFound(configMapGroupResource, configurationName)
-			variablesNotFound     = apierrors.NewNotFound(secretGroupResource, variablesName)
-		)
-
-		runInitializer := func(initializeState bool) error {
-			return DefaultInitializer(c, main, variables, tfVars, "").Initialize(&InitializerConfig{
-				Namespace:         namespace,
-				ConfigurationName: configurationName,
-				VariablesName:     variablesName,
-				StateName:         stateName,
-				InitializeState:   initializeState,
-			})
-		}
-
-		It("should create all resources", func() {
-			gomock.InOrder(
-				c.EXPECT().
-					Get(gomock.Any(), configurationKey, getConfiguration.DeepCopy()).
-					Return(configurationNotFound),
-				c.EXPECT().
-					Create(gomock.Any(), createConfiguration.DeepCopy()),
-
-				c.EXPECT().
-					Get(gomock.Any(), variablesKey, getVariables.DeepCopy()).
-					Return(variablesNotFound),
-				c.EXPECT().
-					Create(gomock.Any(), createVariables.DeepCopy()),
-
-				c.EXPECT().
-					Create(gomock.Any(), createState.DeepCopy()),
-			)
-
-			Expect(runInitializer(true)).NotTo(HaveOccurred())
 		})
 
-		It("should not initialize state when initializeState is false", func() {
-			gomock.InOrder(
-				c.EXPECT().
-					Get(gomock.Any(), configurationKey, getConfiguration.DeepCopy()).
-					Return(configurationNotFound),
-				c.EXPECT().
-					Create(gomock.Any(), createConfiguration.DeepCopy()),
-
-				c.EXPECT().
-					Get(gomock.Any(), variablesKey, getVariables.DeepCopy()).
-					Return(variablesNotFound),
-				c.EXPECT().
-					Create(gomock.Any(), createVariables.DeepCopy()),
+		Describe("#DefaultInitializer", func() {
+			var (
+				state                                                   string
+				createState                                             *corev1.ConfigMap
+				configurationNotFound, variablesNotFound, stateNotFound *apierrors.StatusError
+				runInitializer                                          func(initializeState bool) error
 			)
 
-			Expect(runInitializer(false)).NotTo(HaveOccurred())
+			Context("When there is no init state", func() {
+				BeforeEach(func() {
+					state = ""
+					createState = &corev1.ConfigMap{
+						ObjectMeta: stateObjectMeta,
+						Data: map[string]string{
+							StateKey: state,
+						},
+					}
+					configurationNotFound = apierrors.NewNotFound(configMapGroupResource, configurationName)
+					variablesNotFound = apierrors.NewNotFound(secretGroupResource, variablesName)
+
+					runInitializer = func(initializeState bool) error {
+						return DefaultInitializer(c, main, variables, tfVars, StateConfigMapInitializerFunc(CreateState)).Initialize(&InitializerConfig{
+							Namespace:         namespace,
+							ConfigurationName: configurationName,
+							VariablesName:     variablesName,
+							StateName:         stateName,
+							InitializeState:   initializeState,
+						})
+					}
+				})
+
+				It("should create all resources", func() {
+					gomock.InOrder(
+						c.EXPECT().
+							Get(gomock.Any(), configurationKey, getConfiguration.DeepCopy()).
+							Return(configurationNotFound),
+						c.EXPECT().
+							Create(gomock.Any(), createConfiguration.DeepCopy()),
+
+						c.EXPECT().
+							Get(gomock.Any(), variablesKey, getVariables.DeepCopy()).
+							Return(variablesNotFound),
+						c.EXPECT().
+							Create(gomock.Any(), createVariables.DeepCopy()),
+
+						c.EXPECT().
+							Create(gomock.Any(), createState.DeepCopy()),
+					)
+
+					Expect(runInitializer(true)).NotTo(HaveOccurred())
+				})
+
+				It("should not initialize state when initializeState is false", func() {
+					gomock.InOrder(
+						c.EXPECT().
+							Get(gomock.Any(), configurationKey, getConfiguration.DeepCopy()).
+							Return(configurationNotFound),
+						c.EXPECT().
+							Create(gomock.Any(), createConfiguration.DeepCopy()),
+
+						c.EXPECT().
+							Get(gomock.Any(), variablesKey, getVariables.DeepCopy()).
+							Return(variablesNotFound),
+						c.EXPECT().
+							Create(gomock.Any(), createVariables.DeepCopy()),
+					)
+
+					Expect(runInitializer(false)).NotTo(HaveOccurred())
+				})
+			})
+
+			Context("When there is init state", func() {
+				BeforeEach(func() {
+					state = "{\"data\":\"big data\"}"
+					createState = &corev1.ConfigMap{
+						ObjectMeta: stateObjectMeta,
+						Data: map[string]string{
+							StateKey: state,
+						},
+					}
+					configurationNotFound = apierrors.NewNotFound(configMapGroupResource, configurationName)
+					variablesNotFound = apierrors.NewNotFound(secretGroupResource, variablesName)
+					stateNotFound = apierrors.NewNotFound(configMapGroupResource, stateName)
+
+					runInitializer = func(initializeState bool) error {
+						return DefaultInitializer(c, main, variables, tfVars, &CreateOrUpdateState{state: &state}).Initialize(&InitializerConfig{
+							Namespace:         namespace,
+							ConfigurationName: configurationName,
+							VariablesName:     variablesName,
+							StateName:         stateName,
+							InitializeState:   initializeState,
+						})
+					}
+				})
+
+				It("should create all resources", func() {
+					gomock.InOrder(
+						c.EXPECT().
+							Get(gomock.Any(), configurationKey, getConfiguration.DeepCopy()).
+							Return(configurationNotFound),
+						c.EXPECT().
+							Create(gomock.Any(), createConfiguration.DeepCopy()),
+
+						c.EXPECT().
+							Get(gomock.Any(), variablesKey, getVariables.DeepCopy()).
+							Return(variablesNotFound),
+						c.EXPECT().
+							Create(gomock.Any(), createVariables.DeepCopy()),
+
+						c.EXPECT().
+							Get(gomock.Any(), stateKey, getState.DeepCopy()).
+							Return(stateNotFound),
+						c.EXPECT().
+							Create(gomock.Any(), createState.DeepCopy()),
+					)
+
+					Expect(runInitializer(true)).NotTo(HaveOccurred())
+				})
+
+				It("should not initialize state when initializeState is false", func() {
+					gomock.InOrder(
+						c.EXPECT().
+							Get(gomock.Any(), configurationKey, getConfiguration.DeepCopy()).
+							Return(configurationNotFound),
+						c.EXPECT().
+							Create(gomock.Any(), createConfiguration.DeepCopy()),
+
+						c.EXPECT().
+							Get(gomock.Any(), variablesKey, getVariables.DeepCopy()).
+							Return(variablesNotFound),
+						c.EXPECT().
+							Create(gomock.Any(), createVariables.DeepCopy()),
+					)
+
+					Expect(runInitializer(false)).NotTo(HaveOccurred())
+				})
+			})
 		})
 	})
 

--- a/pkg/terraformer/terraformer.go
+++ b/pkg/terraformer/terraformer.go
@@ -53,8 +53,8 @@ func (f factory) New(logger logrus.FieldLogger, client client.Client, coreV1Clie
 	return New(logger, client, coreV1Client, purpose, namespace, name, image)
 }
 
-func (f factory) DefaultInitializer(c client.Client, main, variables string, tfVars []byte, state string) Initializer {
-	return DefaultInitializer(c, main, variables, tfVars, state)
+func (f factory) DefaultInitializer(c client.Client, main, variables string, tfVars []byte, stateInitializer StateConfigMapInitializer) Initializer {
+	return DefaultInitializer(c, main, variables, tfVars, stateInitializer)
 }
 
 // DefaultFactory returns the default factory.

--- a/pkg/terraformer/types.go
+++ b/pkg/terraformer/types.go
@@ -113,5 +113,19 @@ type Initializer interface {
 type Factory interface {
 	NewForConfig(logger logrus.FieldLogger, config *rest.Config, purpose, namespace, name, image string) (Terraformer, error)
 	New(logger logrus.FieldLogger, client client.Client, coreV1Client corev1client.CoreV1Interface, purpose, namespace, name, image string) Terraformer
-	DefaultInitializer(c client.Client, main, variables string, tfVars []byte, state string) Initializer
+	DefaultInitializer(c client.Client, main, variables string, tfVars []byte, stateInitializer StateConfigMapInitializer) Initializer
+}
+
+// StateConfigMapInitializer initialize terraformer state ConfigMap
+type StateConfigMapInitializer interface {
+	Initialize(ctx context.Context, c client.Client, namespace, name string) error
+}
+
+// StateConfigMapInitializerFunc implements StateConfigMapInitializer
+type StateConfigMapInitializerFunc func(ctx context.Context, c client.Client, namespace, name string) error
+
+// CreateOrUpdateState implements StateConfigMapInitializer.
+// It use it field state for creating or updating the state ConfigMap
+type CreateOrUpdateState struct {
+	state *string
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR we add new functionality to Infrastructure actuator interface consisting of Migrate and Restore. Each provider must implement the corresponding functions.
Migrate must remove all related resources of the shoot control plane without deleting the IaaS resources.
Restore must read the state from Infrastructure.Status.State and base on it to make the proper shoot control plane resources(e.g config maps and secrets)

**Which issue(s) this PR fixes**:
Fixes [#1631](https://github.com/gardener/gardener/issues/1631)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action developer

```
