### PR TITLE
Fix number of arguments for logger.Info() call

### DIFF
--- a/pkg/controller/backupbucket/reconciler.go
+++ b/pkg/controller/backupbucket/reconciler.go
@@ -95,7 +95,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 func (r *reconciler) reconcile(ctx context.Context, bb *extensionsv1alpha1.BackupBucket) (reconcile.Result, error) {
 	if err := extensionscontroller.EnsureFinalizer(ctx, r.client, FinalizerName, bb); err != nil {
-		r.logger.Info("failed to ensure finalizer on backup bucket, %v", err)
+		r.logger.Error(err, "failed to ensure finalizer on backup bucket", "backupbucket", bb.Name)
 		return reconcile.Result{}, err
 	}
 
@@ -106,11 +106,11 @@ func (r *reconciler) reconcile(ctx context.Context, bb *extensionsv1alpha1.Backu
 
 	secret, err := extensionscontroller.GetSecretByReference(ctx, r.client, &bb.Spec.SecretRef)
 	if err != nil {
-		r.logger.Info("failed to get backup bucket secret, %v", err)
+		r.logger.Error(err, "failed to get backup bucket secret", "backupbucket", bb.Name)
 		return reconcile.Result{}, err
 	}
 	if err := extensionscontroller.EnsureFinalizer(ctx, r.client, FinalizerName, secret); err != nil {
-		r.logger.Info("failed to ensure finalizer on bucket secret, %v", err)
+		r.logger.Error(err, "failed to ensure finalizer on bucket secret", "backupbucket", bb.Name)
 		return reconcile.Result{}, err
 	}
 
@@ -168,11 +168,11 @@ func (r *reconciler) delete(ctx context.Context, bb *extensionsv1alpha1.BackupBu
 
 	secret, err := extensionscontroller.GetSecretByReference(ctx, r.client, &bb.Spec.SecretRef)
 	if err != nil {
-		r.logger.Info("failed to get backup bucket secret, %v", err)
+		r.logger.Error(err, "failed to get backup bucket secret", "backupbucket", bb.Name)
 		return reconcile.Result{}, err
 	}
 	if err := extensionscontroller.DeleteFinalizer(ctx, r.client, FinalizerName, secret); err != nil {
-		r.logger.Info("failed to remove finalizer on bucket secret, %v", err)
+		r.logger.Error(err, "failed to remove finalizer on bucket secret", "backupbucket", bb.Name)
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controller/backupentry/reconciler.go
+++ b/pkg/controller/backupentry/reconciler.go
@@ -105,11 +105,11 @@ func (r *reconciler) reconcile(ctx context.Context, be *extensionsv1alpha1.Backu
 
 	secret, err := extensionscontroller.GetSecretByReference(ctx, r.client, &be.Spec.SecretRef)
 	if err != nil {
-		r.logger.Info("failed to get backup entry secret, %v", err)
+		r.logger.Error(err, "failed to get backup entry secret", "backupentry", be.Name)
 		return reconcile.Result{}, err
 	}
 	if err := extensionscontroller.EnsureFinalizer(ctx, r.client, FinalizerName, secret); err != nil {
-		r.logger.Info("failed to ensure finalizer on backup entry secret, %v", err)
+		r.logger.Error(err, "failed to ensure finalizer on backup entry secret", "backupentry", be.Name)
 		return reconcile.Result{}, err
 	}
 
@@ -167,11 +167,11 @@ func (r *reconciler) delete(ctx context.Context, be *extensionsv1alpha1.BackupEn
 
 	secret, err := extensionscontroller.GetSecretByReference(ctx, r.client, &be.Spec.SecretRef)
 	if err != nil {
-		r.logger.Info("failed to get backup entry secret, %v", err)
+		r.logger.Error(err, "failed to get backup entry secret", "backupentry", be.Name)
 		return reconcile.Result{}, err
 	}
 	if err := extensionscontroller.DeleteFinalizer(ctx, r.client, FinalizerName, secret); err != nil {
-		r.logger.Info("failed to remove finalizer on backup entry secret, %v", err)
+		r.logger.Error(err, "failed to remove finalizer on backup entry secret", "backupentry", be.Name)
 		return reconcile.Result{}, err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix number of arguments for logger.Info() call. Ref https://github.com/gardener/gardener-extensions/pull/636

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
