### PR TITLE
Fix even number of arguments for logger.Info() call

### DIFF
--- a/pkg/controller/healthcheck/healtcheck_actuator.go
+++ b/pkg/controller/healthcheck/healtcheck_actuator.go
@@ -147,7 +147,7 @@ func (a *Actuator) ExecuteHealthCheckFunctions(ctx context.Context, request type
 				}
 
 				if !preCheckFunc(obj, cluster) {
-					a.logger.Info("Skipping health check for condition type %q as pre check function returned false", healthConditionType)
+					a.logger.Info("Skipping health check as pre check function returned false", "conditionType", healthConditionType)
 					channel <- channelResult{
 						healthCheckResult: &SingleCheckResult{
 							IsHealthy: true,


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevent 

```
{"level":"dpanic","ts":"2020-03-29T10:19:33.773Z","logger":"aws-ControlPlane-healthcheck-actuator","msg":"odd number of arguments passed as key-value pairs for logging","ignored key":"ControlPlaneHealthy","stacktrace":"github.com/go-logr/zapr.handleFields\n\t/go/src/github.com/gardener/gardener-extension-provider-aws/vendor/github.com/go-logr/zapr/zapr.go:106\ngithub.com/go-logr/zapr.(*infoLogger).Info\n\t/go/src/github.com/gardener/gardener-extension-provider-aws/vendor/github.com/go-logr/zapr/zapr.go:70\ngithub.com/gardener/gardener-extensions/pkg/controller/healthcheck.(*Actuator).ExecuteHealthCheckFunctions.func1\n\t/go/src/github.com/gardener/gardener-extension-provider-aws/vendor/github.com/gardener/gardener-extensions/pkg/controller/healthcheck/healtcheck_actuator.go:150"}
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
