### PR TITLE
Add generic CSI migration controller

### DIFF
--- a/pkg/controller/csimigration/README.md
+++ b/pkg/controller/csimigration/README.md
@@ -1,0 +1,72 @@
+# Generic CSI Migration Controller
+
+This package contains a generic CSI migration controller that helps provider extensions that are still using the legacy in-tree volume provisioner plugins to migrate to CSI.
+
+## How does CSI (migration) work in general?
+
+Classically, the `kube-controller-manager` was responsible for provisioning/deprovisioning and attaching/detaching persistent volumes.
+The `kubelet` running on the worker nodes was mounting/unmounting the disks.
+As there are so many vendor-specific implementations that were all maintained in the main Kubernetes source tree, the community decided to move them out into  dedicated drivers, and let the core Kubernetes components interact with them using a standardized interface (CSI).
+
+In the Gardener context, we usually have two parts of the CSI components: One part contains the controllers that are to be deployed in the seed cluster (as part of shoot control plane).
+They comprise the vendor-specific driver (e.g., AWS EBS driver), plus a generic provisioner, attacher, snapshotter, and resizer controller.
+The other part is deployed as `DaemonSet` on each shoot worker node and is responsible for registering the CSI driver to the `kubelet` as well as mounting/unmounting the disks to the machines.
+
+In order to tell the Kubernetes components that they are no longer responsible for volumes but CSI is used, the community has introduced feature gates.
+There is a general `CSIMigration` feature gate, plus two vendor-specific feature gates, e.g. `CSIMigrationAWS` and `CSIMigrationAWSComplete`:
+
+* If only the first two feature gates are enabled then CSI migration is in process. In this phase the `kube-controller-manager` / `kubelet`s are still partly responsible. Concretely, the `kube-controller-manager` will still provision/deprovision volumes using legacy storage class provisioners (e.g., `kubernetes.io/aws-ebs`), and it will attach/detach volumes for nodes that have not yet been migrated to CSI.
+* If all three feature gates are enabled then CSI migration is completed and no in-tree plugin will be used anymore. Both `kube-controller-manager` and `kubelet` pass on responsibility to the CSI drivers and controllers.
+
+For newly created clusters all feature gates can be enabled directly from the beginning and no migration is needed at all.
+
+For existing clusters there are a few steps that must be performed.
+Usually, the `kube-controller-manager` ran with the `--cloud-config` and `--external-cloud-volume-plugin` flags when using the in-tree volume provisioners.
+Also, the `kube-apiserver` enables the `PersistentVolumeLabel` admission plugin, and the `kubelet` runs with `--cloud-provider=aws`.
+As part of the CSI migration, the `CSIMigration<Provider>Complete` feature gate may only be enabled if all nodes have been drained, and all `kubelet`s have been updated with the feature gate flags.
+
+As provider extensions usually perform a rolling update of worker machines when the Kubernetes minor version is upgraded, it is recommended to start the CSI migration during such a Kubernetes version upgrade.
+Consequently, the migration can now happen by executing with the following steps:
+
+1. The `CSIMigration` and `CSIMigrationAWS` feature gates must be enabled on all master components, i.e., `kube-apiserver`, `kube-controller-manager`, and `kube-scheduler`.
+1. Until the CSI migration has completed the master components keep running with the cloud provider flags allowing to use in-tree volume provisioners.
+1. A rolling update of the worker machines is triggered, new `kubelet`s are coming up with all three CSI migration feature gates enabled + the `--cloud-provider=external` flag.
+1. After only new worker machines exist the master components can be updated with the `CSIMigration<Provider>Complete` feature gate + removal of all cloud-specific flags.
+1. As `StorageClass`es  are immutable the existing ones using a legacy in-tree provisioner can be deleted so that they can be recreated with the same name but using the new CSI provisioner. The CSI drivers are ensuring that they stay compatible with the legacy provisioner names [forever](https://kubernetes.slack.com/archives/CG04EL876/p1578500027013800?thread_ts=1578474999.005000&cid=CG04EL876).  
+
+## How can this controller be used for CSI migration?
+
+As motivated in above paragraph, for provider extensions the easiest way to start the CSI migration is together with a Kubernetes minor version upgrade because the necessary rolling update of the worker machines is triggered.
+
+The problem now is that the steps 4) and 5) must happen only after no old nodes exist in the cluster anymore.
+This could be done in the `Worker` controller, however, it would be somewhat ugly and mix too many things together (it's already pretty large).
+Having such dedicated CSI migration controller allows for better separation, maintainability and less complexity.
+
+The idea is that a provider extension adds this generic CSI migration controller - similar how it adds other generic controllers (like `ControlPlane`, `Infrastructure`, etc.).
+It will watch `Cluster` resources of shoots having the respective provider extension type + minimum Kubernetes version that was declared for starting CSI migration.
+When it detects such a `Cluster` it will start its CSI migration flow.
+
+The (soft) contract between the CSI migration controller and control plane webhooks of provider extensions is that the CSI migration controller will annotate the `Cluster` resource with `csi-migration.extensions.gardener.cloud/needs-complete-feature-gates=true` in case the migration is finished.
+The control webhooks can read this annotation and - if present - configure the Kubernetes components accordingly (e.g., adding the `CSIMigration<Provider>Complete` feature gate + removing the cloud flags).
+
+### CSI Migration Flow
+
+1. Check if the shoot is newly created - if yes, annotate the `Cluster` object with `csi-migration.extensions.gardener.cloud/needs-complete-feature-gates=true` and exit.
+1. If the cluster is an existing one that is getting updated then
+   1. If the shoot is hibernated then requeue and wait until it gets woken up.
+   1. Wait until only new nodes exist in the shoot anymore.
+   1. Delete the legacy storage classes in the shoot.
+   1. Add the `csi-migration.extensions.gardener.cloud/needs-complete-feature-gates=true` annotation to the `Cluster`.
+   1. Send empty `PATCH` requests to the `kube-apiserver`, `kube-controller-manager`, `kube-scheduler` `Deployment` resources to allow the control plane webhook adapting the specification.
+
+Consequently, from the provider extension point of view, what needs to be done is
+
+1. Add the `CSIMigration` controller and start it.
+1. Deploy CSI controller to seed and CSI driver as part of the `ControlPlane` reconciliation for shoots of the Kubernetes version that is used for CSI migration.
+1. Add the `CSIMigration` and `CSIMigration<Provider>` feature gates to the Kubernetes master components (together with the cloud flags) if the `Cluster` was not yet annotated with `csi-migration.extensions.gardener.cloud/needs-complete-feature-gates=true`.
+1. Add the `CSIMigration<Provider>Complete` feature gate and remove all cloud flags if the `Cluster` was annotated with `csi-migration.extensions.gardener.cloud/needs-complete-feature-gates=true`.
+
+## Further References
+
+* k8s.io blog about CSI Migration: https://kubernetes.io/blog/2019/12/09/kubernetes-1-17-feature-csi-migration-beta/
+* KEP for CSI Migration: https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/20190129-csi-migration.md

--- a/pkg/controller/csimigration/controller.go
+++ b/pkg/controller/csimigration/controller.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csimigration
+
+import (
+	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
+	extensionspredicate "github.com/gardener/gardener-extensions/pkg/predicate"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	// ControllerName is the name of the controller
+	ControllerName = "csimigration_controller"
+
+	// AnnotationKeyNeedsComplete is a constant for an annotation on the Cluster resource that indicates that
+	// the control plane components require the CSIMigration<Provider>Complete feature gates.
+	AnnotationKeyNeedsComplete = "csi-migration.extensions.gardener.cloud/needs-complete-feature-gates"
+	// AnnotationKeyControllerFinished is a constant for an annotation on the Cluster resource that indicates that
+	// the CSI migration has nothing more to do anymore because he completed earlier already.
+	AnnotationKeyControllerFinished = "csi-migration.extensions.gardener.cloud/controller-finished"
+)
+
+// AddArgs are arguments for adding an csimigration controller to a manager.
+type AddArgs struct {
+	// ControllerOptions are the controller options used for creating a controller.
+	// The options.Reconciler is always overridden with a reconciler created from the
+	// given actuator.
+	ControllerOptions controller.Options
+	// Predicates are the predicates to use.
+	Predicates []predicate.Predicate
+	// CSIMigrationKubernetesVersion is the smallest Kubernetes version that is used for the CSI migration.
+	CSIMigrationKubernetesVersion string
+	// Type is the provider extension type.
+	Type string
+	// StorageClassNameToLegacyProvisioner is a map of storage class names to the used legacy provisioner name. As part
+	// of the CSI migration they will be deleted so that new storage classes with the same name but a different CSI
+	// provisioner can be created (storage classes are immutable).
+	StorageClassNameToLegacyProvisioner map[string]string
+}
+
+// Add creates a new CSIMigration Controller and adds it to the Manager.
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager, args AddArgs) error {
+	reconciler, err := NewReconciler(args.CSIMigrationKubernetesVersion, args.StorageClassNameToLegacyProvisioner)
+	if err != nil {
+		return err
+	}
+	args.ControllerOptions.Reconciler = reconciler
+
+	ctrl, err := controller.New(ControllerName, mgr, args.ControllerOptions)
+	if err != nil {
+		return err
+	}
+
+	decoder, err := extensionscontroller.NewGardenDecoder()
+	if err != nil {
+		return err
+	}
+
+	defaultPredicates := []predicate.Predicate{
+		extensionspredicate.ClusterShootProviderType(decoder, args.Type),
+		extensionspredicate.ClusterShootKubernetesVersionAtLeast(decoder, args.CSIMigrationKubernetesVersion),
+		ClusterCSIMigrationControllerNotFinished(),
+	}
+
+	return ctrl.Watch(&source.Kind{Type: &extensionsv1alpha1.Cluster{}}, &handler.EnqueueRequestForObject{}, append(defaultPredicates, args.Predicates...)...)
+}

--- a/pkg/controller/csimigration/csimigration_suite_test.go
+++ b/pkg/controller/csimigration/csimigration_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csimigration_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCSIMigration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CSIMigration Controller Suite")
+}

--- a/pkg/controller/csimigration/predicate.go
+++ b/pkg/controller/csimigration/predicate.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csimigration
+
+import (
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// ClusterCSIMigrationControllerNotFinished is a predicate for an annotation on the cluster.
+func ClusterCSIMigrationControllerNotFinished() predicate.Predicate {
+	f := func(obj runtime.Object) bool {
+		if obj == nil {
+			return false
+		}
+
+		cluster, ok := obj.(*extensionsv1alpha1.Cluster)
+		if !ok {
+			return false
+		}
+
+		return !metav1.HasAnnotation(cluster.ObjectMeta, AnnotationKeyControllerFinished)
+	}
+
+	return predicate.Funcs{
+		CreateFunc: func(event event.CreateEvent) bool {
+			return f(event.Object)
+		},
+		UpdateFunc: func(event event.UpdateEvent) bool {
+			return f(event.ObjectNew)
+		},
+		GenericFunc: func(event event.GenericEvent) bool {
+			return f(event.Object)
+		},
+		DeleteFunc: func(event event.DeleteEvent) bool {
+			return f(event.Object)
+		},
+	}
+}

--- a/pkg/controller/csimigration/predicate_test.go
+++ b/pkg/controller/csimigration/predicate_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csimigration_test
+
+import (
+	. "github.com/gardener/gardener-extensions/pkg/controller/csimigration"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+var _ = Describe("predicate", func() {
+	Describe("#ClusterCSIMigrationControllerNotFinished", func() {
+		It("should return true because controller not finished", func() {
+			var (
+				predicate                                           = ClusterCSIMigrationControllerNotFinished()
+				createEvent, updateEvent, deleteEvent, genericEvent = computeEvents(false)
+			)
+
+			Expect(predicate.Create(createEvent)).To(BeTrue())
+			Expect(predicate.Update(updateEvent)).To(BeTrue())
+			Expect(predicate.Delete(deleteEvent)).To(BeTrue())
+			Expect(predicate.Generic(genericEvent)).To(BeTrue())
+		})
+
+		It("should return false because controller is finished", func() {
+			var (
+				predicate                                           = ClusterCSIMigrationControllerNotFinished()
+				createEvent, updateEvent, deleteEvent, genericEvent = computeEvents(true)
+			)
+
+			Expect(predicate.Create(createEvent)).To(BeFalse())
+			Expect(predicate.Update(updateEvent)).To(BeFalse())
+			Expect(predicate.Delete(deleteEvent)).To(BeFalse())
+			Expect(predicate.Generic(genericEvent)).To(BeFalse())
+		})
+	})
+})
+
+func computeEvents(controllerFinished bool) (event.CreateEvent, event.UpdateEvent, event.DeleteEvent, event.GenericEvent) {
+	cluster := &extensionsv1alpha1.Cluster{}
+
+	if controllerFinished {
+		cluster.ObjectMeta.Annotations = map[string]string{AnnotationKeyControllerFinished: "true"}
+	}
+
+	return event.CreateEvent{Object: cluster},
+		event.UpdateEvent{ObjectOld: cluster, ObjectNew: cluster},
+		event.DeleteEvent{Object: cluster},
+		event.GenericEvent{Object: cluster}
+}

--- a/pkg/controller/csimigration/reconciler.go
+++ b/pkg/controller/csimigration/reconciler.go
@@ -1,0 +1,226 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csimigration
+
+import (
+	"context"
+	"time"
+
+	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
+	"github.com/gardener/gardener-extensions/pkg/util"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/version"
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// RequeueAfter is the duration to requeue a Cluster reconciliation if indicated by the CSI controller.
+const RequeueAfter = time.Minute
+
+type reconciler struct {
+	logger logr.Logger
+
+	ctx     context.Context
+	client  client.Client
+	decoder runtime.Decoder
+
+	csiMigrationKubernetesVersion       string
+	storageClassNameToLegacyProvisioner map[string]string
+}
+
+// NewReconciler creates a new reconcile.Reconciler that reconciles
+// Cluster resources of Gardener's `extensions.gardener.cloud` API group.
+func NewReconciler(csiMigrationKubernetesVersion string, storageClassNameToLegacyProvisioner map[string]string) (reconcile.Reconciler, error) {
+	decoder, err := extensionscontroller.NewGardenDecoder()
+	if err != nil {
+		return nil, err
+	}
+
+	return &reconciler{
+		logger:                              log.Log.WithName(ControllerName),
+		decoder:                             decoder,
+		csiMigrationKubernetesVersion:       csiMigrationKubernetesVersion,
+		storageClassNameToLegacyProvisioner: storageClassNameToLegacyProvisioner,
+	}, nil
+}
+
+func (r *reconciler) InjectClient(client client.Client) error {
+	r.client = client
+	return nil
+}
+
+func (r *reconciler) InjectStopChannel(stopCh <-chan struct{}) error {
+	r.ctx = util.ContextFromStopChannel(stopCh)
+	return nil
+}
+
+func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	cluster := &extensionsv1alpha1.Cluster{}
+	if err := r.client.Get(r.ctx, request.NamespacedName, cluster); err != nil {
+		if errors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	if cluster.DeletionTimestamp != nil {
+		return reconcile.Result{}, nil
+	}
+
+	r.logger.Info("CSI migration controller got called with cluster", "name", cluster.Name)
+
+	shoot, err := extensionscontroller.ShootFromCluster(r.decoder, cluster)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	return r.reconcile(r.ctx, cluster, shoot)
+}
+
+// NewClientForShoot is a function to create a new client for shoots.
+var NewClientForShoot = util.NewClientForShoot
+
+func (r *reconciler) reconcile(ctx context.Context, cluster *extensionsv1alpha1.Cluster, shoot *gardencorev1beta1.Shoot) (reconcile.Result, error) {
+	if !metav1.HasAnnotation(cluster.ObjectMeta, AnnotationKeyNeedsComplete) {
+		// Check if a ControlPlane object exists for the cluster. If false then it is a new shoot that was created with
+		// at least the minimum Kubernetes version that is used for CSI migration. In this case we can directly set the
+		// CSIMigration<Provider>Complete annotations and proceed.
+		if err := r.client.Get(ctx, kutil.Key(cluster.Name, shoot.Name), &extensionsv1alpha1.ControlPlane{}); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return reconcile.Result{}, err
+			}
+
+			r.logger.Info("CSI migration controller detected new shoot cluster with minimum CSI migration Kubernetes version - adding both annotations", "name", cluster.Name)
+
+			metav1.SetMetaDataAnnotation(&cluster.ObjectMeta, AnnotationKeyNeedsComplete, "true")
+			metav1.SetMetaDataAnnotation(&cluster.ObjectMeta, AnnotationKeyControllerFinished, "true")
+			return reconcile.Result{}, r.client.Update(ctx, cluster)
+		}
+
+		k8sVersionIsMinimum, err := version.CompareVersions(shoot.Spec.Kubernetes.Version, "~", r.csiMigrationKubernetesVersion)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		// At this point the version is either lower, equal, or higher than the minimum version that introduces CSI. It
+		// cannot be lower as this is prevented via the controller's predicates. It also cannot be higher because then
+		// it was either newly created (but then it only has seen above code and would never reach this step), or it was
+		// regularly updated from the minimum version, but then it has already seen the migration code below. Hence, if
+		// the Kubernetes version does not match the minimum version we have nothing to do anymore. This case should be
+		// basically unreachable.
+		if !k8sVersionIsMinimum {
+			return reconcile.Result{}, nil
+		}
+
+		// At this point the version is equal to the minimum Kubernetes version that introduces CSI, hence, let's start
+		// our migration flow.
+		r.logger.Info("CSI migration controller detected existing shoot cluster with minimum Kubernetes version - starting migration", "name", cluster.Name)
+
+		// If the shoot is hibernated then we wait until the cluster gets woken up again so that the kube-controller-manager
+		// can perform the CSI migration steps.
+		if extensionscontroller.IsHibernated(&extensionscontroller.Cluster{Shoot: shoot}) {
+			r.logger.Info("Shoot cluster is hibernated - doing nothing until it gets woken up", "name", cluster.Name)
+			return reconcile.Result{}, nil
+		}
+
+		_, shootClient, err := NewClientForShoot(ctx, r.client, cluster.Name, client.Options{})
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		// Checking all the nodes - if only nodes running a kubelet of the minimum Kubernetes version exist in the
+		// cluster the CSI migration is considered completed.
+		nodeList := &corev1.NodeList{}
+		if err := shootClient.List(ctx, nodeList); err != nil {
+			return reconcile.Result{}, err
+		}
+
+		for _, node := range nodeList.Items {
+			kubeletVersionAtLeastMinimum, err := version.CompareVersions(node.Status.NodeInfo.KubeletVersion, ">=", r.csiMigrationKubernetesVersion)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+
+			// At least one kubelet is of a version lower than our minimum version - requeueing and waiting until all
+			// kubelets are updated.
+			if !kubeletVersionAtLeastMinimum {
+				r.logger.Info("At least one kubelet was not yet updated to the minimum Kubernetes version - requeuing", "name", cluster.Name, "nodeName", node.Name)
+				return reconcile.Result{RequeueAfter: RequeueAfter}, nil
+			}
+		}
+
+		// Delete legacy storage classes created by the extension controller to allow their recreation with the new CSI
+		// provisioner names and the same storage class names (the storage classes are immutable, hence, a regular UPDATE
+		// does not work).
+		storageClassList := &storagev1beta1.StorageClassList{}
+		if err := shootClient.List(ctx, storageClassList); err != nil {
+			return reconcile.Result{}, err
+		}
+
+		for _, storageClass := range storageClassList.Items {
+			if legacyProvisioner, ok := r.storageClassNameToLegacyProvisioner[storageClass.Name]; ok && storageClass.Provisioner == legacyProvisioner {
+				r.logger.Info("Deleting storage class using legacy provisioner", "name", cluster.Name, "storageClassName", storageClass.Name)
+				if err := shootClient.Delete(ctx, storageClass.DeepCopy()); client.IgnoreNotFound(err) != nil {
+					return reconcile.Result{}, err
+				}
+			}
+		}
+
+		// At this point the migration has been finished. We are updating the annotation and then send out empty PATCH
+		// requests against the Kubernetes control plane component deployments so that the provider-specific webhooks
+		// can adapt the injected feature gates.
+		metav1.SetMetaDataAnnotation(&cluster.ObjectMeta, AnnotationKeyNeedsComplete, "true")
+		if err := r.client.Update(ctx, cluster); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	for _, deploymentName := range []string{
+		v1beta1constants.DeploymentNameKubeAPIServer,
+		v1beta1constants.DeploymentNameKubeControllerManager,
+		v1beta1constants.DeploymentNameKubeScheduler,
+	} {
+		r.logger.Info("Submitting empty PATCH for control plane component deployment", "name", cluster.Name, "deploymentName", deploymentName)
+
+		obj := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      deploymentName,
+				Namespace: cluster.Name,
+			},
+		}
+
+		if err := kutil.SubmitEmptyPatch(ctx, r.client, obj); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	r.logger.Info("CSI migration completed successfully", "name", cluster.Name)
+
+	metav1.SetMetaDataAnnotation(&cluster.ObjectMeta, AnnotationKeyControllerFinished, "true")
+	return reconcile.Result{}, r.client.Update(ctx, cluster)
+}

--- a/pkg/controller/csimigration/reconciler_test.go
+++ b/pkg/controller/csimigration/reconciler_test.go
@@ -1,0 +1,252 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csimigration
+
+import (
+	"context"
+
+	mockclient "github.com/gardener/gardener-extensions/pkg/mock/controller-runtime/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var _ = Describe("reconciler", func() {
+	Describe("#reconcile", func() {
+		var (
+			ctrl *gomock.Controller
+
+			ctx    = context.TODO()
+			logger = log.Log.WithName("test")
+			c      *mockclient.MockClient
+
+			cluster *extensionsv1alpha1.Cluster
+			shoot   *gardencorev1beta1.Shoot
+
+			clusterName                   = "cluster"
+			csiMigrationKubernetesVersion = "1.18"
+			storageClassName              = "foo"
+			storageClassProvisioner       = "bar"
+
+			emptyPatch                      = client.ConstantPatch(types.StrategicMergePatchType, []byte("{}"))
+			kubeAPIServerDeployment         = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer, Namespace: clusterName}}
+			kubeControllerManagerDeployment = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeControllerManager, Namespace: clusterName}}
+			kubeSchedulerDeployment         = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeScheduler, Namespace: clusterName}}
+
+			reconciler = &reconciler{
+				logger:                              logger,
+				ctx:                                 ctx,
+				csiMigrationKubernetesVersion:       csiMigrationKubernetesVersion,
+				storageClassNameToLegacyProvisioner: map[string]string{storageClassName: storageClassProvisioner},
+			}
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			c = mockclient.NewMockClient(ctrl)
+
+			reconciler.client = c
+
+			cluster = &extensionsv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: clusterName}}
+			shoot = shootWithVersion("1.18.0")
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		It("should behave as expected when the needs-complete annotation is already set", func() {
+			cluster.Annotations = map[string]string{
+				AnnotationKeyNeedsComplete: "true",
+			}
+
+			c.EXPECT().Patch(ctx, kubeAPIServerDeployment, emptyPatch)
+			c.EXPECT().Patch(ctx, kubeControllerManagerDeployment, emptyPatch)
+			c.EXPECT().Patch(ctx, kubeSchedulerDeployment, emptyPatch)
+
+			c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.Cluster{})).DoAndReturn(func(_ context.Context, obj runtime.Object, _ ...client.UpdateOption) error {
+				cluster, ok := obj.(*extensionsv1alpha1.Cluster)
+				Expect(ok).To(BeTrue())
+				Expect(cluster.Annotations).To(HaveKeyWithValue(AnnotationKeyNeedsComplete, "true"))
+				Expect(cluster.Annotations).To(HaveKeyWithValue(AnnotationKeyControllerFinished, "true"))
+				return nil
+			})
+
+			_, err := reconciler.reconcile(ctx, cluster, shoot)
+			Expect(err).To(Succeed())
+		})
+
+		It("should behave as expected for new clusters", func() {
+			c.EXPECT().Get(ctx, kutil.Key(cluster.Name, shoot.Name), gomock.AssignableToTypeOf(&extensionsv1alpha1.ControlPlane{})).Return(apierrors.NewNotFound(extensionsv1alpha1.Resource("controlplane"), shoot.Name))
+
+			c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.Cluster{})).DoAndReturn(func(_ context.Context, obj runtime.Object, _ ...client.UpdateOption) error {
+				cluster, ok := obj.(*extensionsv1alpha1.Cluster)
+				Expect(ok).To(BeTrue())
+				Expect(cluster.Annotations).To(HaveKeyWithValue(AnnotationKeyNeedsComplete, "true"))
+				Expect(cluster.Annotations).To(HaveKeyWithValue(AnnotationKeyControllerFinished, "true"))
+				return nil
+			})
+
+			_, err := reconciler.reconcile(ctx, cluster, shoot)
+			Expect(err).To(Succeed())
+		})
+
+		It("should do nothing if the minimum shoot version is not reached", func() {
+			shoot.Spec.Kubernetes.Version = "1.17.1"
+
+			c.EXPECT().Get(ctx, kutil.Key(cluster.Name, shoot.Name), gomock.AssignableToTypeOf(&extensionsv1alpha1.ControlPlane{}))
+
+			_, err := reconciler.reconcile(ctx, cluster, shoot)
+			Expect(err).To(Succeed())
+		})
+
+		It("should do nothing if the shoot is hibernated", func() {
+			shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{Enabled: pointer.BoolPtr(true)}
+
+			c.EXPECT().Get(ctx, kutil.Key(cluster.Name, shoot.Name), gomock.AssignableToTypeOf(&extensionsv1alpha1.ControlPlane{}))
+
+			_, err := reconciler.reconcile(ctx, cluster, shoot)
+			Expect(err).To(Succeed())
+		})
+
+		Context("CSI migration", func() {
+			var shootClient *mockclient.MockClient
+
+			BeforeEach(func() {
+				shootClient = mockclient.NewMockClient(ctrl)
+			})
+
+			It("should requeue if not all nodes are updated", func() {
+				c.EXPECT().Get(ctx, kutil.Key(cluster.Name, shoot.Name), gomock.AssignableToTypeOf(&extensionsv1alpha1.ControlPlane{}))
+
+				oldNewClientForShoot := NewClientForShoot
+				defer func() { NewClientForShoot = oldNewClientForShoot }()
+				NewClientForShoot = func(_ context.Context, _ client.Client, _ string, _ client.Options) (*rest.Config, client.Client, error) {
+					return nil, shootClient, nil
+				}
+
+				shootClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.NodeList{})).DoAndReturn(func(_ context.Context, list runtime.Object, _ ...client.ListOption) error {
+					obj := &corev1.NodeList{
+						Items: []corev1.Node{
+							{
+								Status: corev1.NodeStatus{
+									NodeInfo: corev1.NodeSystemInfo{
+										KubeletVersion: "1.17.0",
+									},
+								},
+							},
+						},
+					}
+					obj.DeepCopyInto(list.(*corev1.NodeList))
+					return nil
+				})
+
+				result, err := reconciler.reconcile(ctx, cluster, shoot)
+				Expect(result.RequeueAfter).To(Equal(RequeueAfter))
+				Expect(err).To(Succeed())
+			})
+
+			It("should perform the migration steps correctly if all nodes are updated", func() {
+				c.EXPECT().Get(ctx, kutil.Key(cluster.Name, shoot.Name), gomock.AssignableToTypeOf(&extensionsv1alpha1.ControlPlane{}))
+
+				oldNewClientForShoot := NewClientForShoot
+				defer func() { NewClientForShoot = oldNewClientForShoot }()
+				NewClientForShoot = func(_ context.Context, _ client.Client, _ string, _ client.Options) (*rest.Config, client.Client, error) {
+					return nil, shootClient, nil
+				}
+
+				shootClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.NodeList{})).DoAndReturn(func(_ context.Context, list runtime.Object, _ ...client.ListOption) error {
+					obj := &corev1.NodeList{
+						Items: []corev1.Node{
+							{
+								Status: corev1.NodeStatus{
+									NodeInfo: corev1.NodeSystemInfo{
+										KubeletVersion: csiMigrationKubernetesVersion,
+									},
+								},
+							},
+						},
+					}
+					obj.DeepCopyInto(list.(*corev1.NodeList))
+					return nil
+				})
+
+				storageClass := &storagev1beta1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: storageClassName,
+					},
+					Provisioner: storageClassProvisioner,
+				}
+				shootClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&storagev1beta1.StorageClassList{})).DoAndReturn(func(_ context.Context, list runtime.Object, _ ...client.ListOption) error {
+					obj := &storagev1beta1.StorageClassList{
+						Items: []storagev1beta1.StorageClass{*storageClass},
+					}
+					obj.DeepCopyInto(list.(*storagev1beta1.StorageClassList))
+					return nil
+				})
+				shootClient.EXPECT().Delete(ctx, storageClass)
+
+				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.Cluster{})).DoAndReturn(func(_ context.Context, obj runtime.Object, _ ...client.UpdateOption) error {
+					cluster, ok := obj.(*extensionsv1alpha1.Cluster)
+					Expect(ok).To(BeTrue())
+					Expect(cluster.Annotations).To(HaveKeyWithValue(AnnotationKeyNeedsComplete, "true"))
+					Expect(cluster.Annotations).NotTo(HaveKeyWithValue(AnnotationKeyControllerFinished, "true"))
+					return nil
+				})
+
+				c.EXPECT().Patch(ctx, kubeAPIServerDeployment, emptyPatch)
+				c.EXPECT().Patch(ctx, kubeControllerManagerDeployment, emptyPatch)
+				c.EXPECT().Patch(ctx, kubeSchedulerDeployment, emptyPatch)
+
+				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.Cluster{})).DoAndReturn(func(_ context.Context, obj runtime.Object, _ ...client.UpdateOption) error {
+					cluster, ok := obj.(*extensionsv1alpha1.Cluster)
+					Expect(ok).To(BeTrue())
+					Expect(cluster.Annotations).To(HaveKeyWithValue(AnnotationKeyNeedsComplete, "true"))
+					Expect(cluster.Annotations).To(HaveKeyWithValue(AnnotationKeyControllerFinished, "true"))
+					return nil
+				})
+
+				_, err := reconciler.reconcile(ctx, cluster, shoot)
+				Expect(err).To(Succeed())
+			})
+		})
+	})
+})
+
+func shootWithVersion(v string) *gardencorev1beta1.Shoot {
+	return &gardencorev1beta1.Shoot{
+		Spec: gardencorev1beta1.ShootSpec{
+			Kubernetes: gardencorev1beta1.Kubernetes{
+				Version: v,
+			},
+		},
+	}
+}

--- a/pkg/controller/csimigration/utils.go
+++ b/pkg/controller/csimigration/utils.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csimigration
+
+import (
+	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
+
+	"github.com/gardener/gardener/pkg/utils/version"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CheckCSIConditions takes the `Cluster` object and the Kubernetes version that shall be used for CSI migration. It
+// returns two booleans - the first one indicates whether CSI shall be used at all (this may help the provider extension
+// to decide whether to enable CSIMigration feature gates), and the second one indicates whether the CSI migration has
+// been completed (this may help the provider extension to decide whether to enable the CSIMigration<Provider>Complete
+// feature gate). If the shoot cluster version is higher than the CSI migration version then it always returns true for
+// both variables. If it's lower than the CSI migration version then it always returns false for both variables. If it's
+// the exact CSI migration (minor) version then it returns true for the first value (CSI migration shall be enabled),
+// and true or false based on whether the "needs-complete-feature-gates" annotation is set on the Cluster object.
+func CheckCSIConditions(cluster *extensionscontroller.Cluster, csiMigrationVersion string) (useCSI bool, csiMigrationComplete bool, err error) {
+	isHigherThanCSIMigrationVersion, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, ">", csiMigrationVersion)
+	if err != nil {
+		return false, false, err
+	}
+
+	if isHigherThanCSIMigrationVersion {
+		return true, true, nil
+	}
+
+	isCSIMigrationVersion, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "~", csiMigrationVersion)
+	if err != nil {
+		return false, false, err
+	}
+
+	if !isCSIMigrationVersion {
+		return false, false, nil
+	}
+
+	return true, metav1.HasAnnotation(cluster.ObjectMeta, AnnotationKeyNeedsComplete), nil
+}

--- a/pkg/controller/csimigration/utils_test.go
+++ b/pkg/controller/csimigration/utils_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csimigration_test
+
+import (
+	. "github.com/gardener/gardener-extensions/pkg/controller/csimigration"
+
+	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("utils", func() {
+	var (
+		k8s118 = "1.18.0"
+
+		clusterBrokenVersion        = &extensionscontroller.Cluster{Shoot: shootWithVersion("foo")}
+		clusterK8sLessThan118       = &extensionscontroller.Cluster{Shoot: shootWithVersion("1.17.0")}
+		clusterK8sMoreThan118       = &extensionscontroller.Cluster{Shoot: shootWithVersion("1.19.0")}
+		clusterK8s118               = &extensionscontroller.Cluster{Shoot: shootWithVersion("1.18.0")}
+		clusterK8s118WithAnnotation = &extensionscontroller.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					AnnotationKeyNeedsComplete: "true",
+				},
+			},
+			Shoot: shootWithVersion("1.18.0"),
+		}
+	)
+
+	DescribeTable("#CheckCSIConditions",
+		func(cluster *extensionscontroller.Cluster, csiMigrationVersion string, expectedCSIEnabled bool, expectedCSIMigrationComplete bool, expectErr bool) {
+			csiEnabled, csiMigrationComplete, err := CheckCSIConditions(cluster, csiMigrationVersion)
+			if expectErr {
+				Expect(err).NotTo(Succeed())
+			} else {
+				Expect(err).To(Succeed())
+				Expect(csiEnabled).To(Equal(expectedCSIEnabled))
+				Expect(csiMigrationComplete).To(Equal(expectedCSIMigrationComplete))
+			}
+		},
+
+		Entry("unparseable version", clusterBrokenVersion, k8s118, false, false, true),
+		Entry("shoot version higher than minimum", clusterK8sMoreThan118, k8s118, true, true, false),
+		Entry("shoot version lower than minimum", clusterK8sLessThan118, k8s118, false, false, false),
+		Entry("shoot version exactly minimum (w/o annotation)", clusterK8s118, k8s118, true, false, false),
+		Entry("shoot version exactly minimum (w/ annotation)", clusterK8s118WithAnnotation, k8s118, true, true, false),
+	)
+})
+
+func shootWithVersion(v string) *gardencorev1beta1.Shoot {
+	return &gardencorev1beta1.Shoot{
+		Spec: gardencorev1beta1.ShootSpec{
+			Kubernetes: gardencorev1beta1.Kubernetes{
+				Version: v,
+			},
+		},
+	}
+}

--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -17,7 +17,7 @@ package predicate
 import (
 	"errors"
 
-	"github.com/gardener/gardener-extensions/pkg/controller"
+	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
 	extensionsevent "github.com/gardener/gardener-extensions/pkg/event"
 	extensionsinject "github.com/gardener/gardener-extensions/pkg/inject"
 
@@ -25,9 +25,9 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils/version"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
-
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -69,7 +69,7 @@ func (s *shootNotFailedMapper) Map(e event.GenericEvent) bool {
 		return false
 	}
 
-	cluster, err := controller.GetCluster(s.Context, s.Client, e.Meta.GetNamespace())
+	cluster, err := extensionscontroller.GetCluster(s.Context, s.Client, e.Meta.GetNamespace())
 	if err != nil {
 		s.log.Error(err, "Could not retrieve corresponding cluster")
 		return false
@@ -237,4 +237,81 @@ func HasPurpose(purpose extensionsv1alpha1.Purpose) predicate.Predicate {
 
 		return *controlPlane.Spec.Purpose == purpose
 	}), CreateTrigger, UpdateNewTrigger, DeleteTrigger, GenericTrigger)
+}
+
+// ClusterShootProviderType is a predicate for the provider type of the shoot in the cluster resource.
+func ClusterShootProviderType(decoder runtime.Decoder, providerType string) predicate.Predicate {
+	f := func(obj runtime.Object) bool {
+		if obj == nil {
+			return false
+		}
+
+		cluster, ok := obj.(*extensionsv1alpha1.Cluster)
+		if !ok {
+			return false
+		}
+
+		shoot, err := extensionscontroller.ShootFromCluster(decoder, cluster)
+		if err != nil {
+			return false
+		}
+
+		return shoot.Spec.Provider.Type == providerType
+	}
+
+	return predicate.Funcs{
+		CreateFunc: func(event event.CreateEvent) bool {
+			return f(event.Object)
+		},
+		UpdateFunc: func(event event.UpdateEvent) bool {
+			return f(event.ObjectNew)
+		},
+		GenericFunc: func(event event.GenericEvent) bool {
+			return f(event.Object)
+		},
+		DeleteFunc: func(event event.DeleteEvent) bool {
+			return f(event.Object)
+		},
+	}
+}
+
+// ClusterShootKubernetesVersionAtLeast is a predicate for the kubernetes version of the shoot in the cluster resource.
+func ClusterShootKubernetesVersionAtLeast(decoder runtime.Decoder, kubernetesVersion string) predicate.Predicate {
+	f := func(obj runtime.Object) bool {
+		if obj == nil {
+			return false
+		}
+
+		cluster, ok := obj.(*extensionsv1alpha1.Cluster)
+		if !ok {
+			return false
+		}
+
+		shoot, err := extensionscontroller.ShootFromCluster(decoder, cluster)
+		if err != nil {
+			return false
+		}
+
+		constraint, err := version.CompareVersions(shoot.Spec.Kubernetes.Version, ">=", kubernetesVersion)
+		if err != nil {
+			return false
+		}
+
+		return constraint
+	}
+
+	return predicate.Funcs{
+		CreateFunc: func(event event.CreateEvent) bool {
+			return f(event.Object)
+		},
+		UpdateFunc: func(event event.UpdateEvent) bool {
+			return f(event.ObjectNew)
+		},
+		GenericFunc: func(event event.GenericEvent) bool {
+			return f(event.Object)
+		},
+		DeleteFunc: func(event event.DeleteEvent) bool {
+			return f(event.Object)
+		},
+	}
 }

--- a/pkg/predicate/predicate_test.go
+++ b/pkg/predicate/predicate_test.go
@@ -15,9 +15,14 @@
 package predicate_test
 
 import (
-	"github.com/gardener/gardener-extensions/pkg/predicate"
+	"encoding/json"
 
+	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
+	extensionspredicate "github.com/gardener/gardener-extensions/pkg/predicate"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,7 +66,7 @@ var _ = Describe("Predicate", func() {
 		})
 
 		It("should match the type", func() {
-			predicate := predicate.HasType(extensionType)
+			predicate := extensionspredicate.HasType(extensionType)
 
 			Expect(predicate.Create(createEvent)).To(BeTrue())
 			Expect(predicate.Update(updateEvent)).To(BeTrue())
@@ -70,7 +75,7 @@ var _ = Describe("Predicate", func() {
 		})
 
 		It("should not match the type", func() {
-			predicate := predicate.HasType("anotherType")
+			predicate := extensionspredicate.HasType("anotherType")
 
 			Expect(predicate.Create(createEvent)).To(BeFalse())
 			Expect(predicate.Update(updateEvent)).To(BeFalse())
@@ -108,7 +113,7 @@ var _ = Describe("Predicate", func() {
 		})
 
 		It("should match the name", func() {
-			predicate := predicate.HasName(name)
+			predicate := extensionspredicate.HasName(name)
 
 			Expect(predicate.Create(createEvent)).To(BeTrue())
 			Expect(predicate.Update(updateEvent)).To(BeTrue())
@@ -117,7 +122,84 @@ var _ = Describe("Predicate", func() {
 		})
 
 		It("should not match the name", func() {
-			predicate := predicate.HasName("anotherName")
+			predicate := extensionspredicate.HasName("anotherName")
+
+			Expect(predicate.Create(createEvent)).To(BeFalse())
+			Expect(predicate.Update(updateEvent)).To(BeFalse())
+			Expect(predicate.Delete(deleteEvent)).To(BeFalse())
+			Expect(predicate.Generic(genericEvent)).To(BeFalse())
+		})
+	})
+
+	const (
+		extensionType = "extension-type"
+		version       = "1.18"
+	)
+
+	Describe("#ClusterShootProviderType", func() {
+		var (
+			decoder runtime.Decoder
+			err     error
+		)
+
+		BeforeEach(func() {
+			decoder, err = extensionscontroller.NewGardenDecoder()
+			Expect(err).To(Succeed())
+		})
+
+		It("should match the type", func() {
+			var (
+				predicate                                           = extensionspredicate.ClusterShootProviderType(decoder, extensionType)
+				createEvent, updateEvent, deleteEvent, genericEvent = computeEvents(extensionType, version)
+			)
+
+			Expect(predicate.Create(createEvent)).To(BeTrue())
+			Expect(predicate.Update(updateEvent)).To(BeTrue())
+			Expect(predicate.Delete(deleteEvent)).To(BeTrue())
+			Expect(predicate.Generic(genericEvent)).To(BeTrue())
+		})
+
+		It("should not match the type", func() {
+			var (
+				predicate                                           = extensionspredicate.ClusterShootProviderType(decoder, extensionType)
+				createEvent, updateEvent, deleteEvent, genericEvent = computeEvents("other-extension-type", version)
+			)
+
+			Expect(predicate.Create(createEvent)).To(BeFalse())
+			Expect(predicate.Update(updateEvent)).To(BeFalse())
+			Expect(predicate.Delete(deleteEvent)).To(BeFalse())
+			Expect(predicate.Generic(genericEvent)).To(BeFalse())
+		})
+	})
+
+	Describe("#ClusterShootKubernetesVersionAtLeast", func() {
+		var (
+			decoder runtime.Decoder
+			err     error
+		)
+
+		BeforeEach(func() {
+			decoder, err = extensionscontroller.NewGardenDecoder()
+			Expect(err).To(Succeed())
+		})
+
+		It("should match the minimum kubernetes version", func() {
+			var (
+				predicate                                           = extensionspredicate.ClusterShootKubernetesVersionAtLeast(decoder, version)
+				createEvent, updateEvent, deleteEvent, genericEvent = computeEvents(extensionType, version)
+			)
+
+			Expect(predicate.Create(createEvent)).To(BeTrue())
+			Expect(predicate.Update(updateEvent)).To(BeTrue())
+			Expect(predicate.Delete(deleteEvent)).To(BeTrue())
+			Expect(predicate.Generic(genericEvent)).To(BeTrue())
+		})
+
+		It("should not match the minimum kubernetes version", func() {
+			var (
+				predicate                                           = extensionspredicate.ClusterShootKubernetesVersionAtLeast(decoder, version)
+				createEvent, updateEvent, deleteEvent, genericEvent = computeEvents(extensionType, "1.17")
+			)
 
 			Expect(predicate.Create(createEvent)).To(BeFalse())
 			Expect(predicate.Update(updateEvent)).To(BeFalse())
@@ -126,3 +208,34 @@ var _ = Describe("Predicate", func() {
 		})
 	})
 })
+
+func computeEvents(extensionType, kubernetesVersion string) (event.CreateEvent, event.UpdateEvent, event.DeleteEvent, event.GenericEvent) {
+	shoot := &gardencorev1beta1.Shoot{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
+			Kind:       "Shoot",
+		},
+		Spec: gardencorev1beta1.ShootSpec{
+			Provider: gardencorev1beta1.Provider{
+				Type: extensionType,
+			},
+			Kubernetes: gardencorev1beta1.Kubernetes{
+				Version: kubernetesVersion,
+			},
+		},
+	}
+
+	shootJSON, err := json.Marshal(shoot)
+	Expect(err).To(Succeed())
+
+	cluster := &extensionsv1alpha1.Cluster{
+		Spec: extensionsv1alpha1.ClusterSpec{
+			Shoot: runtime.RawExtension{Raw: shootJSON},
+		},
+	}
+
+	return event.CreateEvent{Object: cluster},
+		event.UpdateEvent{ObjectOld: cluster, ObjectNew: cluster},
+		event.DeleteEvent{Object: cluster},
+		event.GenericEvent{Object: cluster}
+}

--- a/vendor/github.com/gardener/gardener/pkg/chartrenderer/gomock_reflect_411397209/prog.go
+++ b/vendor/github.com/gardener/gardener/pkg/chartrenderer/gomock_reflect_411397209/prog.go
@@ -1,0 +1,66 @@
+
+package main
+
+import (
+	"encoding/gob"
+	"flag"
+	"fmt"
+	"os"
+	"path"
+	"reflect"
+
+	"github.com/golang/mock/mockgen/model"
+
+	pkg_ "github.com/gardener/gardener/pkg/chartrenderer"
+)
+
+var output = flag.String("output", "", "The output file name, or empty to use stdout.")
+
+func main() {
+	flag.Parse()
+
+	its := []struct{
+		sym string
+		typ reflect.Type
+	}{
+		
+		{ "Interface", reflect.TypeOf((*pkg_.Interface)(nil)).Elem()},
+		
+	}
+	pkg := &model.Package{
+		// NOTE: This behaves contrary to documented behaviour if the
+		// package name is not the final component of the import path.
+		// The reflect package doesn't expose the package name, though.
+		Name: path.Base("github.com/gardener/gardener/pkg/chartrenderer"),
+	}
+
+	for _, it := range its {
+		intf, err := model.InterfaceFromInterfaceType(it.typ)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Reflection: %v\n", err)
+			os.Exit(1)
+		}
+		intf.Name = it.sym
+		pkg.Interfaces = append(pkg.Interfaces, intf)
+	}
+
+	outfile := os.Stdout
+	if len(*output) != 0 {
+		var err error
+		outfile, err = os.Create(*output)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to open output file %q", *output)
+		}
+		defer func() {
+			if err := outfile.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "failed to close output file %q", *output)
+				os.Exit(1)
+			}
+		}()
+	}
+
+	if err := gob.NewEncoder(outfile).Encode(pkg); err != nil {
+		fmt.Fprintf(os.Stderr, "gob encode: %v\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a generic CSI migration controller. Please find more information in the attached `README.md`.

**Which issue(s) this PR fixes**:
Part of gardener/gardener#2095

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
A generic CSI migration controller has been added. It can be used by provider extensions to implement migration from in-tree volume plugins to CSI with just a few steps. Please find more information in [this document](https://github.com/gardener/gardener-extensions/blob/master/pkg/controller/csimigration/README.md).
```
